### PR TITLE
Fix #81

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -49,8 +49,13 @@ pub fn initialize_server(should_detach: bool, action: opts::ActionWithServer) ->
         gtk::StyleContext::add_provider_for_screen(&screen, &app.css_provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 
-    if let Ok(eww_css) = util::parse_scss_from_file(&scss_file_path) {
-        app.load_css(&eww_css)?;
+    match util::parse_scss_from_file(&scss_file_path) {
+        Err(err) => {
+            eprintln!("error parsing scss file: {}", err);
+        },
+        Ok(eww_css) => {
+            app.load_css(&eww_css)?;
+        }
     }
 
     // run the command that eww was started with

--- a/src/server.rs
+++ b/src/server.rs
@@ -52,7 +52,7 @@ pub fn initialize_server(should_detach: bool, action: opts::ActionWithServer) ->
     match util::parse_scss_from_file(&scss_file_path) {
         Err(err) => {
             eprintln!("error parsing scss file: {}", err);
-        },
+        }
         Ok(eww_css) => {
             app.load_css(&eww_css)?;
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -77,15 +77,16 @@ pub fn parse_duration(s: &str) -> Result<std::time::Duration> {
 }
 
 /// Replace all env-var references of the format `"something $foo"` in a string
-/// by the actual env-variables. If the env-var isn't found, will replace the
-/// reference with an empty string.
+/// by the actual env-variables. If the env-var isn't found, the variable
+/// will be left alone.
 pub fn replace_env_var_references(input: String) -> String {
     lazy_static::lazy_static! {
         static ref ENV_VAR_PATTERN: regex::Regex = regex::Regex::new(r"\$([^\s]*)").unwrap();
     }
     ENV_VAR_PATTERN
         .replace_all(&input, |var_name: &regex::Captures| {
-            std::env::var(var_name.get(1).unwrap().as_str()).unwrap_or_default()
+            let var_name_string = var_name.get(1).unwrap().as_str();
+            std::env::var(var_name_string).unwrap_or(format!("${}", var_name_string))
         })
         .into_owned()
 }


### PR DESCRIPTION
Fix for #81 

## Description

Instead of replacing all SCSS variables that do not have a non-null environment variable with an empty string, leave the SCSS variable alone. This is option 3 described in #81. 

Adds error message when trying to load invalid `scss` file

e.g. putting in `$PWD: #000;` in the place of `$red` variable declaration from example in #81, 
```
jack@CASTOR ~> eww open controls_side
error parsing scss file: encountered SCSS parsing error: SassError { kind: ParseError { message: "Undefined variable.", loc: SpanLoc { file: File("stdin"), begin: LineCol { line: 6, column: 9 }, end: LineCol { line: 6, column: 14 } }, unicode: true } }
```
which should allow the user to diagnose the issue (though if a less cryptic message is desired, we can try to elucidate if possible).

## Usage

See example from #81. Intended behavior should be output.

## Additional Notes

This is WIP because this is one of the proposed solutions, but it is the one that made the most sense to me and I implemented it for my own setup. This could be a good starting point for the real solution.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
