### PR TITLE
Added angle property for label widget

### DIFF
--- a/src/widgets/widget_definitions.rs
+++ b/src/widgets/widget_definitions.rs
@@ -502,7 +502,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         prop(wrap: as_bool) {
             gtk_widget.set_line_wrap(wrap)
         },
-        // @prop angle - the angle of rotation for the label
+        // @prop angle - the angle of rotation for the label (between 0 - 360)
         prop(angle: as_f64 = 0) {
             gtk_widget.set_angle(angle)
         }

--- a/src/widgets/widget_definitions.rs
+++ b/src/widgets/widget_definitions.rs
@@ -501,6 +501,10 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         // @prop wrap - Wrap the text. This mainly makes sense if you set the width of this widget.
         prop(wrap: as_bool) {
             gtk_widget.set_line_wrap(wrap)
+        },
+        // @prop angle - the angle of rotation for the label
+        prop(angle: as_f64 = 0) {
+            gtk_widget.set_angle(angle)
         }
     });
     Ok(gtk_widget)


### PR DESCRIPTION
## Description

Added the ability to set the angle of the label widget. Useful for sidebars :D

## Usage

```xml
<label angle="90" text="Awesome!"/>
```
angle is a double, and will default to 0 (horizontal) if omitted

### Showcase

![image](https://user-images.githubusercontent.com/59150607/125327471-0d42f680-e33b-11eb-8501-04b59f7d57d4.png)
![image-21.png](https://user-images.githubusercontent.com/59150607/125363100-ed75f780-e367-11eb-9e28-61d0f060f218.png)