### PR TITLE
I3 dock fix

### DIFF
--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -345,7 +345,7 @@ fn initialize_window(
 
     window.add(&root_widget);
 
-    window.show_all();
+    window.realize();
 
     #[cfg(feature = "x11")]
     {
@@ -358,6 +358,9 @@ fn initialize_window(
         }
         display_backend::set_xprops(&window, monitor_geometry, &window_def)?;
     }
+
+    window.show_all();
+
     Ok(EwwWindow { name: window_def.name.clone(), definition: window_def, gtk_window: window })
 }
 
@@ -371,7 +374,13 @@ fn apply_window_position(
     let gdk_window = window.get_window().context("Failed to get gdk window from gtk window")?;
     window_geometry.size = Coords::from_pixels(window.get_size());
     let actual_window_rect = get_window_rectangle(window_geometry, monitor_geometry);
-    gdk_window.move_(actual_window_rect.x, actual_window_rect.y);
+
+    let gdk_origin = gdk_window.get_origin();
+
+    if actual_window_rect.x != gdk_origin.1 || actual_window_rect.y != gdk_origin.2 {
+        gdk_window.move_(actual_window_rect.x, actual_window_rect.y);
+    }
+
     Ok(())
 }
 

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -274,7 +274,6 @@ impl App {
         // refresh script-var poll stuff
         self.script_var_handler.stop_all();
 
-
         log::trace!("loading config: {:#?}", config);
 
         self.eww_config = config;

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -173,7 +173,7 @@ fn parse_var_update_arg(s: &str) -> Result<(VarName, DynVal)> {
 
 impl ActionWithServer {
     pub fn can_start_daemon(&self) -> bool {
-        matches!(self, ActionWithServer::OpenWindow {..} | ActionWithServer::OpenMany { .. })
+        matches!(self, ActionWithServer::OpenWindow { .. } | ActionWithServer::OpenMany { .. })
     }
 
     pub fn into_daemon_command(self) -> (app::DaemonCommand, Option<daemon_response::DaemonResponseReceiver>) {

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -8,7 +8,7 @@ use gdk::WindowExt;
 use glib;
 use gtk::{self, prelude::*, ImageExt};
 use itertools::Itertools;
-use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration, cmp::Ordering};
+use std::{cell::RefCell, cmp::Ordering, collections::HashMap, rc::Rc, time::Duration};
 use yuck::{
     config::validate::ValidationError,
     error::{AstError, AstResult, AstResultExt},
@@ -41,7 +41,11 @@ pub(super) fn widget_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::Widge
         "revealer" => build_gtk_revealer(bargs)?.upcast(),
         "if-else" => build_if_else(bargs)?.upcast(),
         _ => {
-            return Err(AstError::ValidationError(ValidationError::UnknownWidget(bargs.widget.name_span, bargs.widget.name.to_string())).into())
+            return Err(AstError::ValidationError(ValidationError::UnknownWidget(
+                bargs.widget.name_span,
+                bargs.widget.name.to_string(),
+            ))
+            .into())
         }
     };
     Ok(gtk_widget)
@@ -517,11 +521,18 @@ fn build_center_box(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
             // we know that there is more than three children, so unwrapping on first and left here is fine.
             let first_span = additional_children.first().unwrap().span();
             let last_span = additional_children.last().unwrap().span();
-            Err(DiagError::new(gen_diagnostic!("centerbox must contain exactly 3 elements, but got more", first_span.to(last_span))).into())
+            Err(DiagError::new(gen_diagnostic!(
+                "centerbox must contain exactly 3 elements, but got more",
+                first_span.to(last_span)
+            ))
+            .into())
         }
         Ordering::Equal => {
-            let mut children =
-            bargs.widget.children.iter().map(|child| child.render(bargs.eww_state, bargs.window_name, bargs.widget_definitions));
+            let mut children = bargs
+                .widget
+                .children
+                .iter()
+                .map(|child| child.render(bargs.eww_state, bargs.window_name, bargs.widget_definitions));
             // we know that we have exactly three children here, so we can unwrap here.
             let (first, center, end) = children.next_tuple().unwrap();
             let (first, center, end) = (first?, center?, end?);

--- a/crates/eww/src/widgets/widget_node.rs
+++ b/crates/eww/src/widgets/widget_node.rs
@@ -113,7 +113,7 @@ pub fn generate_generic_widget_node(
 ) -> AstResult<Box<dyn WidgetNode>> {
     if let Some(def) = defs.get(&w.name) {
         if !w.children.is_empty() {
-            return Err(AstError::TooManyNodes(w.children_span(), 0).note("User-defined widgets cannot be given children."))
+            return Err(AstError::TooManyNodes(w.children_span(), 0).note("User-defined widgets cannot be given children."));
         }
 
         let mut new_local_env = w


### PR DESCRIPTION
## Description

Show window only after settings x-props. According to the EWMH spec:
> _NET_WM_WINDOW_TYPE
> This SHOULD be set by the Client before mapping to a list of atoms
> indicating the functional type of the window.

The callback to the configure event handle now checks the window's
current geometry to not move the window if it's already where it's
supposed to be. This prevents the eww daemon from endlessly chatting
with X11 in some instances.

## Additional Notes

Closes #248
Closes #197

## Checklist

- [x] I used `cargo fmt` to automatically format all code before committing