### PR TITLE
Added support for custom config dir path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,14 +54,12 @@ fn main() {
             opts::Action::WithServer(action) => {
                 log::info!("Trying to find server process");
                 if let Ok(stream) = net::UnixStream::connect(&*IPC_SOCKET_PATH) {
-
                     client::forward_command_to_server(stream, action).context("Error while forwarding command to server")?;
                 } else if action.needs_server_running() {
                     println!("No eww server running");
-
                 } else {
                     log::info!("No server running, initializing server...");
-                    server::initialize_server(opts.should_detach, action)?;
+                    server::initialize_server(opts.should_detach, opts.config_dir, action)?;
                 }
             }
         }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -7,6 +7,7 @@ use crate::{
     config::{AnchorPoint, WindowName},
     value::{Coords, PrimitiveValue, VarName},
 };
+use std::path::PathBuf;
 
 #[derive(StructOpt, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Opt {
@@ -17,6 +18,9 @@ pub struct Opt {
     /// When daemonized, to kill eww you can run `eww kill`. To see logs, use `eww logs`.
     #[structopt(short = "-d", long = "--detach")]
     pub should_detach: bool,
+
+    #[structopt(short = "-c", long = "--config", default_value = "")]
+    pub config_dir: PathBuf,
 }
 
 #[derive(StructOpt, Debug, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## Description

This PR implements support for a user specified config directory path. It aims to fix #67.

## Usage

Simply run the program with the arguments `-c [config_dir_path]` or `--config [config_dir_path]`

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing

## TODO: 
- Update documentation
- I think the way server.rs handles configuration paths could be cleaned up a bit.