### PR TITLE
Shows warnings when defining variables that are already defined, and other general improvements

### DIFF
--- a/docs/content/main/configuration.md
+++ b/docs/content/main/configuration.md
@@ -118,10 +118,12 @@ Here you can include other config files so that they are merged together at star
 
 ```xml
 <includes>
-  <file path="./something.xml"/>
-  <file path="./somethingelse.xml"/>
+  <file path="./other_config_file.xml"/>
+  <file path="./other_config_file2.xml"/>
 </includes>
 ```
+
+If you define a variable/widget/window, in a config file, when it's defined somewhere else, you can see a warning in the eww logs (`eww logs`)
 
 ### The `<definitions>` block
 In here you whole widget will be made, and you can also create your own widgets. Check [Widget Documentation](@/main/widgets.md) for pre-defined widgets.

--- a/src/app.rs
+++ b/src/app.rs
@@ -265,7 +265,7 @@ impl App {
         // TODO somehow make this less shit
         for newly_used_var in self
             .variables_only_used_in(&window_name)
-            .filter_map(|var| self.eww_config.get_script_var(&var))
+            .filter_map(|var| self.eww_config.get_script_var(&var).ok())
         {
             self.script_var_handler.add(newly_used_var.clone());
         }

--- a/src/config/eww_config.rs
+++ b/src/config/eww_config.rs
@@ -19,8 +19,6 @@ pub struct EwwConfig {
     widgets: HashMap<String, WidgetDefinition>,
     windows: HashMap<WindowName, EwwWindowDefinition>,
     initial_variables: HashMap<VarName, PrimitiveValue>,
-
-    // TODO make this a hashmap
     script_vars: HashMap<VarName, ScriptVar>,
     pub filepath: PathBuf,
 }
@@ -54,7 +52,7 @@ fn check_merge<K: std::hash::Hash + Eq + std::fmt::Display, V: std::fmt::Debug>(
 impl EwwConfig {
     pub fn merge_includes(mut eww_config: EwwConfig, includes: Vec<EwwConfig>) -> Result<EwwConfig> {
         for config in includes {
-            // Destructures the `includes`, because of the borrow checker
+            // Destructures `config`, because of the borrow checker
             let widgets_: HashMap<String, WidgetDefinition>;
             let windows_: HashMap<WindowName, EwwWindowDefinition>;
             let script_vars_: HashMap<VarName, ScriptVar>;
@@ -77,7 +75,6 @@ impl EwwConfig {
             }
 
             // widgets
-
             check_merge(&eww_config.widgets, &widgets_, &path);
             eww_config.widgets.extend(widgets_);
 
@@ -203,11 +200,13 @@ impl EwwConfig {
     }
 
     pub fn get_script_vars(&self) -> Vec<ScriptVar> {
-        self.script_vars.iter().map(|a| a.1.clone()).collect()
+        self.script_vars.values().map(|a| a.clone()).collect()
     }
 
-    pub fn get_script_var(&self, name: &VarName) -> Option<&ScriptVar> {
-        self.script_vars.iter().map(|a| a.1).find(|x| x.name() == name)
+    pub fn get_script_var(&self, name: &VarName) -> Result<&ScriptVar> {
+        self.script_vars
+            .get(name)
+            .with_context(|| format!("No script var named '{}' exists", name))
     }
 }
 
@@ -316,7 +315,7 @@ mod test {
             widgets: HashMap::new(),
             windows: HashMap::new(),
             initial_variables: HashMap::new(),
-            script_vars: Vec::new(),
+            script_vars: HashMap::new(),
             filepath: "test_path".into(),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ fn main() {
                 } else {
                     log::info!("Initializing Eww server.");
                     let _ = std::fs::remove_file(&*crate::IPC_SOCKET_PATH);
-                    println!("Run `eww logs` to see any errors, warnings or informatiion while editing your configuration.");
+                    println!("Run `eww logs` to see any errors, warnings or information while editing your configuration.");
                     server::initialize_server()?;
                 }
             }


### PR DESCRIPTION
## Description

This PR adds support for warnings when the same variables/windows/widgets and initial script variables in different config files.  
And other general improvements.

## Usage

Include another config, define something, which is defined in the main config.

The warnings will then be shown in `eww logs`

### Showcase

```
The normal config, and the included config: /home/legend/.config/eww/test.xml, both define a widget, with the same name: 'combo-box'
```

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before 