### PR TITLE
Advanced window positioning with anchors

### DIFF
--- a/docs/content/main/_index.md
+++ b/docs/content/main/_index.md
@@ -5,7 +5,10 @@ sort_by = "weight"
 +++
 
 
-Eww (ElKowar's Wacky Widgets, pronounced with sufficient amounts of disgust) Is a widgeting system made in [rust](https://www.rust-lang.org/), which let's you create your own widgets similarly to how you can in AwesomeWM. The key difference: It is independent of your window manager!
+Eww (ElKowar's Wacky Widgets, pronounced with sufficient amounts of disgust)
+is a widgeting system made in [rust](https://www.rust-lang.org/),
+which let's you create your own widgets similarly to how you can in AwesomeWM.
+The key difference: It is independent of your window manager!
 
 Configured in XML and themed using CSS, it is easy to customize and provides all the flexibility you need!
 
@@ -17,7 +20,9 @@ Configured in XML and themed using CSS, it is easy to customize and provides all
 * rustc
 * cargo (nightly toolchain)
 
-Rather than with your system package manager, I recommend installing it using  [rustup](https://rustup.rs/), as this makes it easy to use the nightly toolchain, which is necessary to build eww.
+Rather than with your system package manager,
+I recommend installing it using  [rustup](https://rustup.rs/),
+as this makes it easy to use the nightly toolchain necessary to build eww.
 
 ### Building
 

--- a/docs/content/main/configuration.md
+++ b/docs/content/main/configuration.md
@@ -28,11 +28,11 @@ Your config structure should look like this:
 	<definitions>
 		<!-- Put your <def>'s in here -->
 	</definitions>
-	
+
 	<variables>
 		<!-- Put your <script-var> and <var>'s in here -->
 	</variables>
-	
+
 	<windows>
 		<!-- Put your window blocks here -->
 	</windows>
@@ -75,7 +75,7 @@ Example:
 ```xml
 <variables>
     <script-var name="date" interval="5s">
-    date +%H:%M
+        date +%H:%M
     </script-var>
 </variables>
 ```
@@ -141,7 +141,7 @@ This part:
 ```xml
 <def name="clock">
     <box>
-	The time is: {{my_time}} currently.
+        The time is: {{my_time}} currently.
     </box>
 </def>
 ```
@@ -156,7 +156,7 @@ So if we look at:
 ```xml
 <def name="main">
     <box>
-	<clock my_time="{{date}}"/>
+        <clock my_time="{{date}}"/>
     </box>
 </def>
 ```
@@ -172,7 +172,7 @@ It doesn't have to be `{{my_time}}` either, it can be anything.
 ```xml
 <def name="clock">
     <box>
-	The time is: {{very_long_list_of_animals}} currently.
+        The time is: {{very_long_list_of_animals}} currently.
     </box>
 </def>
 ```
@@ -182,83 +182,29 @@ To use that it would look like this:
 ```xml
 <def name="main">
     <box>
-	<clock very_long_list_of_animals="{{date}}"/>
+        <clock very_long_list_of_animals="{{date}}"/>
     </box>
 </def>
 ```
 ### The `<windows>` block {#windows-block}
 
-This is the part the Eww reads and loads. The `<windows>` config should look something like this:
+All different windows you might want to use are defined in the `<windows>` block.
+The `<windows>` config should look something like this:
 
 ```xml
 <windows>
     <window name="main_window" stacking="fg">
-      <size x="300" y="300" />
-      <pos x="0" y="500" />
-      <widget>
-	<main/>
-      </widget>
-    </window>
-</windows>
-```
-`<window name="main_window">` is the part that eww runs when you start it. In this example you would run eww by doing:
-```bash
-./eww open main_window
-```
-but if renamed the `<window>` to be `<window name="apple">` we would run eww by doing:
-```bash
-./eww open apple
-```
-
-The `stacking="fg"` says where the widget will be stacked. Possible values here are `foreground`, `fg`, `background` and `bg`.
-`foreground` or `fg` *always* stays above windows.
-`background` or `bg` *always* stays behind windows. So it will stay on your desktop.
-
-If you were to remove the `stacking="fg"` it would default it to `fg`.
-
-You can also have multiple windows in one document by  doing:
-
-```xml
-<windows>
-    <window name="main_window">
-        <size x="300" y="300" />
-        <pos x="0" y="500" />
+        <geometry anchor="top left" x="300px" y="50%" width="25%" height="20px">
         <widget>
             <main/>
         </widget>
     </window>
-    <window name="main_window2">
-        <size x="400" y="600"/>
-        <pos x="0" y="0"/>
-        <widget>
-            <main2/>
-        </widget>
-    </window>
 </windows>
 ```
----
 
-- `<size>` sets x-y size of the widget.
-- `<pos>` sets x-y position of the widget.
-- `<widget>` is the part which you say which `<def>` eww should run. So if we take the example config from before:
-```xml
-<definitions>
-    <def name="clock">
-        <box>
-            The time is: {{my_time}} currently.
-        </box>
-    </def>
-    <def name="main">
-        <box>
-            <clock my_time="{{date}}"/>
-        </box>
-    </def>
-</definitions>
-```
-and then look at
-```xml
-<widget>
-    <main/>
-</widget>
-```
-we will see that eww will run `<def name="main">` and not `<def name="clock">`.
+The window block contains multiple elements to configure the window.
+- `<geometry>` is used to specify the position and size of the window.
+- `<widget>` will contain the widget that is shown in the window.
+
+The `stacking="fg"` specifies if the window should appear on top of or behind other windows.
+Possible values here are `foreground`, `fg`, `background` and `bg`. It defaults to `fg`.

--- a/src/config/element.rs
+++ b/src/config/element.rs
@@ -28,12 +28,9 @@ impl WidgetDefinition {
                 );
             }
 
-            let size: Option<_> = Option::zip(xml.attr("width").ok(), xml.attr("height").ok());
-            let size: Option<Result<_>> = size.map(|(x, y)| Ok((x.parse()?, y.parse()?)));
-
             WidgetDefinition {
                 name: xml.attr("name")?.to_owned(),
-                size: size.transpose()?,
+                size: Option::zip(xml.parse_optional_attr("width")?, xml.parse_optional_attr("height")?),
                 structure: WidgetUse::from_xml_node(xml.only_child()?)?,
             }
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,10 +11,12 @@ pub mod element;
 pub mod eww_config;
 pub mod script_var;
 pub mod window_definition;
+pub mod window_geometry;
 pub mod xml_ext;
 pub use eww_config::*;
 pub use script_var::*;
 pub use window_definition::*;
+pub use window_geometry::*;
 
 #[macro_export]
 macro_rules! ensure_xml_tag_is {

--- a/src/config/window_geometry.rs
+++ b/src/config/window_geometry.rs
@@ -1,0 +1,151 @@
+use crate::value::Coords;
+use anyhow::*;
+use serde::{Deserialize, Serialize};
+use smart_default::SmartDefault;
+
+use std::fmt;
+
+use super::xml_ext::XmlElement;
+
+#[derive(Debug, derive_more::Display, Clone, Copy, Eq, PartialEq, SmartDefault, Serialize, Deserialize)]
+pub enum AnchorAlignment {
+    #[display("start")]
+    #[default]
+    START,
+    #[display("center")]
+    CENTER,
+    #[display("end")]
+    END,
+}
+
+impl AnchorAlignment {
+    pub fn from_x_alignment(s: &str) -> Result<AnchorAlignment> {
+        match s {
+            "l" | "left" => Ok(AnchorAlignment::START),
+            "c" | "center" => Ok(AnchorAlignment::CENTER),
+            "r" | "right" => Ok(AnchorAlignment::END),
+            _ => bail!(
+                r#"couldn't parse '{}' as x-alignment. Must be one of "left", "center", "right""#,
+                s
+            ),
+        }
+    }
+
+    pub fn from_y_alignment(s: &str) -> Result<AnchorAlignment> {
+        match s {
+            "t" | "top" => Ok(AnchorAlignment::START),
+            "c" | "center" => Ok(AnchorAlignment::CENTER),
+            "b" | "bottom" => Ok(AnchorAlignment::END),
+            _ => bail!(
+                r#"couldn't parse '{}' as y-alignment. Must be one of "top", "center", "bottom""#,
+                s
+            ),
+        }
+    }
+
+    pub fn alignment_to_coordinate(&self, size_inner: i32, size_container: i32) -> i32 {
+        match self {
+            AnchorAlignment::START => 0,
+            AnchorAlignment::CENTER => (size_container / 2) - (size_inner / 2),
+            AnchorAlignment::END => size_container - size_inner,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
+pub struct AnchorPoint {
+    x: AnchorAlignment,
+    y: AnchorAlignment,
+}
+
+impl std::fmt::Display for AnchorPoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use AnchorAlignment::*;
+        match (self.x, self.y) {
+            (CENTER, CENTER) => write!(f, "center"),
+            (x, y) => write!(
+                f,
+                "{} {}",
+                match x {
+                    START => "left",
+                    CENTER => "center",
+                    END => "right",
+                },
+                match y {
+                    START => "top",
+                    CENTER => "center",
+                    END => "bottom",
+                }
+            ),
+        }
+    }
+}
+
+impl std::str::FromStr for AnchorPoint {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "center" {
+            Ok(AnchorPoint {
+                x: AnchorAlignment::CENTER,
+                y: AnchorAlignment::CENTER,
+            })
+        } else {
+            let (first, second) = s
+                .split_once(' ')
+                .context("Failed to parse anchor: Must either be \"center\" or be formatted like \"top left\"")?;
+            let x_y_result: Result<_> = try {
+                AnchorPoint {
+                    x: AnchorAlignment::from_x_alignment(first)?,
+                    y: AnchorAlignment::from_y_alignment(second)?,
+                }
+            };
+            x_y_result.or_else(|_| {
+                Ok(AnchorPoint {
+                    x: AnchorAlignment::from_x_alignment(second)?,
+                    y: AnchorAlignment::from_y_alignment(first)?,
+                })
+            })
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct EwwWindowGeometry {
+    pub anchor_point: AnchorPoint,
+    pub offset: Coords,
+    pub size: Coords,
+}
+
+impl EwwWindowGeometry {
+    pub fn from_xml_element(xml: XmlElement) -> Result<Self> {
+        Ok(EwwWindowGeometry {
+            anchor_point: xml.parse_optional_attr("anchor")?.unwrap_or_default(),
+            size: Coords {
+                x: xml.parse_optional_attr("width")?.unwrap_or_default(),
+                y: xml.parse_optional_attr("height")?.unwrap_or_default(),
+            },
+            offset: Coords {
+                x: xml.parse_optional_attr("x")?.unwrap_or_default(),
+                y: xml.parse_optional_attr("y")?.unwrap_or_default(),
+            },
+        })
+    }
+}
+
+impl std::fmt::Display for EwwWindowGeometry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{} ({})", self.offset, self.size, self.anchor_point)
+    }
+}
+
+impl EwwWindowGeometry {
+    /// Calculate the window rectangle given the configured window geometry
+    pub fn get_window_rectangle(&self, screen_rect: gdk::Rectangle) -> gdk::Rectangle {
+        let (offset_x, offset_y) = self.offset.relative_to(screen_rect.width, screen_rect.height);
+        let (width, height) = self.size.relative_to(screen_rect.width, screen_rect.height);
+        let x = screen_rect.x + offset_x + self.anchor_point.x.alignment_to_coordinate(width, screen_rect.width);
+        let y = screen_rect.y + offset_y + self.anchor_point.y.alignment_to_coordinate(height, screen_rect.height);
+        gdk::Rectangle { x, y, width, height }
+    }
+}

--- a/src/config/xml_ext.rs
+++ b/src/config/xml_ext.rs
@@ -177,6 +177,20 @@ impl<'a, 'b> XmlElement<'a, 'b> {
         }
     }
 
+    pub fn optional_attr<O, F: FnOnce(&str) -> Result<O>>(&self, key: &str, parse: F) -> Result<Option<O>> {
+        match self.0.attribute(key) {
+            Some(value) => parse(value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    pub fn parse_optional_attr<E, O: std::str::FromStr<Err = E>>(&self, key: &str) -> Result<Option<O>, E> {
+        match self.0.attribute(key) {
+            Some(value) => value.parse::<O>().map(Some),
+            None => Ok(None),
+        }
+    }
+
     pub fn only_child(&self) -> Result<XmlNode> {
         with_text_pos_context! { self =>
             let mut children_iter = self.children();

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -4,7 +4,7 @@ use structopt::StructOpt;
 
 use crate::{
     app,
-    config::WindowName,
+    config::{AnchorPoint, WindowName},
     value::{Coords, PrimitiveValue, VarName},
 };
 
@@ -57,6 +57,10 @@ pub enum ActionWithServer {
         /// The size of the window to open
         #[structopt(short, long)]
         size: Option<Coords>,
+
+        /// Anchorpoint of the window, formatted like "top right"
+        #[structopt(short, long)]
+        anchor: Option<AnchorPoint>,
     },
 
     /// Close the window with the given name
@@ -92,7 +96,17 @@ impl ActionWithServer {
             ActionWithServer::Update { mappings } => {
                 app::EwwCommand::UpdateVars(mappings.into_iter().map(|x| x.into()).collect())
             }
-            ActionWithServer::OpenWindow { window_name, pos, size } => app::EwwCommand::OpenWindow { window_name, pos, size },
+            ActionWithServer::OpenWindow {
+                window_name,
+                pos,
+                size,
+                anchor,
+            } => app::EwwCommand::OpenWindow {
+                window_name,
+                pos,
+                size,
+                anchor,
+            },
             ActionWithServer::CloseWindow { window_name } => app::EwwCommand::CloseWindow { window_name },
             ActionWithServer::KillServer => app::EwwCommand::KillServer,
             ActionWithServer::ShowState => {


### PR DESCRIPTION
## Description

Fixes #50 

This PR adds a more flexible system to specify how windows should be positioned.

It adds the concept of an anchor, relative to which the window can be positioned.

## Usage

```xml
<window>
  <geometry anchor="bottom left" x="50px" y="-10%"/>
  <!-- additional window definition stuff --!>
</window>
```

## Checklist

- [ ] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
