### PR TITLE
Improve error messages when parsing config files

### DIFF
--- a/src/config/eww_config.rs
+++ b/src/config/eww_config.rs
@@ -11,6 +11,7 @@ use super::{
     xml_ext::{XmlElement, XmlNode},
     EwwWindowDefinition, ScriptVar, WindowName,
 };
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct EwwConfig {
@@ -20,6 +21,7 @@ pub struct EwwConfig {
 
     // TODO make this a hashmap
     script_vars: Vec<ScriptVar>,
+    pub filepath: PathBuf
 }
 
 impl EwwConfig {
@@ -108,7 +110,7 @@ impl EwwConfig {
             windows,
             initial_variables,
             script_vars,
-
+            filepath: path.to_path_buf(),
         };
         EwwConfig::merge_includes(current_config, includes)
     }

--- a/src/config/eww_config.rs
+++ b/src/config/eww_config.rs
@@ -21,7 +21,7 @@ pub struct EwwConfig {
 
     // TODO make this a hashmap
     script_vars: Vec<ScriptVar>,
-    pub filepath: PathBuf
+    pub filepath: PathBuf,
 }
 
 impl EwwConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,9 @@ fn main() {
             opts::Action::WithServer(action) => {
                 log::info!("Trying to find server process");
                 if let Ok(stream) = net::UnixStream::connect(&*IPC_SOCKET_PATH) {
-
                     client::forward_command_to_server(stream, action).context("Error while forwarding command to server")?;
                 } else if action.needs_server_running() {
                     println!("No eww server running");
-
                 } else {
                     log::info!("No server running, initializing server...");
                     server::initialize_server(opts.should_detach, action)?;


### PR DESCRIPTION
## Description

This PR improves the way errors are shown when parsing the xml configs.

## Additional Notes

Also added a `filepath` field in the `eww_config` struct which would make easier the implementation of a command to list all config files. (related to #57).

## Showcase

![iRzt](https://user-images.githubusercontent.com/43417195/99880806-f027af00-2c15-11eb-8960-3ff7530ef633.png)

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
