### PR TITLE
Add struts support and 'sticky' config option.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,7 @@ dependencies = [
  "filedescriptor",
  "gdk",
  "gdk-pixbuf",
+ "gdkx11",
  "gio",
  "glib",
  "grass",
@@ -351,7 +352,7 @@ dependencies = [
  "libc",
  "log 0.4.11",
  "maplit",
- "nix",
+ "nix 0.19.0",
  "num",
  "popol",
  "pretty_assertions",
@@ -364,6 +365,7 @@ dependencies = [
  "smart-default",
  "stoppable_thread",
  "structopt",
+ "x11rb",
 ]
 
 [[package]]
@@ -616,6 +618,55 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "gdkx11"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89606baa221f9b8d8aa81924fd448c6b107d20de949f0fbf9a4ec203bb54b63"
+dependencies = [
+ "bitflags",
+ "gdk",
+ "gdk-pixbuf",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gdkx11-sys",
+ "gio",
+ "gio-sys",
+ "glib",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango",
+ "x11",
+]
+
+[[package]]
+name = "gdkx11-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6710388d530f3178ccbeb65cbafdf497a5772c4409eaf574ee9fa461af0a3d09"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+ "x11",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1051,6 +1102,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "nix"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2097,6 +2160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2182,28 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "x11"
+version = "2.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232bc353846d5350d7a815c249209f9545f1d5c725dca846a5ae383a70f30fa5"
+dependencies = [
+ "gethostname",
+ "nix 0.18.0",
+ "winapi 0.3.9",
+ "winapi-wsapoll",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,8 @@ dashmap = "3.11"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+gdkx11 = "0.9.0"
+x11rb = "0.7.0"
+

--- a/docs/content/main/configuration.md
+++ b/docs/content/main/configuration.md
@@ -216,6 +216,8 @@ The `<windows>` config should look something like this:
     </window>
 </windows>
 ```
+
+The window block contains multiple elements to configure the window.
 - `<geometry>` is used to specify the position and size of the window.
 - `<widget>` will contain the widget that is shown in the window.
 - `<struts>` Tells the window manager to reserve space at the edge of the screen (for a status bar or panel sort of widget).

--- a/docs/content/main/configuration.md
+++ b/docs/content/main/configuration.md
@@ -239,3 +239,6 @@ There are a couple things you can optionally configure on the window itself:
   This can be any number, representing the index of your monitor.
 - `sticky`: Controls whether the window is present on all workspaces.
   Possible values: `"true"`, `"false"`. Default: `"true"`
+- `popup`: Whether the window should be a popup. This basically makes the window manager ignore the window and not manage it.
+  Setting this to true will prevent struts from working, and it will be visible in all workspaces regardless of what 'sticky' is set to (because the WM is ignoring the window).
+  Possible values: `"true"`, `"false"`. Default: `"false"`

--- a/docs/content/main/configuration.md
+++ b/docs/content/main/configuration.md
@@ -225,8 +225,11 @@ The window block contains multiple elements to configure the window.
   The `left_start_y`, `left_end_y`, `right_start_y`, `right_end_y`, `top_start_x`, `top_end_x`, `bottom_start_x` and `bottom_end_x`
   attributes tell the WM the x or y limits of the strut. For example, `<struts top="30" top_start_x="0" top_end_x="960" />` would
   reserve a strut 30px down from the top edge of the screen, up to the 960th pixel from the left side of the screen.
-  Not all window managers support partial struts and may ignore the 'end' or 'start' attributes. All of these values default to zero if unset.
-  Also note that struts do not automatically position the window within the strut, it just tells the window manager you want to reserve space there.
+  Not all window managers support partial struts and may ignore the 'end' or 'start' attributes. All of these values default to zero if unset,
+  and it's not necessary to set all of them, only the ones that you need. You are also able to create multiple struts
+  if you'd like, like one at the top of the screen and another at the bottom. Also note that struts do not 
+  automatically position the window within the strut, it just tells the window manager you want to reserve space there.
+  [For more information check the X11 spec on window struts.](https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm45760170756000)
 
 There are a couple things you can optionally configure on the window itself:
 - `stacking`: stacking describes if the window will be shown in the foreground (in front of other windows)

--- a/docs/content/main/configuration.md
+++ b/docs/content/main/configuration.md
@@ -216,10 +216,15 @@ The `<windows>` config should look something like this:
     </window>
 </windows>
 ```
-
-The window block contains multiple elements to configure the window.
 - `<geometry>` is used to specify the position and size of the window.
 - `<widget>` will contain the widget that is shown in the window.
+- `<struts>` Tells the window manager to reserve space at the edge of the screen (for a status bar or panel sort of widget).
+  The `left`, `right`, `top` and `bottom` attributes tell the WM how far to set struts away from that edge of the screen
+  The `left_start_y`, `left_end_y`, `right_start_y`, `right_end_y`, `top_start_x`, `top_end_x`, `bottom_start_x` and `bottom_end_x`
+  attributes tell the WM the x or y limits of the strut. For example, `<struts top="30" top_start_x="0" top_end_x="960" />` would
+  reserve a strut 30px down from the top edge of the screen, up to the 960th pixel from the left side of the screen.
+  Not all window managers support partial struts and may ignore the 'end' or 'start' attributes. All of these values default to zero if unset.
+  Also note that struts do not automatically position the window within the strut, it just tells the window manager you want to reserve space there.
 
 There are a couple things you can optionally configure on the window itself:
 - `stacking`: stacking describes if the window will be shown in the foreground (in front of other windows)
@@ -230,3 +235,5 @@ There are a couple things you can optionally configure on the window itself:
   Possible values: `"true"`, `"false"`. Default: `"false"`
 - `screen`: Specifies on which display to show the window in a multi-monitor setup.
   This can be any number, representing the index of your monitor.
+- `sticky`: Controls whether the window is present on all workspaces.
+  Possible values: `"true"`, `"false"`. Default: `"true"`

--- a/src/app.rs
+++ b/src/app.rs
@@ -288,7 +288,11 @@ fn initialize_window(
 ) -> Result<EwwWindow> {
     let actual_window_rect = window_def.geometry.get_window_rectangle(monitor_geometry);
 
-    let window = gtk::Window::new(gtk::WindowType::Toplevel);
+    let window = if window_def.popup {
+        gtk::Window::new(gtk::WindowType::Popup)
+    } else {
+        gtk::Window::new(gtk::WindowType::Toplevel)
+    };
 
     window.set_title(&format!("Eww - {}", window_def.name));
     let wm_class_name = format!("eww-{}", window_def.name);

--- a/src/app.rs
+++ b/src/app.rs
@@ -336,7 +336,7 @@ fn set_struts(eww_window: &EwwWindow) -> Result<()> {
         .context("Could not get GDK window from GTK window")?
         .downcast()
         .ok()
-        .context("Could not get X11 widnow from GDK window")?;
+        .context("Could not get X11 window from GDK window")?;
     // This is ugly but I don't think there is a better way to do it
     let xid = x11win.get_xid() as u32;
 

--- a/src/config/window_definition.rs
+++ b/src/config/window_definition.rs
@@ -16,6 +16,7 @@ pub struct EwwWindowDefinition {
     pub struts: Struts,
     pub focusable: bool,
     pub sticky: bool,
+    pub popup: bool,
 }
 
 impl EwwWindowDefinition {
@@ -25,6 +26,7 @@ impl EwwWindowDefinition {
         let screen_number = xml.parse_optional_attr("screen")?;
         let focusable = xml.parse_optional_attr("focusable")?;
         let sticky = xml.parse_optional_attr("sticky")?;
+        let popup = xml.parse_optional_attr("popup")?;
 
         let struts = xml.child("struts").ok().map(Struts::from_xml_element).transpose()?;
 
@@ -40,6 +42,7 @@ impl EwwWindowDefinition {
             focusable: focusable.unwrap_or(false),
             sticky: sticky.unwrap_or(true),
             struts: struts.unwrap_or_default(),
+            popup: popup.unwrap_or(false),
         })
     }
 

--- a/src/config/window_definition.rs
+++ b/src/config/window_definition.rs
@@ -15,6 +15,7 @@ pub struct EwwWindowDefinition {
     pub widget: WidgetUse,
     pub struts: Struts,
     pub focusable: bool,
+    pub sticky: bool,
 }
 
 impl EwwWindowDefinition {
@@ -23,6 +24,7 @@ impl EwwWindowDefinition {
         let stacking: WindowStacking = xml.parse_optional_attr("stacking")?.unwrap_or_default();
         let screen_number = xml.parse_optional_attr("screen")?;
         let focusable = xml.parse_optional_attr("focusable")?;
+        let sticky = xml.parse_optional_attr("sticky")?;
 
         let struts = xml.child("struts").ok().map(Struts::from_xml_element).transpose()?;
 
@@ -36,6 +38,7 @@ impl EwwWindowDefinition {
             stacking,
             screen_number,
             focusable: focusable.unwrap_or(false),
+            sticky: sticky.unwrap_or(true),
             struts: struts.unwrap_or_default(),
         })
     }
@@ -48,20 +51,36 @@ impl EwwWindowDefinition {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Struts {
-    left: i32,
-    right: i32,
-    top: i32,
-    bottom: i32,
+    pub left: u32,
+    pub right: u32,
+    pub top: u32,
+    pub bottom: u32,
+    pub left_start_y: u32,
+    pub left_end_y: u32,
+    pub right_start_y: u32,
+    pub right_end_y: u32,
+    pub top_start_x: u32,
+    pub top_end_x: u32,
+    pub bottom_start_x: u32,
+    pub bottom_end_x: u32,
 }
 
 impl Struts {
     pub fn from_xml_element(xml: XmlElement) -> Result<Self> {
         ensure_xml_tag_is!(xml, "struts");
         Ok(Struts {
-            left: xml.attr("left")?.parse()?,
-            right: xml.attr("right")?.parse()?,
-            top: xml.attr("top")?.parse()?,
-            bottom: xml.attr("bottom")?.parse()?,
+            left: xml.parse_optional_attr("left")?.unwrap_or(0),
+            right: xml.parse_optional_attr("right")?.unwrap_or(0),
+            top: xml.parse_optional_attr("top")?.unwrap_or(0),
+            bottom: xml.parse_optional_attr("bottom")?.unwrap_or(0),
+            left_start_y: xml.parse_optional_attr("left_start_y")?.unwrap_or(0),
+            left_end_y: xml.parse_optional_attr("left_end_y")?.unwrap_or(0),
+            right_start_y: xml.parse_optional_attr("right_start_y")?.unwrap_or(0),
+            right_end_y: xml.parse_optional_attr("right_end_y")?.unwrap_or(0),
+            top_start_x: xml.parse_optional_attr("top_start_x")?.unwrap_or(0),
+            top_end_x: xml.parse_optional_attr("top_end_x")?.unwrap_or(0),
+            bottom_start_x: xml.parse_optional_attr("bottom_start_x")?.unwrap_or(0),
+            bottom_end_x: xml.parse_optional_attr("bottom_end_x")?.unwrap_or(0),
         })
     }
 }


### PR DESCRIPTION
## Description

I added strut support which is configurable with the strut element in a window.

I changed the behavior of the 'focusable' attribute, which used to make the window a 'Popup' and set override redirect. The issue with both of these is they essentially tell the window manager to ignore the window and not manage it at all or check its properties. I think this is generally not desirable, and making the window a 'Dock' is sufficient. I've made 'popup' into its own option if people want the WM to ignore their widget. So setting `focusable="false"` should make it so you can't drag the window around, but the WM will still pay attention to properties like struts and stuff.

I also added a 'sticky' attribute to the window, which independently controls whether a  widget is visible on all workspaces. I have this set to true by default, but maybe this should be changed to better suit common use cases. Previously, if an eww window was not focusable, it would not be present on all workspaces, and now it would by default. This might mean some people need to change their configs.

## Usage

Simple example configuration:

```xml
<eww>
   <windows>
      <window name="main_window" focusable="false" sticky="true">
        <geometry anchor="top left" x="10px" y="10px" width="1900" height="30" />
        <struts top="50" top_end_x="1920" />
        <widget>
          <box>
            Cool eww bar
          </box>
        </widget>
      </window>
  </windows>
</eww>
```

The 'struts' element controls struts. By default everything is set to zero. Possible attributes are: left, right, top, bottom, left_start_y, left_end_y, right_start_y, right_end_y, top_start_x, top_end_x, bottom_start_x, bottom_end_x.

You should technically set the 'start' and 'end' of a strut, but I don't think most window managers properly support partial struts. At least awesome and openbox don't care from what I've noticed.

### Showcase

https://user-images.githubusercontent.com/68155222/103149510-05b15c80-471f-11eb-9acc-0482e25bf8c6.mp4

## Additional Notes

Struts won't compile on macos and the sticky feature doesn't seem to be working either.

Also struts behave kind of weird on some WM's, like on i3 the window resizes to fill the whole strut regardless of where I try to position it. But nothing I can really do about that.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- 

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing