### PR TITLE
Adds `:onhoverlost` and separates out event based actions on eventbox widget (See #251 for more info).

### DIFF
--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -268,7 +268,6 @@ impl App {
         // refresh script-var poll stuff
         self.script_var_handler.stop_all();
 
-
         log::trace!("loading config: {:#?}", config);
 
         self.eww_config = config;

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -557,7 +557,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
             ));
             old_id.map(|id| gtk_widget.disconnect(id));
         },
-        // @prop cursor - Cursor to show while hovering (see [gtk3-cursors](https://developer.gnome.org/gdk3/stable/gdk3-Cursors.html) for possible names)
+        // @prop cursor - Cursor to show while hovering (see [gtk3-cursors](https://docs.gtk.org/gdk3/ctor.Cursor.new_from_name.html) for possible names)
         prop(cursor: as_string) {
             gtk_widget.add_events(gdk::EventMask::ENTER_NOTIFY_MASK);
             gtk_widget.add_events(gdk::EventMask::LEAVE_NOTIFY_MASK);

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -69,8 +69,9 @@ pub(super) fn resolve_widget_attrs(bargs: &mut BuilderArgs, gtk_widget: &gtk::Wi
     if !contained_deprecated.is_empty() {
         let diag = error_handling_ctx::stringify_diagnostic(gen_diagnostic! {
             kind =  Severity::Error,
-            msg = format!("The attribute(s) ({}) has/have been removed, as GTK does not support it consistently. Instead, use eventbox to wrap this widget and set the attribute there. See #251 (https://github.com/elkowar/eww/issues/251) for more details.", contained_deprecated.iter().join(", ")),
-            label = bargs.widget.span => "Found in here"
+            msg = "Unsupported attributes provided",
+            label = bargs.widget.span => "Found in here",
+            note = format!("The attribute(s) ({}) has/have been removed, as GTK does not support it consistently. Instead, use eventbox to wrap this widget and set the attribute there. See #251 (https://github.com/elkowar/eww/issues/251) for more details.", contained_deprecated.iter().join(", ")),
         }).unwrap();
         eprintln!("{}", diag);
     }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -10,7 +10,12 @@ use glib;
 use gtk::{self, prelude::*, ImageExt};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
-use std::{cell::RefCell, collections::{HashMap, HashSet}, rc::Rc, time::Duration};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    rc::Rc,
+    time::Duration,
+};
 use yuck::{
     config::validate::ValidationError,
     error::{AstError, AstResult, AstResultExt},
@@ -50,7 +55,9 @@ pub(super) fn widget_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::Widge
     Ok(gtk_widget)
 }
 
-static DEPRECATED_ATTRS: Lazy<HashSet<&str>> = Lazy::new(|| ["timeout", "onscroll", "onhover", "cursor"].iter().cloned().collect());
+/// Deprecated attributes from top of widget hierarchy
+static DEPRECATED_ATTRS: Lazy<HashSet<&str>> =
+    Lazy::new(|| ["timeout", "onscroll", "onhover", "cursor"].iter().cloned().collect());
 
 /// attributes that apply to all widgets
 /// @widget widget
@@ -59,7 +66,7 @@ pub(super) fn resolve_widget_attrs(bargs: &mut BuilderArgs, gtk_widget: &gtk::Wi
     let widget = bargs.widget;
 
     if DEPRECATED_ATTRS.to_owned().iter().any(|attr| match widget.get_attr(attr).err().map(|e| e.downcast::<AstError>()) {
-        Some(Ok(AstError::ValidationError(ValidationError::MissingAttr {..}))) => false,
+        Some(Ok(AstError::ValidationError(ValidationError::MissingAttr { .. }))) => false,
         _ => true,
     }) {
         let args_set: HashSet<&str> = widget.attrs.keys().map(|attr| &attr.0 as &str).collect();


### PR DESCRIPTION
## Description

Deprecates `:timeout`, `:onscroll`, `:onhover` and `:cursor` from top of widget hierarchy.
Moves these to a new widget `(eventbox ...)`.
Adds `:onhoverlost` property to `(eventbox ...)`.

Fix #250 and fix #251 (see them for more details).

## Usage

```
(eventbox :timeout <timeout>
          :onscroll "<cmd to run on scroll with {} being replaced by up or down>"
          :onhover "<cmd to run on hover with {} being replaced by 'x y' coordinate>"
          :onhoverlost "<cmd to run on hover loss wih {} being replaced by 'x y' coordinate>"
          :cursor "<type of cursor>"
    "Content")
```

### Showcase

https://user-images.githubusercontent.com/26714676/131639040-89781f4e-68af-4079-be2b-0c6ac4ff6d97.mp4

Edit: I should have probably add revealer within the box contained in the eventbox widget, so that hover applies to both revealer and the date here to remain it opened. Ignore it please 😅😅

## Additional Notes

Widget must contain exactly one child (restriction from GTK).

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
