### PR TITLE
Implement optional initial value for pollvars

### DIFF
--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -268,7 +268,6 @@ impl App {
         // refresh script-var poll stuff
         self.script_var_handler.stop_all();
 
-
         log::trace!("loading config: {:#?}", config);
 
         self.eww_config = config;

--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -13,6 +13,7 @@ macro_rules! builtin_vars {
             VarName::from($name) => ScriptVarDefinition::Poll(PollScriptVar {
                 name: VarName::from($name),
                 command: VarSource::Function($fun),
+                initial_value: None,
                 interval: $interval,
                 name_span: eww_shared_util::span::Span::DUMMY,
             })

--- a/crates/yuck/src/config/script_var_definition.rs
+++ b/crates/yuck/src/config/script_var_definition.rs
@@ -56,6 +56,7 @@ pub enum VarSource {
 pub struct PollScriptVar {
     pub name: VarName,
     pub command: VarSource,
+    pub initial_value: Option<DynVal>,
     pub interval: std::time::Duration,
     pub name_span: Span,
 }
@@ -67,6 +68,7 @@ impl FromAstElementContent for PollScriptVar {
         let result: AstResult<_> = try {
             let (name_span, name) = iter.expect_symbol()?;
             let mut attrs = iter.expect_key_values()?;
+            let initial_value = Some(attrs.primitive_optional("initial")?.unwrap_or_else(|| DynVal::from_string(String::new())));
             let interval = attrs.primitive_required::<DynVal, _>("interval")?.as_duration()?;
             let timeout = attrs
                 .primitive_optional::<DynVal, _>("timeout")?
@@ -75,7 +77,13 @@ impl FromAstElementContent for PollScriptVar {
                 .unwrap_or_else(|| std::time::Duration::from_millis(200));
             let (script_span, script) = iter.expect_literal()?;
             iter.expect_done()?;
-            Self { name_span, name: VarName(name), command: VarSource::Shell(script_span, script.to_string()), interval }
+            Self {
+                name_span,
+                name: VarName(name),
+                command: VarSource::Shell(script_span, script.to_string()),
+                initial_value,
+                interval,
+            }
         };
         result.note(r#"Expected format: `(defpoll name :interval "10s" "echo 'a shell script'")`"#)
     }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,7 +1,6 @@
 # Writing your eww configuration
 
 (For a list of all built in widgets (i.e. `box`, `label`, `button`)  see [Widget Documentation](widgets.md))
-
 Eww is configured using its own language called `yuck`.
 using yuck, you declare the structure and content of your widgets, the geometry, position and behavior of any windows,
 as well as any state and data that will be used in your widgets.
@@ -157,6 +156,7 @@ They may also be useful to have buttons within eww change what is shown within y
 ```lisp
 (defpoll time :interval "1s"
               :timeout "0.1s" ; setting timeout is optional
+              :initial "initial-value" ; setting timeout is optional
   `date +%H:%M:%S`)
 ```
 
@@ -168,6 +168,9 @@ and thus are the perfect choice for showing your time, date, as well as other bi
 
 Optionally, you can specify a timeout, after which the provided script will be aborted.
 This helps to avoid accidentally launching thousands of never-ending processes on your system.
+
+You can also specify an initial-value, this should prevent eww from waiting for the result of a give command during startup, thus,
+making the startup time faster.
 
 **Listening variables (`deflisten`)**
 


### PR DESCRIPTION
## Description

This PR adds the functionality described in #241. It implements an optional "initial-value" field for pollvars. 

## Usage

When opening a window, all pollvars are calculated. By using initial-value when defining a pollvar, eww wont have to wait until the result of said pollvar is computed, therefore, making it not block the startup of the window.

An example of this can be found bellow.
```
; This pollvar blocks eww for 10s on startup.
(defpoll date_poll_blocking :interval "1m" "sleep 10 && date +%d/%m/%Y")

; This pollvar displays "initial_date" for 10s, thus, not blocking eww
(defpoll date_poll :initial "initial_date" :interval "1m" "sleep 10 && date +%d/%m/%Y")

; This pollvar gets calculated quick enough so it doesnt have time to display "initial_time"
(defpoll time_poll :initial "initial_time" :interval "1s" "date +%H:%M")
```

This PR shouldnt be a breaking change, as initial-value is an optional field, and, in its absence, the program should behave exacly as it did before.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
