### PR TITLE
fix: correct gt and lt parsing

### DIFF
--- a/crates/simplexpr/src/simplexpr_parser.lalrpop
+++ b/crates/simplexpr/src/simplexpr_parser.lalrpop
@@ -94,8 +94,8 @@ pub Expr: SimplExpr = {
   #[precedence(level="5")] #[assoc(side="left")]
   <l:@L> <le:Expr> "==" <re:Expr> <r:@R> => BinOp(Span(l, r, fid), b(le), Equals,     b(re)),
   <l:@L> <le:Expr> "!=" <re:Expr> <r:@R> => BinOp(Span(l, r, fid), b(le), NotEquals,  b(re)),
-  <l:@L> <le:Expr> "<"  <re:Expr> <r:@R> => BinOp(Span(l, r, fid), b(le), GT,         b(re)),
-  <l:@L> <le:Expr> ">"  <re:Expr> <r:@R> => BinOp(Span(l, r, fid), b(le), LT,         b(re)),
+  <l:@L> <le:Expr> ">"  <re:Expr> <r:@R> => BinOp(Span(l, r, fid), b(le), GT,         b(re)),
+  <l:@L> <le:Expr> "<"  <re:Expr> <r:@R> => BinOp(Span(l, r, fid), b(le), LT,         b(re)),
   <l:@L> <le:Expr> "=~" <re:Expr> <r:@R> => BinOp(Span(l, r, fid), b(le), RegexMatch, b(re)),
 
   #[precedence(level="6")] #[assoc(side="left")]


### PR DESCRIPTION
The parser swapped the meaning of > and <, this pr corrects that.