### PR TITLE
Change environment variable syntax to ${VAR} - Fix for #81

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -89,3 +89,19 @@ pub fn replace_env_var_references(input: String) -> String {
         })
         .into_owned()
 }
+
+#[cfg(test)]
+mod test {
+    use super::replace_env_var_references;
+    use std;
+
+    #[test]
+    fn test_replace_env_var_references() {
+        let scss = "$test: ${USER};";
+
+        assert_eq!(
+            replace_env_var_references(String::from(scss)),
+            format!("$test: {};", std::env::var("USER").unwrap_or_default())
+        )
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -76,12 +76,12 @@ pub fn parse_duration(s: &str) -> Result<std::time::Duration> {
     }
 }
 
-/// Replace all env-var references of the format `"something $foo"` in a string
+/// Replace all env-var references of the format `"something ${foo}"` in a string
 /// by the actual env-variables. If the env-var isn't found, will replace the
 /// reference with an empty string.
 pub fn replace_env_var_references(input: String) -> String {
     lazy_static::lazy_static! {
-        static ref ENV_VAR_PATTERN: regex::Regex = regex::Regex::new(r"\$([^\s]*)").unwrap();
+        static ref ENV_VAR_PATTERN: regex::Regex = regex::Regex::new(r"\$\{([^\s]*)\}").unwrap();
     }
     ENV_VAR_PATTERN
         .replace_all(&input, |var_name: &regex::Captures| {


### PR DESCRIPTION
Fix for #81 

## Description
Changes the syntax of using environment variables in `eww.scss` to not collide with scss variable syntax.
Adds test for `test_replace_env_var_references`.

## Usage
### Before

```
.app {
  background-color: $MY_ENV_COLOR;
}
```

### After
```
.app {
  background-color: ${MY_ENV_COLOR};
}
```

## Additional Notes
Should we add more documentation?

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
