### PR TITLE
Fix variables to be scoped from literal created/called widgets

### DIFF
--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -268,7 +268,6 @@ impl App {
         // refresh script-var poll stuff
         self.script_var_handler.stop_all();
 
-
         log::trace!("loading config: {:#?}", config);
 
         self.eww_config = config;

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -595,14 +595,12 @@ fn build_gtk_literal(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
                 };
 
                 let widget_node = widget_node_result.context_label(literal_use_span, "Error in the literal used here")?;
-                let child_widget = unsafe {
-                    widget_node.render(std::mem::transmute(eww_state), &window_name, &widget_definitions)
+                let child_widget = widget_node.render(unsafe { std::mem::transmute(eww_state) }, &window_name, &widget_definitions)
                         .map_err(|e| AstError::ErrorContext {
                             label_span: literal_use_span,
                             context: "Error in the literal used here".to_string(),
                             main_err: Box::new(error_handling_ctx::anyhow_err_to_diagnostic(&e).unwrap_or_else(|| gen_diagnostic!(e)))
-                        })?
-                };
+                        })?;
                 gtk_widget.add(&child_widget);
                 child_widget.show();
             }


### PR DESCRIPTION
## Description

Instead of passing empty `EwwState` (which I assume is added by mistake in staging incomplete code), passes the actual state by creating second mutable reference to the EwwState passed (because the `resolve_block` macro used the `bargs` mutably once and the actual mutation only happens after the block runs so it was safe operation to do it).

Closes #267

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing.
