### PR TITLE
fix: make shell.nix use flake.nix through flake-compat

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1630895391,
-        "narHash": "sha256-yokHZl7RvKfvmAmouI0Zr5x4SKhYvukRcU8XzRk7yf0=",
+        "lastModified": 1635402244,
+        "narHash": "sha256-4bUSYJDRxAo66UpNkFmEMRIWMdDXBEnq8GB/rG++Y3A=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "3893e32c15e2ba4999510de67023a31d6f0e8b6e",
+        "rev": "840f96d1f3257d64c04fe949dfc9c0b4795c04c1",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1629707199,
-        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "lastModified": 1635444951,
+        "narHash": "sha256-1y3YkERwoYDIZjGow7HLAR8K3C/9VBPCBy8VpftMPsM=",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "df71f5e4babda41cd919a8684b72218e2e809fa9",
+        "rev": "0d2ce479df4633dbeb53a8ea96e5098ed37fbcc6",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1630761588,
-        "narHash": "sha256-7GXckvZy7DGh2KIyfdArqwnyeSc5Owy1fumEDQyd8eY=",
-        "path": "/nix/store/8i2kd1ndvx8adgid7vf4szhxsh1f9pkm-source",
-        "rev": "a51aa6523bd8ee985bc70987909eff235900197a",
-        "type": "path"
+        "lastModified": 1635481254,
+        "narHash": "sha256-tyVpgjeNhzCP2bBdIgFOkTtwDJWO/bKp59V5ctfonyg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f1d9248eddad2369fca6572470670ec45aa85272",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",
@@ -85,11 +86,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1630140382,
-        "narHash": "sha256-ntXepAHFlAEtaYIU5EzckRUODeeMgpu1u2Yug+4LFNc=",
+        "lastModified": 1635336330,
+        "narHash": "sha256-EPrCZTmuOEY1KLjUCu7rXCBxNemggIFJMDdfEqXQKGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08ef0f28e3a41424b92ba1d203de64257a9fca6a",
+        "rev": "51acb65b302551ac7993b437cc6863fe9fa8ae50",
         "type": "github"
       },
       "original": {
@@ -110,11 +111,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1630870637,
-        "narHash": "sha256-TacpTVvHAIs4kZ5vibj8luy/kryYwxY+OXFNPnqiXP0=",
+        "lastModified": 1635274542,
+        "narHash": "sha256-Cew1/WUozM3jalItPuj4cNN8GIFMvCaJ1KXoj6wrHwE=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "b73b321478d3b2a98d380eb79de717e01620c4e9",
+        "rev": "dd43f3f2d13a32199828e758ddf13176df1f17f9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,21 @@
         apps.eww-wayland = flake-utils.lib.mkApp { drv = packages.eww-wayland; };
         defaultApp = apps.eww;
 
-        devShell = import ./shell.nix { inherit pkgs; };
+        devShell = pkgs.mkShell {
+          packages = with pkgs; [
+            rustc
+            cargo
+            rust-analyzer
+            gcc
+            gtk3
+            gtk-layer-shell
+            pkg-config
+            rustfmt-preview
+            clippy-preview
+            deno
+            mdbook
+          ];
+          RUST_SRC_PATH = "${pkgs.rust-src}/lib/rustlib/src/rust/library";
+        };
       });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,31 +1,9 @@
-{ pkgs ? import <nixpkgs> {
-    overlays = [
-      (import (fetchTarball
-      "https://github.com/nix-community/fenix/archive/main.tar.gz"))
-      (self: super: {
-          rustc = super.fenix.latest.rustc;
-          cargo  = super.fenix.latest.cargo;
-          rust-src = super.fenix.latest.rust-src;
-      }
-        )
-    ];
-  }
-}:
-
-pkgs.mkShell {
-  packages = with pkgs; [
-    rustc
-    cargo
-    rust-analyzer
-    gcc
-    gtk3
-    pkg-config
-    rustfmt-preview
-    clippy-preview
-    deno
-    mdbook
-  ];
-
-
-  RUST_SRC_PATH = "${pkgs.rust-src}/lib/rustlib/src/rust/library";
-}
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
The previous `shell.nix` would fail with an error if it was loaded using nix-shell:
```
<hexagon:~/prog/misc/eww>% nix-shell
error: infinite recursion encountered

       at /nix/store/dqwxj68v872a26czhmccm10iy7cvj2s4-nixos-21.11pre321003.14aef06d9b3/nixos/lib/fixed-points.nix:69:67:

           68|   #
           69|   extends = f: rattrs: self: let super = rattrs self; in super // f self super;
             |                                                                   ^
           70|
```
This fixes that error by making `shell.nix` use [flake-compat](https://github.com/edolstra/flake-compat), and having `flake.nix` be the single source of truth - it contains all necessary packages. This PR also updates `flake.lock` (through `nix flake update`), because the previous `flake.lock` caused a different error on my system when I ran `nix-build`:

```
<hexagon:~/prog/misc/eww>% nix-build
error (ignored): error: bad archive: input doesn't look like a Nix archive
error: getting status of '/nix/store/8i2kd1ndvx8adgid7vf4szhxsh1f9pkm-source': No such file or directory
(use '--show-trace' to show detailed location information)
```

This PR works with both flake- and non-flake- enabled systems. Tested with (non-flake) `nix-build`, `nix-shell`, as well as (flake) `nix develop` and `nix run`.