### PR TITLE
Indicate label truncation

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -540,8 +540,15 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
     resolve_block!(bargs, gtk_widget, {
         // @prop text - the text to display
         // @prop limit-width - maximum count of characters to display
-        prop(text: as_string, limit_width: as_i32 = i32::MAX) {
-            let text = text.chars().take(limit_width as usize).collect::<String>();
+        // @prop show_truncated - show whether the text was truncated
+        prop(text: as_string, limit_width: as_i32 = i32::MAX, show_truncated: as_bool = true) {
+            let truncated = text.chars().count() > limit_width as usize;
+            let mut text = text.chars().take(limit_width as usize).collect::<String>();
+
+            if show_truncated && truncated {
+                text.push_str("...");
+            }
+
             let text = unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))?;
             let text = unindent::unindent(&text);
             gtk_widget.set_text(&text);


### PR DESCRIPTION
Closes #257

I am not sure if the documentation is automatically updated when adding new parameters, can someone help me there? Thanks!

## Description

When `:show-truncated` and `:limit-width` are set, indicate label truncation by appending `...` to the displayed text.

## Usage

```lisp
(label :limit-width 20 :show-truncation true "012345678901234567890123456789")
```

### Showcase

![image](https://user-images.githubusercontent.com/6503361/132019849-a7b2ecc0-2dcf-41e4-8ea0-70df9b0e9dd5.png)

## Checklist

- [ ] All widgets I've added are correctly documented.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
