### PR TITLE
fix: eww passes x11 and wayland features down to yuck

### DIFF
--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -11,8 +11,8 @@ homepage = "https://github.com/elkowar/eww"
 
 [features]
 default = ["x11"]
-x11 = ["gdkx11", "x11rb"]
-wayland = ["gtk-layer-shell", "gtk-layer-shell-sys"]
+x11 = ["gdkx11", "x11rb", "yuck/x11"]
+wayland = ["gtk-layer-shell", "gtk-layer-shell-sys", "yuck/wayland"]
 [dependencies.cairo-sys-rs]
 version = "0.14.0"
 


### PR DESCRIPTION
Please follow this template, if applicable.

## Description

<!-- Provide a short description of the changes your PR introduces.
This includes the actual feature you are adding,
as well as any other relevant additions that were necessary to implement your feature. -->

Fixes #305. Allows to `cargo check` specifically only `eww` package.

## Additional Notes

There was a PR #289 to solve #305, but it was ignored for lack of the issue it fixes.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
