### PR TITLE
Explicetely states where to look for installing eww

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 Elkowar&rsquo;s Wacky Widgets is a standalone widget system made in Rust that allows you to implement
 your own, custom widgets in any window manager.
 
-Documentation can be found [here](https://elkowar.github.io/eww/main).
+Documentation **and instructions on how to install** can be found [here](https://elkowar.github.io/eww/main).
 
-# Examples
+
+## Examples
 
 * A basic bar, see [examples](./examples/eww-bar)
 ![Example 1](./examples/eww-bar/eww-bar.png)
 
 * [Setup by Axarva](https://github.com/Axarva/dotfiles-2.0)
 ![Axarva-rice](https://raw.githubusercontent.com/Axarva/dotfiles-2.0/main/screenshots/center.png)
-
 
 ## Contribewwting
 


### PR DESCRIPTION
I think this should be added, because we already had a couple of people opening issues because they didn't read the docs on how to install eww.

This also fixes this weird formatting of the "Examples" heading being too large and being on the same line as the image (wait that doesn't happen in the readme that's shown but only in the github editor 🤔 )
