### PR TITLE
Implement trigger for defpoll variable

### DIFF
--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -205,10 +205,10 @@ impl App {
     fn update_state(&mut self, fieldname: VarName, value: DynVal) {
         self.eww_state.update_variable(fieldname.clone(), value);
 
-        if let Some(linked_poll_vars) = self.eww_config.poll_var_trigger.get(&fieldname) {
+        if let Ok(linked_poll_vars) = self.eww_config.get_poll_var_link(&fieldname) {
             linked_poll_vars.iter().filter_map(|name| self.eww_config.get_script_var(name).ok()).for_each(|var| {
                 if let ScriptVarDefinition::Poll(poll_var) = var {
-                    match poll_var.trigger_expr.eval(self.eww_state.get_variables()).map(|v| v.as_bool()) {
+                    match poll_var.run_while_expr.eval(self.eww_state.get_variables()).map(|v| v.as_bool()) {
                         Ok(Ok(true)) => self.script_var_handler.add(var.clone()),
                         Ok(Ok(false)) => self.script_var_handler.stop_for_variable(poll_var.name.clone()),
                         Ok(Err(err)) => error_handling_ctx::print_error(anyhow!(err)),

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -12,7 +12,10 @@ use simplexpr::dynval::DynVal;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc::UnboundedSender;
 use yuck::{
-    config::window_geometry::{AnchorPoint, WindowGeometry},
+    config::{
+        script_var_definition::ScriptVarDefinition,
+        window_geometry::{AnchorPoint, WindowGeometry},
+    },
     value::Coords,
 };
 
@@ -200,7 +203,20 @@ impl App {
     }
 
     fn update_state(&mut self, fieldname: VarName, value: DynVal) {
-        self.eww_state.update_variable(fieldname, value)
+        self.eww_state.update_variable(fieldname.clone(), value);
+
+        if let Some(linked_poll_vars) = self.eww_config.poll_var_trigger.get(&fieldname) {
+            linked_poll_vars.iter().filter_map(|name| self.eww_config.get_script_var(name).ok()).for_each(|var| {
+                if let ScriptVarDefinition::Poll(poll_var) = var {
+                    match poll_var.trigger_expr.eval(self.eww_state.get_variables()).map(|v| v.as_bool()) {
+                        Ok(Ok(true)) => self.script_var_handler.add(var.clone()),
+                        Ok(Ok(false)) => self.script_var_handler.stop_for_variable(poll_var.name.clone()),
+                        Ok(Err(err)) => error_handling_ctx::print_error(anyhow!(err)),
+                        Err(err) => error_handling_ctx::print_error(anyhow!(err)),
+                    };
+                }
+            });
+        }
     }
 
     fn close_window(&mut self, window_name: &String) -> Result<()> {

--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -12,8 +12,8 @@ macro_rules! builtin_vars {
             $(
             VarName::from($name) => ScriptVarDefinition::Poll(PollScriptVar {
                 name: VarName::from($name),
-                trigger_expr: SimplExpr::Literal(DynVal::from(true)),
-                trigger_var_refs: Vec::new(),
+                run_while_expr: SimplExpr::Literal(DynVal::from(true)),
+                run_while_var_refs: Vec::new(),
                 command: VarSource::Function($fun),
                 initial_value: None,
                 interval: $interval,

--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, time::Duration};
 
-use simplexpr::dynval::DynVal;
+use simplexpr::{dynval::DynVal, SimplExpr};
 use yuck::config::script_var_definition::{PollScriptVar, ScriptVarDefinition, VarSource};
 
 use crate::config::system_stats::*;
@@ -12,6 +12,8 @@ macro_rules! builtin_vars {
             $(
             VarName::from($name) => ScriptVarDefinition::Poll(PollScriptVar {
                 name: VarName::from($name),
+                trigger_expr: SimplExpr::Literal(DynVal::from(true)),
+                trigger_var_refs: Vec::new(),
                 command: VarSource::Function($fun),
                 initial_value: None,
                 interval: $interval,

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -173,7 +173,7 @@ fn parse_var_update_arg(s: &str) -> Result<(VarName, DynVal)> {
 
 impl ActionWithServer {
     pub fn can_start_daemon(&self) -> bool {
-        matches!(self, ActionWithServer::OpenWindow {..} | ActionWithServer::OpenMany { .. })
+        matches!(self, ActionWithServer::OpenWindow { .. } | ActionWithServer::OpenMany { .. })
     }
 
     pub fn into_daemon_command(self) -> (app::DaemonCommand, Option<daemon_response::DaemonResponseReceiver>) {

--- a/crates/eww/src/script_var_handler.rs
+++ b/crates/eww/src/script_var_handler.rs
@@ -134,6 +134,10 @@ impl PollVarHandler {
     }
 
     async fn start(&mut self, var: PollScriptVar) {
+        if self.poll_handles.contains_key(&var.name) {
+            return;
+        }
+
         log::debug!("starting poll var {}", &var.name);
         let cancellation_token = CancellationToken::new();
         self.poll_handles.insert(var.name.clone(), cancellation_token.clone());

--- a/crates/eww/src/util.rs
+++ b/crates/eww/src/util.rs
@@ -116,7 +116,6 @@ pub fn parse_scss_from_file(path: &Path) -> Result<String> {
     grass::from_string(file_content, &grass_config).map_err(|err| anyhow!("Encountered SCSS parsing error: {:?}", err))
 }
 
-
 #[ext(pub, name = StringExt)]
 impl<T: AsRef<str>> T {
     /// check if the string is empty after removing all linebreaks and trimming

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -8,7 +8,7 @@ use gdk::WindowExt;
 use glib;
 use gtk::{self, prelude::*, ImageExt};
 use itertools::Itertools;
-use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration, cmp::Ordering};
+use std::{cell::RefCell, cmp::Ordering, collections::HashMap, rc::Rc, time::Duration};
 use yuck::{
     config::validate::ValidationError,
     error::{AstError, AstResult, AstResultExt},
@@ -41,7 +41,11 @@ pub(super) fn widget_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::Widge
         "revealer" => build_gtk_revealer(bargs)?.upcast(),
         "if-else" => build_if_else(bargs)?.upcast(),
         _ => {
-            return Err(AstError::ValidationError(ValidationError::UnknownWidget(bargs.widget.name_span, bargs.widget.name.to_string())).into())
+            return Err(AstError::ValidationError(ValidationError::UnknownWidget(
+                bargs.widget.name_span,
+                bargs.widget.name.to_string(),
+            ))
+            .into())
         }
     };
     Ok(gtk_widget)
@@ -517,11 +521,18 @@ fn build_center_box(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
             // we know that there is more than three children, so unwrapping on first and left here is fine.
             let first_span = additional_children.first().unwrap().span();
             let last_span = additional_children.last().unwrap().span();
-            Err(DiagError::new(gen_diagnostic!("centerbox must contain exactly 3 elements, but got more", first_span.to(last_span))).into())
+            Err(DiagError::new(gen_diagnostic!(
+                "centerbox must contain exactly 3 elements, but got more",
+                first_span.to(last_span)
+            ))
+            .into())
         }
         Ordering::Equal => {
-            let mut children =
-            bargs.widget.children.iter().map(|child| child.render(bargs.eww_state, bargs.window_name, bargs.widget_definitions));
+            let mut children = bargs
+                .widget
+                .children
+                .iter()
+                .map(|child| child.render(bargs.eww_state, bargs.window_name, bargs.widget_definitions));
             // we know that we have exactly three children here, so we can unwrap here.
             let (first, center, end) = children.next_tuple().unwrap();
             let (first, center, end) = (first?, center?, end?);

--- a/crates/eww/src/widgets/widget_node.rs
+++ b/crates/eww/src/widgets/widget_node.rs
@@ -113,7 +113,7 @@ pub fn generate_generic_widget_node(
 ) -> AstResult<Box<dyn WidgetNode>> {
     if let Some(def) = defs.get(&w.name) {
         if !w.children.is_empty() {
-            return Err(AstError::TooManyNodes(w.children_span(), 0).note("User-defined widgets cannot be given children."))
+            return Err(AstError::TooManyNodes(w.children_span(), 0).note("User-defined widgets cannot be given children."));
         }
 
         let mut new_local_env = w

--- a/crates/simplexpr/src/ast.rs
+++ b/crates/simplexpr/src/ast.rs
@@ -86,6 +86,39 @@ impl SimplExpr {
     pub fn synth_literal<T: Into<DynVal>>(s: T) -> Self {
         Self::Literal(s.into())
     }
+
+    pub fn dfs_collect_var_refs_into(&self, dest: &mut Vec<VarName>) {
+        match self {
+            SimplExpr::VarRef(_, x) => dest.push(x.clone()),
+            SimplExpr::UnaryOp(_, _, x) => x.as_ref().dfs_collect_var_refs_into(dest),
+            SimplExpr::BinOp(_, l, _, r) => {
+                l.as_ref().dfs_collect_var_refs_into(dest);
+                r.as_ref().dfs_collect_var_refs_into(dest);
+            }
+            SimplExpr::IfElse(_, a, b, c) => {
+                a.as_ref().dfs_collect_var_refs_into(dest);
+                b.as_ref().dfs_collect_var_refs_into(dest);
+                c.as_ref().dfs_collect_var_refs_into(dest);
+            }
+            SimplExpr::JsonAccess(_, value, index) => {
+                value.as_ref().dfs_collect_var_refs_into(dest);
+                index.as_ref().dfs_collect_var_refs_into(dest);
+            }
+            SimplExpr::FunctionCall(_, _, args) => args.iter().for_each(|x: &SimplExpr| x.dfs_collect_var_refs_into(dest)),
+            SimplExpr::JsonArray(_, values) => values.iter().for_each(|v| v.dfs_collect_var_refs_into(dest)),
+            SimplExpr::JsonObject(_, entries) => entries.iter().for_each(|(k, v)| {
+                k.dfs_collect_var_refs_into(dest);
+                v.dfs_collect_var_refs_into(dest);
+            }),
+            _ => (),
+        };
+    }
+
+    pub fn dfs_collect_var_refs(&self) -> Vec<VarName> {
+        let mut dest = Vec::new();
+        self.dfs_collect_var_refs_into(&mut dest);
+        dest
+    }
 }
 
 impl Spanned for SimplExpr {

--- a/crates/simplexpr/src/ast.rs
+++ b/crates/simplexpr/src/ast.rs
@@ -87,36 +87,36 @@ impl SimplExpr {
         Self::Literal(s.into())
     }
 
-    pub fn dfs_collect_var_refs_into(&self, dest: &mut Vec<VarName>) {
+    pub fn collect_var_refs_into(&self, dest: &mut Vec<VarName>) {
         match self {
             SimplExpr::VarRef(_, x) => dest.push(x.clone()),
-            SimplExpr::UnaryOp(_, _, x) => x.as_ref().dfs_collect_var_refs_into(dest),
+            SimplExpr::UnaryOp(_, _, x) => x.as_ref().collect_var_refs_into(dest),
             SimplExpr::BinOp(_, l, _, r) => {
-                l.as_ref().dfs_collect_var_refs_into(dest);
-                r.as_ref().dfs_collect_var_refs_into(dest);
+                l.as_ref().collect_var_refs_into(dest);
+                r.as_ref().collect_var_refs_into(dest);
             }
             SimplExpr::IfElse(_, a, b, c) => {
-                a.as_ref().dfs_collect_var_refs_into(dest);
-                b.as_ref().dfs_collect_var_refs_into(dest);
-                c.as_ref().dfs_collect_var_refs_into(dest);
+                a.as_ref().collect_var_refs_into(dest);
+                b.as_ref().collect_var_refs_into(dest);
+                c.as_ref().collect_var_refs_into(dest);
             }
             SimplExpr::JsonAccess(_, value, index) => {
-                value.as_ref().dfs_collect_var_refs_into(dest);
-                index.as_ref().dfs_collect_var_refs_into(dest);
+                value.as_ref().collect_var_refs_into(dest);
+                index.as_ref().collect_var_refs_into(dest);
             }
-            SimplExpr::FunctionCall(_, _, args) => args.iter().for_each(|x: &SimplExpr| x.dfs_collect_var_refs_into(dest)),
-            SimplExpr::JsonArray(_, values) => values.iter().for_each(|v| v.dfs_collect_var_refs_into(dest)),
+            SimplExpr::FunctionCall(_, _, args) => args.iter().for_each(|x: &SimplExpr| x.collect_var_refs_into(dest)),
+            SimplExpr::JsonArray(_, values) => values.iter().for_each(|v| v.collect_var_refs_into(dest)),
             SimplExpr::JsonObject(_, entries) => entries.iter().for_each(|(k, v)| {
-                k.dfs_collect_var_refs_into(dest);
-                v.dfs_collect_var_refs_into(dest);
+                k.collect_var_refs_into(dest);
+                v.collect_var_refs_into(dest);
             }),
             _ => (),
         };
     }
 
-    pub fn dfs_collect_var_refs(&self) -> Vec<VarName> {
+    pub fn collect_var_refs(&self) -> Vec<VarName> {
         let mut dest = Vec::new();
-        self.dfs_collect_var_refs_into(&mut dest);
+        self.collect_var_refs_into(&mut dest);
         dest
     }
 }

--- a/crates/yuck/src/config/script_var_definition.rs
+++ b/crates/yuck/src/config/script_var_definition.rs
@@ -55,6 +55,8 @@ pub enum VarSource {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 pub struct PollScriptVar {
     pub name: VarName,
+    pub trigger_expr: SimplExpr,
+    pub trigger_var_refs: Vec<VarName>,
     pub command: VarSource,
     pub initial_value: Option<DynVal>,
     pub interval: std::time::Duration,
@@ -71,10 +73,17 @@ impl FromAstElementContent for PollScriptVar {
             let initial_value = Some(attrs.primitive_optional("initial")?.unwrap_or_else(|| DynVal::from_string(String::new())));
             let interval = attrs.primitive_required::<DynVal, _>("interval")?.as_duration()?;
             let (script_span, script) = iter.expect_literal()?;
+
+            let trigger_expr =
+                attrs.ast_optional::<SimplExpr>("trigger")?.unwrap_or_else(|| SimplExpr::Literal(DynVal::from(true)));
+            let trigger_var_refs = trigger_expr.dfs_collect_var_refs();
+
             iter.expect_done()?;
             Self {
                 name_span,
                 name: VarName(name),
+                trigger_expr,
+                trigger_var_refs,
                 command: VarSource::Shell(script_span, script.to_string()),
                 initial_value,
                 interval,

--- a/crates/yuck/src/config/script_var_definition.rs
+++ b/crates/yuck/src/config/script_var_definition.rs
@@ -55,8 +55,8 @@ pub enum VarSource {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 pub struct PollScriptVar {
     pub name: VarName,
-    pub trigger_expr: SimplExpr,
-    pub trigger_var_refs: Vec<VarName>,
+    pub run_while_expr: SimplExpr,
+    pub run_while_var_refs: Vec<VarName>,
     pub command: VarSource,
     pub initial_value: Option<DynVal>,
     pub interval: std::time::Duration,
@@ -74,16 +74,16 @@ impl FromAstElementContent for PollScriptVar {
             let interval = attrs.primitive_required::<DynVal, _>("interval")?.as_duration()?;
             let (script_span, script) = iter.expect_literal()?;
 
-            let trigger_expr =
-                attrs.ast_optional::<SimplExpr>("trigger")?.unwrap_or_else(|| SimplExpr::Literal(DynVal::from(true)));
-            let trigger_var_refs = trigger_expr.dfs_collect_var_refs();
+            let run_while_expr =
+                attrs.ast_optional::<SimplExpr>("run-while")?.unwrap_or_else(|| SimplExpr::Literal(DynVal::from(true)));
+            let run_while_var_refs = run_while_expr.collect_var_refs();
 
             iter.expect_done()?;
             Self {
                 name_span,
                 name: VarName(name),
-                trigger_expr,
-                trigger_var_refs,
+                run_while_expr,
+                run_while_var_refs,
                 command: VarSource::Shell(script_span, script.to_string()),
                 initial_value,
                 interval,

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -154,8 +154,13 @@ They may also be useful to have buttons within eww change what is shown within y
 **Polling variables (`defpoll`)**
 
 ```lisp
+(defvar time-visible false)   ; for :run-while property of below variable
+                              ; when this turns true, the polling starts and
+                              ; var gets updated with given interval
+
 (defpoll time :interval "1s"
-              :initial "initial-value" ; setting initial is optional
+              :initial "initial-value"  ; optional, defaults to poll at startup
+              :run-while time-visible   ; optional, defaults to 'true'
   `date +%H:%M:%S`)
 ```
 
@@ -163,7 +168,7 @@ A polling variable is a variable which runs a provided shell-script repeatedly, 
 
 This may be the most commonly used type of variable.
 They are useful to access any quickly retrieved value repeatedly,
-and thus are the perfect choice for showing your time, date, as well as other bits of information such as your volume.
+and thus are the perfect choice for showing your time, date, as well as other bits of information such as pending package updates, weather and battery-level.
 
 You can also specify an initial-value, this should prevent eww from waiting for the result of a give command during startup, thus,
 making the startup time faster.
@@ -180,9 +185,12 @@ A listening variable runs a script once, and reads its output continously.
 Whenever the script outputs a new line, the value will be updated to that new line.
 In the example given above, the value of `foo` will start out as `"whatever"`, and will change whenever a new line is appended to `/tmp/some_file`.
 
-These are particularly useful if you have a script that can monitor some value on its own.
+These are particularly useful when you want to apply changes instantaneously when an operation happens if you have a script
+that can monitor some value on its own. Volume, brighness, workspaces that get added/removed at runtime,
+monitoring currently focused desktop/tag, etc. are the most common usecases of this type of variable.
+These are particularly efficient and should be preffered if possible.
+
 For example, the command `xprop -spy -root _NET_CURRENT_DESKTOP` writes the currently focused desktop whenever it changes.
-This can be used to implement a workspace widget for a bar, for example.
 Another example usecase is monitoring the currently playing song with playerctl: `playerctl --follow metadata --format {{title}}`.
 
 **Built-in "magic" variables**


### PR DESCRIPTION
## Description

Adds trigger property to `(devpoll` variable, so that polling may stop when required and start at any instant with subsequent interval given.

Close #271

## Usage

```yuck
(defpoll :trigger <s-expr>
         :interval "0.2s"
         :initial "Initial value"
         `cmd`)
```

### Showcase

Sample widget controlled to be polled by another variable.

https://user-images.githubusercontent.com/26714676/132949323-24d69090-beb4-46ca-8505-e39a9865a101.mp4

## Additional Notes
\-

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
