### PR TITLE
Exclude duplicates of widget property in docs

### DIFF
--- a/gen-docs.ts
+++ b/gen-docs.ts
@@ -108,13 +108,16 @@ function parseDocs(code: string) {
             if (possibleMatch == -1) {
                 console.log(`Failed to find a match for "${propMatch[1].replace("-", "_")}" ~ ${JSON.stringify(matches, null, 2)} ~ ${lines[no]}`)
             }
-            const type = replaceTypeNames(matches[possibleMatch + 1])
 
-            widgets[currentWidget].props.push({
-                name: propMatch[1],
-                desc: propMatch[2],
-                type: type ?? "no-type-found"
-            });
+            if (!widgets[currentWidget].props.some(p => p.name == propMatch[1])) {
+                const type = replaceTypeNames(matches[possibleMatch + 1])
+
+                widgets[currentWidget].props.push({
+                    name: propMatch[1],
+                    desc: propMatch[2],
+                    type: type ?? "no-type-found"
+                });
+            }
         }
     }
     return widgets;


### PR DESCRIPTION
## Description

When same property is used multiple times in the [widget_definition.rs](https://github.com/elkowar/eww/blob/master/crates/eww/src/widgets/widget_definitions.rs) and annotated with `@prop` for giving description, the docs generated writes it multiple times.

Previously the `timeout` was shown twice, now by addition of `onhoverlost` using the same property (timeout) again, it is shown thrice 😂. This simply exclude duplicate property by same name in the docs.