### PR TITLE
Updated Shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,31 +1,32 @@
-{ pkgs ? import <nixpkgs> {
-    overlays = [
-      (import (fetchTarball
-      "https://github.com/nix-community/fenix/archive/main.tar.gz"))
-      (self: super: {
-          rustc = super.fenix.latest.rustc;
-          cargo  = super.fenix.latest.cargo;
-          rust-src = super.fenix.latest.rust-src;
-      }
-        )
-    ];
-  }
-}:
+{npkgs ? import <nixpkgs> {}}:
 
-pkgs.mkShell {
-  packages = with pkgs; [
-    rustc
-    cargo
-    rust-analyzer
-    gcc
-    gtk3
-    pkg-config
-    rustfmt-preview
-    clippy-preview
-    deno
-    mdbook
-  ];
+let
+    fenix = import
+      (fetchTarball "https://github.com/nix-community/fenix/archive/main.tar.gz")
+      { };
+in
+  let
+    rustc = fenix.latest.rustc;
+    cargo  = fenix.latest.cargo;
+    rust-src = fenix.latest.rust-src;
+    rustfmt-preview = fenix.latest.rustfmt-preview;
+    clippy-preview = fenix.latest.clippy-preview;
+  in
 
 
-  RUST_SRC_PATH = "${pkgs.rust-src}/lib/rustlib/src/rust/library";
-}
+    npkgs.mkShell {
+      packages = [
+          rustc
+          cargo
+          npkgs.rust-analyzer
+          npkgs.gcc
+          npkgs.gtk3
+          rust-src
+          npkgs.pkg-config
+          rustfmt-preview
+          clippy-preview
+          npkgs.deno
+          npkgs.mdbook
+        ];
+      RUST_SRC_PATH = "${rust-src}/lib/rustlib/src/rust/library";
+    }


### PR DESCRIPTION
Bug corretion: error: infinite recursion encountered, at undefined position

Please follow this template, if applicable.

## Description

Wen trying to build on nixos the nix shell doesn't work, the problem is the shell.nix file that on nix 2.3 create an error of infinite recursion, this pull request repair the issue reformating the shell.nix file

## Usage

install nix package manager or nixos then clone the repo and for be able to build the project use the nix-shell command, there you will have the shell with the needed sources for the build

### Showcase



## Additional Notes

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
