### PR TITLE
Add `eww close-all` subcommand to close all running windows 

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,6 @@ pub enum EwwCommand {
     CloseAll,
     PrintState(crossbeam_channel::Sender<String>),
     PrintDebug(crossbeam_channel::Sender<String>),
-
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,8 +29,10 @@ pub enum EwwCommand {
         window_name: WindowName,
     },
     KillServer,
+    CloseAll,
     PrintState(crossbeam_channel::Sender<String>),
     PrintDebug(crossbeam_channel::Sender<String>),
+
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -80,6 +82,11 @@ impl App {
                     self.windows.drain().for_each(|(_, w)| w.close());
                     script_var_process::on_application_death();
                     std::process::exit(0);
+                }
+                EwwCommand::CloseAll => {
+                    log::info!("Received close command, closing all windows");
+                    self.script_var_handler.stop_all();
+                    self.windows.drain().for_each(|(_, w)| w.close());
                 }
                 EwwCommand::OpenWindow {
                     window_name,

--- a/src/app.rs
+++ b/src/app.rs
@@ -84,8 +84,9 @@ impl App {
                 }
                 EwwCommand::CloseAll => {
                     log::info!("Received close command, closing all windows");
-                    self.script_var_handler.stop_all();
-                    self.windows.drain().for_each(|(_, w)| w.close());
+                    for (window_name, _window) in self.windows.clone() {
+                        self.close_window(&window_name)?;
+                    }
                 }
                 EwwCommand::OpenWindow {
                     window_name,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -84,6 +84,10 @@ pub enum ActionWithServer {
     #[structopt(name = "kill")]
     KillServer,
 
+    /// Close all windows, without killing the daemon
+    #[structopt(name = "close-all")]
+    CloseAll,
+
     /// Print the current eww-state
     #[structopt(name = "state")]
     ShowState,
@@ -139,6 +143,7 @@ impl ActionWithServer {
             },
             ActionWithServer::CloseWindow { window_name } => app::EwwCommand::CloseWindow { window_name },
             ActionWithServer::KillServer => app::EwwCommand::KillServer,
+            ActionWithServer::CloseAll => app::EwwCommand::CloseAll,
             ActionWithServer::ShowState => {
                 let (send, recv) = crossbeam_channel::unbounded();
                 return (app::EwwCommand::PrintState(send), Some(recv));


### PR DESCRIPTION
Please follow this template, if applicable.

## Description
Adds the `eww close-all` command to close all windows without killing the eww server
Solves #77
## Usage
`eww close-all`


## Additional Notes

Please do look if I've missed something lol

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented. (None added)
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes. (Not applicable)
- [x] I used `cargo fmt` to automatically format all code before committing
