### PR TITLE
Fix onscroll direction issue

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -538,7 +538,10 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
             gtk_widget.add_events(gdk::EventMask::SMOOTH_SCROLL_MASK);
             let old_id = on_scroll_handler_id.replace(Some(
                 gtk_widget.connect_scroll_event(move |_, evt| {
-                    run_command(timeout, &onscroll, if evt.delta().1 < 0f64 { "up" } else { "down" });
+                    let delta = evt.delta().1;
+                    if delta != 0f64 { // Ignore the first event https://bugzilla.gnome.org/show_bug.cgi?id=675959
+                        run_command(timeout, &onscroll, if delta < 0f64 { "up" } else { "down" });
+                    }
                     gtk::Inhibit(false)
                 })
             ));


### PR DESCRIPTION
## Description

This PR fixes the issue detailed in #278. 
It does so by ignoring the first onscroll event which has no direction.   
https://bugzilla.gnome.org/show_bug.cgi?id=675959

## Additional Notes

This shouldnt be a breaking change, because when ignoring said event no command is called at all.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
