### PR TITLE
Better EWW_RAM / Docs update

### DIFF
--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -23,13 +23,13 @@ macro_rules! builtin_vars {
 pub fn get_inbuilt_vars() -> HashMap<VarName, ScriptVarDefinition> {
     builtin_vars! {Duration::new(2, 0),
         // @desc EWW_TEMPS - Heat of the components in Celcius\nExample: `{(CPU_TEMPS.core_1 + CPU_TEMPS.core_2) / 2}`
-        "EWW_TEMPS" => || Ok(DynVal::from(cores())),
+        "EWW_TEMPS" => || Ok(DynVal::from(get_core_temperatures())),
 
         // @desc EWW_RAM - The current RAM + Swap usage
-        "EWW_RAM" => || Ok(DynVal::from(format!("{:.2}", ram()))),
+        "EWW_RAM" => || Ok(DynVal::from(format!("{:.2}", get_ram()))),
 
         // @desc EWW_DISK - Information on on all mounted partitions (Might report inaccurately on some filesystems, like btrfs)\nExample: `{EWW_DISK["/"]}`
-        "EWW_DISK" => || Ok(DynVal::from(disk())),
+        "EWW_DISK" => || Ok(DynVal::from(get_disks())),
 
         // @desc EWW_BATTERY - Battery capacity in procent of the main battery
         "EWW_BATTERY" => || Ok(DynVal::from(
@@ -43,7 +43,7 @@ pub fn get_inbuilt_vars() -> HashMap<VarName, ScriptVarDefinition> {
         )),
 
         // @desc EWW_CPU_USAGE - Average CPU usage (all cores) since the last update (No MacOS support)
-        "EWW_CPU_USAGE" => || Ok(DynVal::from(get_avg_cpu_usage())),
+        "EWW_CPU_USAGE" => || Ok(DynVal::from(get_cpus())),
 
         // @desc EWW_NET - Bytes up/down on all interfaces
         "EWW_NET" => || Ok(DynVal::from(net())),

--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -22,10 +22,10 @@ macro_rules! builtin_vars {
 
 pub fn get_inbuilt_vars() -> HashMap<VarName, ScriptVarDefinition> {
     builtin_vars! {Duration::new(2, 0),
-        // @desc EWW_TEMPS - Heat of the components in Celcius\nExample: `{(CPU_TEMPS.core_1 + CPU_TEMPS.core_2) / 2}`
-        "EWW_TEMPS" => || Ok(DynVal::from(get_core_temperatures())),
+        // @desc EWW_TEMPS - Heat of the components in Celcius
+        "EWW_TEMPS" => || Ok(DynVal::from(get_temperatures())),
 
-        // @desc EWW_RAM - The current RAM + Swap usage
+        // @desc EWW_RAM - Information on ram and swap usage in kB.
         "EWW_RAM" => || Ok(DynVal::from(get_ram())),
 
         // @desc EWW_DISK - Information on on all mounted partitions (Might report inaccurately on some filesystems, like btrfs)\nExample: `{EWW_DISK["/"]}`
@@ -42,8 +42,16 @@ pub fn get_inbuilt_vars() -> HashMap<VarName, ScriptVarDefinition> {
             }
         )),
 
-        // @desc EWW_CPU_USAGE - Average CPU usage (all cores) since the last update (No MacOS support)
-        "EWW_CPU_USAGE" => || Ok(DynVal::from(get_cpus())),
+        // @desc EWW_CPU - Information on the CPU cores: frequency and usage (No MacOS support)
+        "EWW_CPU" => || Ok(DynVal::from(get_cpus())),
+
+        // TODO: Change this eventually, maybe implement an error system
+        // @desc EWW_CPU_USAGE - Outdated, use `EWW_CPU` instead
+        "EWW_CPU_USAGE" => {
+            log::warn!("EWW_CPU_BATTERY is deprecated, use EWW_CPU instead");
+            || Ok(DynVal::from(get_cpus()))
+        },
+
 
         // @desc EWW_NET - Bytes up/down on all interfaces
         "EWW_NET" => || Ok(DynVal::from(net())),

--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -26,7 +26,7 @@ pub fn get_inbuilt_vars() -> HashMap<VarName, ScriptVarDefinition> {
         "EWW_TEMPS" => || Ok(DynVal::from(get_core_temperatures())),
 
         // @desc EWW_RAM - The current RAM + Swap usage
-        "EWW_RAM" => || Ok(DynVal::from(format!("{:.2}", get_ram()))),
+        "EWW_RAM" => || Ok(DynVal::from(get_ram())),
 
         // @desc EWW_DISK - Information on on all mounted partitions (Might report inaccurately on some filesystems, like btrfs)\nExample: `{EWW_DISK["/"]}`
         "EWW_DISK" => || Ok(DynVal::from(get_disks())),

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -40,7 +40,7 @@ pub fn get_ram() -> String {
     )
 }
 
-pub fn get_core_temperatures() -> String {
+pub fn get_temperatures() -> String {
     let mut c = SYSTEM.lock().unwrap();
     c.refresh_components_list();
     c.refresh_components();

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -7,7 +7,7 @@ use sysinfo::{ComponentExt, DiskExt, NetworkExt, NetworksExt, ProcessorExt, Syst
 
 static SYSTEM: Lazy<Mutex<System>> = Lazy::new(|| Mutex::new(System::new()));
 
-pub fn disk() -> String {
+pub fn get_disks() -> String {
     let mut c = SYSTEM.lock().unwrap();
     c.refresh_disks_list();
 
@@ -26,13 +26,13 @@ pub fn disk() -> String {
     )
 }
 
-pub fn ram() -> f32 {
+pub fn get_ram() -> f32 {
     let mut c = SYSTEM.lock().unwrap();
     c.refresh_memory();
     (c.get_used_memory() as f32 + c.get_used_swap() as f32) / 1_000_000f32
 }
 
-pub fn cores() -> String {
+pub fn get_core_temperatures() -> String {
     let mut c = SYSTEM.lock().unwrap();
     c.refresh_components_list();
     c.refresh_components();
@@ -45,7 +45,7 @@ pub fn cores() -> String {
     )
 }
 
-pub fn get_avg_cpu_usage() -> String {
+pub fn get_cpus() -> String {
     let mut c = SYSTEM.lock().unwrap();
     c.refresh_cpu();
     let processors = c.get_processors();
@@ -133,7 +133,7 @@ pub fn get_battery_capacity() -> Result<String> {
 #[cfg(not(target_os = "macos"))]
 #[cfg(not(target_os = "linux"))]
 pub fn get_battery_capacity() -> Result<u8> {
-    anyhow!("eww doesn't support your OS for getting the battery capacity")
+    anyhow!("Eww doesn't support your OS for getting the battery capacity")
 }
 
 pub fn net() -> String {

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -26,10 +26,18 @@ pub fn get_disks() -> String {
     )
 }
 
-pub fn get_ram() -> f32 {
+pub fn get_ram() -> String {
     let mut c = SYSTEM.lock().unwrap();
     c.refresh_memory();
-    (c.get_used_memory() as f32 + c.get_used_swap() as f32) / 1_000_000f32
+    format!(
+        r#"{{"total_mem": {}, "free_mem": {}, "total_swap": {}, "free_swap": {}, "available_mem": {}, "used_mem": {}}}"#,
+        c.get_total_memory(),
+        c.get_free_memory(),
+        c.get_total_swap(),
+        c.get_free_swap(),
+        c.get_available_memory(),
+        c.get_used_memory(),
+    )
 }
 
 pub fn get_core_temperatures() -> String {


### PR DESCRIPTION
## Description

This PR:
- adds information to the magic variable EWW_RAM. 
- renames EWW_CPU_USAGE to EWW_CPU given that it also has frequency
- it also renames some of the functions related to magic variables (system_stats.rs) for the sake of consistency.  
- updates the docs regarding magic variables briefly

## Additional Notes

Using EWW_CPU_USAGE is still okay, but I've added a deprecation warning. 

## Checklist

- [ ] All widgets I've added are correctly documented.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
