### PR TITLE
Adding the GtkRevealer widget

### DIFF
--- a/src/widgets/widget_definitions.rs
+++ b/src/widgets/widget_definitions.rs
@@ -28,6 +28,7 @@ pub(super) fn widget_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<Option<gtk
         "color-chooser" => build_gtk_color_chooser(bargs)?.upcast(),
         "combo-box-text" => build_gtk_combo_box_text(bargs)?.upcast(),
         "checkbox" => build_gtk_checkbox(bargs)?.upcast(),
+        "revealer" => build_gtk_revealer(bargs)?.upcast(),
         "if-else" => build_if_else(bargs)?.upcast(),
         _ => return Ok(None),
     };
@@ -264,6 +265,32 @@ fn build_gtk_expander(bargs: &mut BuilderArgs) -> Result<gtk::Expander> {
     prop(name: as_string) {gtk_widget.set_label(Some(&name));},
     // @prop expanded - sets if the tree is expanded
     prop(expanded: as_bool) { gtk_widget.set_expanded(expanded); }
+    });
+    Ok(gtk_widget)
+}
+
+/// @widget expander extends container
+/// @desc A widget that can expand and collapse, showing/hiding it's children.
+fn build_gtk_revealer(bargs: &mut BuilderArgs) -> Result<gtk::Revealer> {
+    let gtk_widget = gtk::Revealer::new();
+    resolve_block!(bargs, gtk_widget, {
+    // @prop name - name of the expander
+    prop(transition: as_string) {
+        match transition.as_str() {
+            "slideright" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::SlideRight),
+            "slideleft" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::SlideLeft),
+            "slideup" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::SlideUp),
+            "slidedown" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::SlideDown),
+            "crossfade" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::Crossfade),
+            _ => gtk_widget.set_transition_type(gtk::RevealerTransitionType::None),
+        }
+    },
+    prop(reveal: as_bool) { gtk_widget.set_reveal_child(reveal); },
+    prop(duration: as_string) {
+        if let Ok(duration) = duration.parse::<u32>() {
+            gtk_widget.set_transition_duration(duration);
+        }
+    },
     });
     Ok(gtk_widget)
 }

--- a/src/widgets/widget_definitions.rs
+++ b/src/widgets/widget_definitions.rs
@@ -261,10 +261,10 @@ fn build_gtk_combo_box_text(bargs: &mut BuilderArgs) -> Result<gtk::ComboBoxText
 fn build_gtk_expander(bargs: &mut BuilderArgs) -> Result<gtk::Expander> {
     let gtk_widget = gtk::Expander::new(None);
     resolve_block!(bargs, gtk_widget, {
-    // @prop name - name of the expander
-    prop(name: as_string) {gtk_widget.set_label(Some(&name));},
-    // @prop expanded - sets if the tree is expanded
-    prop(expanded: as_bool) { gtk_widget.set_expanded(expanded); }
+        // @prop name - name of the expander
+        prop(name: as_string) {gtk_widget.set_label(Some(&name));},
+        // @prop expanded - sets if the tree is expanded
+        prop(expanded: as_bool) { gtk_widget.set_expanded(expanded); }
     });
     Ok(gtk_widget)
 }
@@ -274,12 +274,12 @@ fn build_gtk_expander(bargs: &mut BuilderArgs) -> Result<gtk::Expander> {
 fn build_gtk_revealer(bargs: &mut BuilderArgs) -> Result<gtk::Revealer> {
     let gtk_widget = gtk::Revealer::new();
     resolve_block!(bargs, gtk_widget, {
-    // @prop transition - the name of the transition. Possible values: $transition
-    prop(transition: as_string) { gtk_widget.set_transition_type(parse_transition(&transition)?); },
-    // @prop reveal - sets if the child is revealed or not
-    prop(reveal: as_bool) { gtk_widget.set_reveal_child(reveal); },
-    // @prop duration - the duration of the reveal transition
-    prop(duration: as_string) { gtk_widget.set_transition_duration(parse_duration(&duration)?.as_millis() as u32); },
+        // @prop transition - the name of the transition. Possible values: $transition
+        prop(transition: as_string) { gtk_widget.set_transition_type(parse_transition(&transition)?); },
+        // @prop reveal - sets if the child is revealed or not
+        prop(reveal: as_bool) { gtk_widget.set_reveal_child(reveal); },
+        // @prop duration - the duration of the reveal transition
+        prop(duration: as_string) { gtk_widget.set_transition_duration(parse_duration(&duration)?.as_millis() as u32); },
     });
     Ok(gtk_widget)
 }

--- a/src/widgets/widget_definitions.rs
+++ b/src/widgets/widget_definitions.rs
@@ -269,27 +269,18 @@ fn build_gtk_expander(bargs: &mut BuilderArgs) -> Result<gtk::Expander> {
     Ok(gtk_widget)
 }
 
-/// @widget expander extends container
-/// @desc A widget that can expand and collapse, showing/hiding it's children.
+/// @widget revealer extends container
+/// @desc A widget that can reveal a child with an animation.
 fn build_gtk_revealer(bargs: &mut BuilderArgs) -> Result<gtk::Revealer> {
     let gtk_widget = gtk::Revealer::new();
     resolve_block!(bargs, gtk_widget, {
-    // @prop name - name of the expander
-    prop(transition: as_string) {
-        match transition.as_str() {
-            "slideright" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::SlideRight),
-            "slideleft" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::SlideLeft),
-            "slideup" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::SlideUp),
-            "slidedown" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::SlideDown),
-            "crossfade" => gtk_widget.set_transition_type(gtk::RevealerTransitionType::Crossfade),
-            _ => gtk_widget.set_transition_type(gtk::RevealerTransitionType::None),
-        }
-    },
+    // @prop transition - the name of the transition
+    prop(transition: as_string) { gtk_widget.set_transition_type(parse_transition(&transition)?); },
+    // @prop reveal - sets if the child is revealed or not
     prop(reveal: as_bool) { gtk_widget.set_reveal_child(reveal); },
-    prop(duration: as_string) {
-        if let Ok(duration) = duration.parse::<u32>() {
-            gtk_widget.set_transition_duration(duration);
-        }
+    // @prop duration - the duration of the reveal animation
+    prop(duration: as_i32) {
+        gtk_widget.set_transition_duration(duration.abs() as u32);
     },
     });
     Ok(gtk_widget)
@@ -583,6 +574,19 @@ fn parse_orientation(o: &str) -> Result<gtk::Orientation> {
         "vertical" | "v" => gtk::Orientation::Vertical,
         "horizontal" | "h" => gtk::Orientation::Horizontal,
         _ => bail!(r#"Couldn't parse orientation: '{}'. Possible values are "vertical", "v", "horizontal", "h""#, o),
+    })
+}
+
+/// @var transition - "slideright", "slideleft", "slideup", "slidedown", "crossfade", "none"
+fn parse_transition(t: &str) -> Result<gtk::RevealerTransitionType> {
+    Ok(match t {
+        "slideright" => gtk::RevealerTransitionType::SlideRight,
+        "slideleft" => gtk::RevealerTransitionType::SlideLeft,
+        "slideup" => gtk::RevealerTransitionType::SlideUp,
+        "slidedown" => gtk::RevealerTransitionType::SlideDown,
+        "crossfade" => gtk::RevealerTransitionType::Crossfade,
+        "none" => gtk::RevealerTransitionType::None,
+        _ => bail!(r#"Couldn't parse transition: '{}'. Possible values are "slideright", "slideleft", "slideup", "slidedown", "crossfade" and "none" "#, t),
     })
 }
 

--- a/src/widgets/widget_definitions.rs
+++ b/src/widgets/widget_definitions.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::option_map_unit_fn)]
 use super::{run_command, BuilderArgs};
-use crate::{config, eww_state, resolve_block, value::AttrVal, widgets::widget_node};
+use crate::{config, eww_state, resolve_block, value::AttrVal, widgets::widget_node, util::parse_duration};
 use anyhow::*;
 use gdk::WindowExt;
 use glib;
@@ -279,7 +279,7 @@ fn build_gtk_revealer(bargs: &mut BuilderArgs) -> Result<gtk::Revealer> {
     // @prop reveal - sets if the child is revealed or not
     prop(reveal: as_bool) { gtk_widget.set_reveal_child(reveal); },
     // @prop duration - the duration of the reveal transition
-    prop(duration: as_i32) { gtk_widget.set_transition_duration(parse_duration(duration)?); },
+    prop(duration: as_string) { gtk_widget.set_transition_duration(parse_duration(&duration)?.as_millis() as u32); },
     });
     Ok(gtk_widget)
 }
@@ -598,15 +598,6 @@ fn parse_align(o: &str) -> Result<gtk::Align> {
         "end" => gtk::Align::End,
         _ => bail!(r#"Couldn't parse alignment: '{}'. Possible values are "fill", "baseline", "center", "start", "end""#, o),
     })
-}
-
-/// @var duration - positive integer
-fn parse_duration(d: i32) -> Result<u32> {
-    Ok( if d.is_positive() {
-        d as u32
-    } else {
-        bail!(r#"Couldn't parse duration: '{}'. The duration must be a positive integer"#, d)
-    } )
 }
 
 fn connect_first_map<W: IsA<gtk::Widget>, F: Fn(&W) + 'static>(widget: &W, func: F) {

--- a/src/widgets/widget_definitions.rs
+++ b/src/widgets/widget_definitions.rs
@@ -274,14 +274,12 @@ fn build_gtk_expander(bargs: &mut BuilderArgs) -> Result<gtk::Expander> {
 fn build_gtk_revealer(bargs: &mut BuilderArgs) -> Result<gtk::Revealer> {
     let gtk_widget = gtk::Revealer::new();
     resolve_block!(bargs, gtk_widget, {
-    // @prop transition - the name of the transition
+    // @prop transition - the name of the transition. Possible values: $transition
     prop(transition: as_string) { gtk_widget.set_transition_type(parse_transition(&transition)?); },
     // @prop reveal - sets if the child is revealed or not
     prop(reveal: as_bool) { gtk_widget.set_reveal_child(reveal); },
-    // @prop duration - the duration of the reveal animation
-    prop(duration: as_i32) {
-        gtk_widget.set_transition_duration(duration.abs() as u32);
-    },
+    // @prop duration - the duration of the reveal transition
+    prop(duration: as_i32) { gtk_widget.set_transition_duration(parse_duration(duration)?); },
     });
     Ok(gtk_widget)
 }
@@ -600,6 +598,15 @@ fn parse_align(o: &str) -> Result<gtk::Align> {
         "end" => gtk::Align::End,
         _ => bail!(r#"Couldn't parse alignment: '{}'. Possible values are "fill", "baseline", "center", "start", "end""#, o),
     })
+}
+
+/// @var duration - positive integer
+fn parse_duration(d: i32) -> Result<u32> {
+    Ok( if d.is_positive() {
+        d as u32
+    } else {
+        bail!(r#"Couldn't parse duration: '{}'. The duration must be a positive integer"#, d)
+    } )
 }
 
 fn connect_first_map<W: IsA<gtk::Widget>, F: Fn(&W) + 'static>(widget: &W, func: F) {


### PR DESCRIPTION
Widget enabling animations.

## Usage

When the child is revealed or hidden, a transition animation will happen.

### Showcase

https://user-images.githubusercontent.com/49378990/122963105-fa4c9000-d353-11eb-8a74-8451bfa766b3.mp4

## Additional Notes
```xml
      <revealer transition="slideup" duration="600" reveal="{{show}}">
        <box orientation="h">
            jeff
        </box>
      </revealer>

```

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
