### PR TITLE
Set _NET_WM_WINDOW_TYPE and related fields properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,8 @@ dependencies = [
  "simple-signal",
  "smart-default",
  "structopt",
+ "strum 0.20.0",
+ "strum_macros 0.20.1",
  "sysinfo",
  "tokio",
  "tokio-stream",
@@ -1712,10 +1714,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
 
 [[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+
+[[package]]
 name = "strum_macros"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1778,8 +1798,8 @@ checksum = "0f3ecc17269a19353b3558b313bba738b25d82993e30d62a18406a24aba4649b"
 dependencies = [
  "heck",
  "pkg-config",
- "strum",
- "strum_macros",
+ "strum 0.18.0",
+ "strum_macros 0.18.0",
  "thiserror",
  "toml",
  "version-compare",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ base64 = "0.13"
 wait-timeout = "0.2"
 
 notify = "5.0.0-pre.7"
+strum_macros = "0.20.1"
+strum = "0.20.0"
 
 [dev-dependencies]
 pretty_assertions = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,6 @@ base64 = "0.13"
 wait-timeout = "0.2"
 
 notify = "5.0.0-pre.7"
-strum_macros = "0.20.1"
-strum = "0.20.0"
 
 [dev-dependencies]
 pretty_assertions = "0.7.1"

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -220,7 +220,7 @@ For Wayland users the `<reserve/>` block is replaced by the exclusive field in `
 The previous `<window>` block would look like this.
 
 ```xml
-    <window name="main_window" stacking="fg" focusable="false" screen="1" exclusive="true">
+    <window name="main_window" stacking="fg" focusable="false" screen="1" exclusive="true" windowtype="normal">
         <geometry anchor="top left" x="300px" y="50%" width="25%" height="20px"/>
         <widget>
             <main/>
@@ -247,3 +247,10 @@ There are a couple things you can optionally configure on the window itself:
   The details on how it is actually implemented are left to the compositor.
   This option is only valid on Wayland.
   Possible values: `"true"`, `"false"`. Default: `"false"`
+- `windowtype`: (X11 only) Can be used in determining the decoration, stacking position and other behavior of the window.
+  Possible values: 
+    - `"normal"`: indicates that this is a normal, top-level window
+    - `"dock"`: indicates a dock or panel feature
+    - `"toolbar"`: toolbars "torn off" from the main application
+    - `"dialog"`: indicates that this is a dialog window
+Default: `"dock"` if reserve is set, else `"normal"` 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -253,4 +253,4 @@ There are a couple things you can optionally configure on the window itself:
     - `"dock"`: indicates a dock or panel feature
     - `"toolbar"`: toolbars "torn off" from the main application
     - `"dialog"`: indicates that this is a dialog window
-Default: `"dock"` if reserve is set, else `"normal"` 
+    - Default: `"dock"` if reserve is set, else `"normal"` 

--- a/examples/eww-bar/eww.xml
+++ b/examples/eww-bar/eww.xml
@@ -93,7 +93,7 @@ contain are defined. -->
 
   <windows>
     <!-- These are the windows -->
-    <window name="bar" screen="0">
+    <window name="bar" screen="0" focusable="true" windowtype="dock">
       <geometry x="0%" y="0%" width="100%" height="4%"/> <!--Specifies geometry-->
       <reserve side="top" distance="4%" layer="top"/>
       <widget>

--- a/src/app.rs
+++ b/src/app.rs
@@ -307,7 +307,6 @@ fn initialize_window(
     window_def: config::EwwWindowDefinition,
 ) -> Result<EwwWindow> {
     let actual_window_rect = window_def.geometry.get_window_rectangle(monitor_geometry);
-
     if let Some(window) = display_backend::initialize_window(&window_def, monitor_geometry) {
         window.set_title(&format!("Eww - {}", window_def.name));
         let wm_class_name = format!("eww-{}", window_def.name);
@@ -329,7 +328,7 @@ fn initialize_window(
         gdk_window.set_override_redirect(!window_def.focusable);
 
         #[cfg(feature = "x11")]
-        display_backend::reserve_space_for(&window, monitor_geometry, window_def.struts)?;
+        display_backend::set_xprops(&window, monitor_geometry, &window_def)?;
 
         // this should only be required on x11, as waylands layershell should manage the margins properly anways.
         #[cfg(feature = "x11")]
@@ -344,7 +343,6 @@ fn initialize_window(
     } else {
         Err(anyhow!("monitor {} is unavailable", window_def.screen_number.unwrap()))
     }
-
 }
 
 /// Apply the provided window-positioning rules to the window.

--- a/src/config/window_definition.rs
+++ b/src/config/window_definition.rs
@@ -37,16 +37,19 @@ impl Default for EwwWindowType {
 #[derive(Debug, Clone)]
 pub struct EwwWindowDefinition {
     pub name: WindowName,
-    pub window_type: EwwWindowType,
+    
     pub geometry: EwwWindowGeometry,
     pub stacking: WindowStacking,
     pub screen_number: Option<i32>,
     pub widget: Box<dyn widget_node::WidgetNode>,
     pub focusable: bool,
-
+    
+    #[cfg(feature = "x11")]
+    pub window_type: EwwWindowType,
+    
     #[cfg(feature = "x11")]
     pub struts: StrutDefinition,
-
+    
     #[cfg(feature = "wayland")]
     pub exclusive: bool,
 }

--- a/src/config/window_definition.rs
+++ b/src/config/window_definition.rs
@@ -4,16 +4,28 @@ use derive_more::*;
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
 use std::{collections::HashMap, str::FromStr};
-use strum_macros::EnumString;
 
-#[derive(Debug, Clone, PartialEq, EnumString)]
-#[strum(serialize_all = "lowercase")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum EwwWindowType {
     Dock,
     Dialog,
     Toolbar,
     Normal,
 }
+impl FromStr for EwwWindowType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dock" => Ok(Self::Dock),
+            "toolbar" => Ok(Self::Toolbar),
+            "dialog" => Ok(Self::Dialog),
+            "normal" => Ok(Self::Normal),
+            x => Err(anyhow!("Unknown windowtype provided '{}'. Possible values are: dock, toolbar, dialog, normal", x)),
+        }
+    }
+}
+
 impl Default for EwwWindowType {
     fn default() -> Self {
         Self::Normal

--- a/src/config/window_definition.rs
+++ b/src/config/window_definition.rs
@@ -58,12 +58,13 @@ impl EwwWindowDefinition {
     pub fn generate(defs: &HashMap<String, WidgetDefinition>, window: RawEwwWindowDefinition) -> Result<Self> {
         Ok(EwwWindowDefinition {
             name: window.name,
-            window_type: window.window_type,
             geometry: window.geometry,
             stacking: window.stacking,
             screen_number: window.screen_number,
             widget: widget_node::generate_generic_widget_node(defs, &HashMap::new(), window.widget)?,
             focusable: window.focusable,
+            #[cfg(feature = "x11")]
+            window_type: window.window_type,
             #[cfg(feature = "x11")]
             struts: window.struts,
             #[cfg(feature = "wayland")]


### PR DESCRIPTION
## Description

resolving #153 according to [comment](https://github.com/elkowar/eww/issues/153#issuecomment-819362565)

## Additional Notes

This could technically be marked as resolved. But here are some points to consider before merging 
- When `focusable` is `false`, setting `_NET_WM_WINDOW_TYPE` doesn't do anything at all. Should the `focusable` attribute affect the defaults ? 
- `_NET_WM_STATE` also seems important, should there be some way to set it from the top level API ?
- This is exposing some low level stuff to the top-level API and kinda pushes work to the user-side, not to mention that some stuff will break when switching between `wayland` and `x11`. Should there be higher-level abstractions that hide those params ?  

## Checklist

- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
