### PR TITLE
Wayland support in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,10 @@
 
         eww-wayland = naersk-lib.buildPackage {
           pname = "eww";
+          buildInputs = with pkgs; [ gtk-layer-shell ];
           nativeBuildInputs = with pkgs; [ pkg-config gtk3 ];
-          cargoBuildOptions = opts: opts ++ ["--no-default-features" "--features=wayland"];
+          cargoBuildOptions = opts:
+            opts ++ [ "--no-default-features" "--features=wayland" ];
           root = ./.;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
         eww-wayland = naersk-lib.buildPackage {
           pname = "eww";
           nativeBuildInputs = with pkgs; [ pkg-config gtk3 ];
-          cargoBuildOptions = opts: opts ++ ["--no-default-features" "--feature=wayland"]
+          cargoBuildOptions = opts: opts ++ ["--no-default-features" "--feature=wayland"];
           root = ./.;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,15 +29,26 @@
           root = ./.;
         };
 
+        eww-wayland = naersk-lib.buildPackage {
+          pname = "eww";
+          nativeBuildInputs = with pkgs; [ pkg-config gtk3 ];
+          cargoBuildOptions = opts: opts ++ ["--no-default-features" "--feature=wayland"]
+          root = ./.;
+        };
+
 
       in
       rec {
         packages.eww = eww;
+        packages.eww-wayland = eww-wayland;
 
         defaultPackage = eww;
 
         apps.eww = flake-utils.lib.mkApp {
           drv = eww;
+        };
+        apps.eww-wayland = flake-utils.lib.mkApp {
+          drv = eww-wayland;
         };
         defaultApp = apps.eww;
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
         eww-wayland = naersk-lib.buildPackage {
           pname = "eww";
           nativeBuildInputs = with pkgs; [ pkg-config gtk3 ];
-          cargoBuildOptions = opts: opts ++ ["--no-default-features" "--feature=wayland"];
+          cargoBuildOptions = opts: opts ++ ["--no-default-features" "--features=wayland"];
           root = ./.;
         };
 


### PR DESCRIPTION
## Description

Provide a short description of the changes your PR introduces.
This includes the actual feature you are adding,
as well as any other relevant additions that were necessary to implement your feature.

This pull request adds a second package to `flake.nix` with Wayland support.

## Usage

When adding a widget or anything else that affects the configuration,
please provide a minimal example configuration snippet showcasing how to use it and

It will be possible to get a wayland enabled `eww` via `nix build github:elkowar/eww#eww-wayland`, just as it is possible to get an X11 enabled version via `nix build github:elkowar/eww`. 
