### PR TITLE
replaces all daemon prints with logs and enables logging by default

### DIFF
--- a/src/config/eww_config.rs
+++ b/src/config/eww_config.rs
@@ -82,7 +82,7 @@ impl RawEwwConfig {
     pub fn merge_includes(mut eww_config: RawEwwConfig, includes: Vec<RawEwwConfig>) -> Result<RawEwwConfig> {
         let config_path = eww_config.filepath.clone();
         let log_conflict = |what: &str, conflict: &str, included_path: &std::path::PathBuf| {
-            eprintln!(
+            log::error!(
                 "{} '{}' defined twice (defined in {} and in {})",
                 what,
                 conflict,
@@ -200,7 +200,7 @@ fn parse_variables_block(xml: XmlElement) -> Result<(HashMap<VarName, PrimVal>, 
     // Extends the variables with the predefined variables
     let inbuilt = crate::config::inbuilt::get_inbuilt_vars();
     for i in util::extend_safe(&mut script_vars, inbuilt) {
-        eprintln!(
+        log::error!(
             "script-var '{}' defined twice (defined in your config and in the eww included variables)\nHint: don't define any \
              varible like any of these: https://elkowar.github.io/eww/main/magic-variables-documenation/",
             i,

--- a/src/eww_state.rs
+++ b/src/eww_state.rs
@@ -33,7 +33,7 @@ impl StateChangeHandler {
             Ok(resolved_attrs) => {
                 crate::print_result_err!("while updating UI based after state change", &(self.func)(resolved_attrs))
             }
-            Err(err) => eprintln!("Error while resolving attributes: {:?}", err),
+            Err(err) => log::error!("Error while resolving attributes: {:?}", err),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,9 @@ pub mod widgets;
 fn main() {
     let opts: opts::Opt = opts::Opt::from_env();
 
-    let log_level_filter = if opts.log_debug { log::LevelFilter::Debug } else { log::LevelFilter::Off };
+    let log_level_filter = if opts.log_debug { log::LevelFilter::Debug } else { log::LevelFilter::Info };
 
-    pretty_env_logger::formatted_builder().filter(Some("eww"), log_level_filter).init();
+    pretty_env_logger::formatted_timed_builder().filter(Some("eww"), log_level_filter).init();
 
     let result: Result<()> = try {
         let paths = opts
@@ -89,7 +89,7 @@ fn main() {
     };
 
     if let Err(e) = result {
-        eprintln!("{:?}", e);
+        log::error!("{:?}", e);
         std::process::exit(1);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,7 +25,7 @@ macro_rules! try_logging_errors {
     ($context:expr => $code:block) => {{
         let result: Result<_> = try { $code };
         if let Err(err) = result {
-            eprintln!("[{}:{}] Error while {}: {:?}", ::std::file!(), ::std::line!(), $context, err);
+            log::error!("[{}:{}] Error while {}: {:?}", ::std::file!(), ::std::line!(), $context, err);
         }
     }};
 }
@@ -34,7 +34,7 @@ macro_rules! try_logging_errors {
 macro_rules! print_result_err {
     ($context:expr, $result:expr $(,)?) => {{
         if let Err(err) = $result {
-            eprintln!("[{}:{}] Error {}: {:?}", ::std::file!(), ::std::line!(), $context, err);
+            log::error!("[{}:{}] Error {}: {:?}", ::std::file!(), ::std::line!(), $context, err);
         }
     }};
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -29,14 +29,14 @@ pub(self) fn run_command<T: 'static + std::fmt::Display + Send + Sync>(cmd: &str
             Ok(mut child) => match child.wait_timeout(std::time::Duration::from_millis(200)) {
                 // child timed out
                 Ok(None) => {
-                    eprintln!("WARNING: command {} timed out", &cmd);
+                    log::error!("WARNING: command {} timed out", &cmd);
                     let _ = child.kill();
                     let _ = child.wait();
                 }
-                Err(err) => eprintln!("Failed to execute command {}: {}", cmd, err),
+                Err(err) => log::error!("Failed to execute command {}: {}", cmd, err),
                 Ok(Some(_)) => {}
             },
-            Err(err) => eprintln!("Failed to launch child process: {}", err),
+            Err(err) => log::error!("Failed to launch child process: {}", err),
         }
     });
 }
@@ -106,8 +106,8 @@ fn build_builtin_gtk_widget(
     resolve_widget_attrs(&mut bargs, &gtk_widget);
 
     if !bargs.unhandled_attrs.is_empty() {
-        eprintln!(
-            "{}WARN: Unknown attribute used in {}: {}",
+        log::error!(
+            "{}: Unknown attribute used in {}: {}",
             widget.text_pos.map(|x| format!("{} | ", x)).unwrap_or_default(),
             widget.name,
             bargs.unhandled_attrs.iter().map(|x| x.to_string()).join(", ")
@@ -167,7 +167,7 @@ macro_rules! log_errors {
     ($body:expr) => {{
         let result = try { $body };
         if let Err(e) = result {
-            eprintln!("WARN: {}", e);
+            log::warn!("{}", e);
         }
     }};
 }


### PR DESCRIPTION
A lot of errors wouldn't be logged with how it is currently, as any logging is disabled without the --debug flag.

With this patch all warnings and errors will be printed, if the --debug flag isn't specified + it also enables the time flags, for easier debugging of script vars and when they execute.

Furthermore, as it's currently there is the issue that eprintln/println and the log crate is used, this tries to minimize the usage of the standard print macros