### PR TITLE
Circular progress widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "a83b21d2aa75e464db56225e1bda2dd5993311ba1095acaa8fa03d1ae67026ba"
 dependencies = [
  "atk-sys",
  "bitflags",
- "glib 0.14.4",
+ "glib 0.14.8",
  "libc",
 ]
 
@@ -152,7 +152,7 @@ checksum = "f859ade407c19810ae920b4fafab92189ed312adad490d08fb16b5f49f1e2207"
 dependencies = [
  "bitflags",
  "cairo-sys-rs",
- "glib 0.14.4",
+ "glib 0.14.8",
  "libc",
  "thiserror",
 ]
@@ -428,7 +428,7 @@ dependencies = [
  "gdk-pixbuf 0.9.0",
  "gdkx11",
  "gio 0.9.1",
- "glib 0.10.3",
+ "glib 0.14.8",
  "grass",
  "gtk",
  "gtk-layer-shell",
@@ -620,7 +620,7 @@ dependencies = [
  "gdk-pixbuf 0.14.0",
  "gdk-sys",
  "gio 0.14.3",
- "glib 0.14.4",
+ "glib 0.14.8",
  "libc",
  "pango",
 ]
@@ -648,7 +648,7 @@ checksum = "534192cb8f01daeb8fab2c8d4baa8f9aae5b7a39130525779f5c2608e235b10f"
 dependencies = [
  "gdk-pixbuf-sys 0.14.0",
  "gio 0.14.3",
- "glib 0.14.4",
+ "glib 0.14.8",
  "libc",
 ]
 
@@ -704,7 +704,7 @@ dependencies = [
  "gdk",
  "gdkx11-sys",
  "gio 0.14.3",
- "glib 0.14.4",
+ "glib 0.14.8",
  "libc",
  "x11",
 ]
@@ -775,7 +775,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "gio-sys 0.14.0",
- "glib 0.14.4",
+ "glib 0.14.8",
  "libc",
  "once_cell",
  "thiserror",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.14.4"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fb802e3798d75b415bea8f016eed88d50106ce82f1274e80f31d80cfd4b056"
+checksum = "7c515f1e62bf151ef6635f528d05b02c11506de986e43b34a5c920ef0b3796a4"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -951,7 +951,7 @@ dependencies = [
  "gdk",
  "gdk-pixbuf 0.14.0",
  "gio 0.14.3",
- "glib 0.14.4",
+ "glib 0.14.8",
  "gtk-sys",
  "gtk3-macros",
  "libc",
@@ -968,7 +968,7 @@ checksum = "4a106f40f47bf7eb2d0d62313b82e8cb9829c4c6ab4a1087c72c95ae6ed03726"
 dependencies = [
  "bitflags",
  "gdk",
- "glib 0.14.4",
+ "glib 0.14.8",
  "glib-sys 0.14.0",
  "gtk",
  "gtk-layer-shell-sys",
@@ -1402,7 +1402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc88307d9797976ea62722ff2ec5de3fae279c6e20100ed3f49ca1a4bf3f96"
 dependencies = [
  "bitflags",
- "glib 0.14.4",
+ "glib 0.14.8",
  "libc",
  "once_cell",
  "pango-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bincode",
+ "cairo-rs",
  "cairo-sys-rs",
  "codespan-reporting",
  "debug_stub_derive",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Additionally, a couple _amazing_ people have started to work on an
 ![Example 1](./examples/eww-bar/eww-bar.png)
 
 * [Some setups by Druskus20](https://github.com/druskus20/eugh)
-![Druskus20-bar](https://github.com/druskus20/eugh/raw/master/polybar-replacement/preview.png)
+![Druskus20-bar](https://raw.githubusercontent.com/druskus20/eugh/master/polybar-replacement/.github/preview.png)
 
 * [My own vertical bar](https://github.com/elkowar/dots-of-war/tree/master/eww-bar/.config/eww-bar)
 

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -22,6 +22,8 @@ gdk = { version = "*", features = ["v3_22"] }
 gio = { version = "*", features = ["v2_44"] }
 glib = { version = "*", features = ["v2_44"] }
 
+cairo-rs = "0.9"
+
 gdk-pixbuf = "0.9"
 
 gtk-layer-shell = { version="0.2.0", optional=true }

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.14.0"
 gtk = { version = "0.14", features = [ "v3_22" ] }
 gdk = { version = "*", features = ["v3_22"] }
 gio = { version = "*", features = ["v2_44"] }
-glib = { version = "*", features = ["v2_44"] }
+glib = { version = "0.14.8"}
 
-cairo-rs = "0.9"
+cairo-rs = "0.14.0"
 
 gdk-pixbuf = "0.9"
 

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -67,10 +67,11 @@ impl ObjectImpl for CircProgPriv {
     //        self.parent_constructed(obj);
     //    }
 
-    fn set_property(&self, _obj: &Self::Type, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+    fn set_property(&self, obj: &Self::Type, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
         match pspec.name() {
             "value" => {
                 self.value.replace(value.get().unwrap());
+                obj.queue_draw(); // Queue a draw call with the updated value
             }
             "thickness" => {
                 self.thickness.replace(value.get().unwrap());

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -19,13 +19,17 @@ glib_wrapper! {
 pub struct CircProgPriv {
     start_angle: RefCell<f32>,
     value: RefCell<f32>,
+    thickness: RefCell<f32>,
 
     content: RefCell<Option<gtk::Widget>>,
 }
 
-static PROPERTIES: [subclass::Property; 2] = [
+static PROPERTIES: [subclass::Property; 3] = [
     subclass::Property("value", |v| {
         glib::ParamSpec::float(v, "Value", "The value", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE)
+    }),
+    subclass::Property("thickness", |v| {
+        glib::ParamSpec::float(v, "Thickness", "Thickness", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE)
     }),
     subclass::Property("start-angle", |v| {
         glib::ParamSpec::float(v, "Starting angle", "Starting angle", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE)
@@ -46,6 +50,9 @@ impl ObjectImpl for CircProgPriv {
             "value" => {
                 self.value.replace(value.get_some().unwrap());
             }
+            "thickness" => {
+                self.thickness.replace(value.get_some().unwrap());
+            }
             "start-angle" => {
                 self.start_angle.replace(value.get_some().unwrap());
             }
@@ -58,6 +65,7 @@ impl ObjectImpl for CircProgPriv {
         match prop.0 {
             "value" => Ok(self.value.borrow().to_value()),
             "start-angle" => Ok(self.start_angle.borrow().to_value()),
+            "thickness" => Ok(self.thickness.borrow().to_value()),
             x => panic!("Tried to access inexistant property of CircProg: {}", x,),
         }
     }
@@ -79,7 +87,12 @@ impl ObjectSubclass for CircProgPriv {
     }
 
     fn new() -> Self {
-        Self { value: RefCell::new(0f32), start_angle: RefCell::new(0f32), content: RefCell::new(None) }
+        Self {
+            value: RefCell::new(0f32),
+            start_angle: RefCell::new(0f32),
+            content: RefCell::new(None),
+            thickness: RefCell::new(0f32),
+        }
     }
 }
 impl CircProg {
@@ -104,6 +117,7 @@ impl WidgetImpl for CircProgPriv {
         let styles = widget.get_style_context();
         let value = *self.value.borrow();
         let start_angle = *self.start_angle.borrow() as f64;
+        let thickness = *self.thickness.borrow() as f64;
         let width = widget.get_allocated_width() as f64;
         let height = widget.get_allocated_height() as f64;
 
@@ -119,7 +133,7 @@ impl WidgetImpl for CircProgPriv {
         cr.arc(width / 2.0, height / 2.0, f64::min(width, height) / 2.0, 0.0, perc_to_rad(value as f64));
         cr.set_source_rgba(20.0, bg_color.green, bg_color.blue, bg_color.alpha);
         cr.move_to(width / 2.0, height / 2.0);
-        cr.arc(width / 2.0, height / 2.0, f64::min(width, height) / 3.0, 0.0, perc_to_rad(value as f64));
+        cr.arc(width / 2.0, height / 2.0, (f64::min(width, height) - thickness) / 2.0, 0.0, perc_to_rad(value as f64));
         cr.set_fill_rule(cairo::FillRule::EvenOdd); // Substract one circle from the other
         cr.fill();
         cr.restore();

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,21 +1,20 @@
 use std::cell::RefCell;
 // https://www.figuiere.net/technotes/notes/tn002/
 // https://github.com/gtk-rs/examples/blob/master/src/bin/listbox_model.rs
-use glib::{glib_object_impl, glib_object_subclass, glib_wrapper, subclass, translate::*, Type};
+use anyhow::Result;
+use glib::{object_subclass, wrapper};
 use gtk::{prelude::*, subclass::prelude::*};
 
-glib_wrapper! {
-    pub struct CircProg(
-        Object<subclass::simple::InstanceStruct<CircProgPriv>,
-        subclass::simple::ClassStruct<CircProgPriv>,
-        CircProgClass>)
-        @extends gtk::Box, gtk::Container, gtk::Widget;
+use crate::error_handling_ctx;
 
-    match fn {
-        get_type => || CircProgPriv::get_type().to_glib(),
-    }
+wrapper! {
+    pub struct CircProg(ObjectSubclass<CircProgPriv>)
+    @extends gtk::Bin, gtk::Container, gtk::Widget;
 }
 
+// wrapper! { pub struct CircProg(ObjectSubclass<CircProgPriv>) @extends gtk::Box, gtk::Container, gtk::Widget; }
+
+#[derive(Default)]
 pub struct CircProgPriv {
     start_angle: RefCell<f32>,
     value: RefCell<f32>,
@@ -24,87 +23,81 @@ pub struct CircProgPriv {
     content: RefCell<Option<gtk::Widget>>,
 }
 
-static PROPERTIES: [subclass::Property; 3] = [
-    subclass::Property("value", |v| {
-        glib::ParamSpec::float(v, "Value", "The value", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE)
-    }),
-    subclass::Property("thickness", |v| {
-        glib::ParamSpec::float(v, "Thickness", "Thickness", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE)
-    }),
-    subclass::Property("start-angle", |v| {
-        glib::ParamSpec::float(v, "Starting angle", "Starting angle", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE)
-    }),
-];
-
 impl ObjectImpl for CircProgPriv {
-    glib_object_impl!();
+    // glib_object_impl!();
+    fn properties() -> &'static [glib::ParamSpec] {
+        use once_cell::sync::Lazy;
+        static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+            vec![
+                glib::ParamSpec::new_float("value", "Value", "The value", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE),
+                glib::ParamSpec::new_float(
+                    "thickness",
+                    "Thickness",
+                    "Thickness",
+                    0f32,
+                    100f32,
+                    0f32,
+                    glib::ParamFlags::READWRITE,
+                ),
+                glib::ParamSpec::new_float(
+                    "start-angle",
+                    "Starting angle",
+                    "Starting angle",
+                    0f32,
+                    100f32,
+                    0f32,
+                    glib::ParamFlags::READWRITE,
+                ),
+            ]
+        });
 
-    fn constructed(&self, obj: &glib::Object) {
-        self.parent_constructed(obj);
-        dbg!("constructed");
+        PROPERTIES.as_ref()
     }
 
-    fn set_property(&self, _obj: &glib::Object, id: usize, value: &glib::Value) {
-        let prop = &PROPERTIES[id];
-        match prop.0 {
+    //    fn constructed(&self, obj: &Self::Type) {
+    //        self.parent_constructed(obj);
+    //    }
+
+    fn set_property(&self, _obj: &Self::Type, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        match pspec.name() {
             "value" => {
-                self.value.replace(value.get_some().unwrap());
+                self.value.replace(value.get().unwrap());
             }
             "thickness" => {
-                self.thickness.replace(value.get_some().unwrap());
+                self.thickness.replace(value.get().unwrap());
             }
             "start-angle" => {
-                self.start_angle.replace(value.get_some().unwrap());
+                self.start_angle.replace(value.get().unwrap());
             }
             x => panic!("Tried to set inexistant property of CircProg: {}", x,),
         }
     }
 
-    fn get_property(&self, _obj: &glib::Object, id: usize) -> Result<glib::Value, ()> {
-        let prop = &PROPERTIES[id];
-        match prop.0 {
-            "value" => Ok(self.value.borrow().to_value()),
-            "start-angle" => Ok(self.start_angle.borrow().to_value()),
-            "thickness" => Ok(self.thickness.borrow().to_value()),
+    fn property(&self, _obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        match pspec.name() {
+            "value" => self.value.borrow().to_value(),
+            "start-angle" => self.start_angle.borrow().to_value(),
+            "thickness" => self.thickness.borrow().to_value(),
             x => panic!("Tried to access inexistant property of CircProg: {}", x,),
         }
     }
 }
 
+#[object_subclass]
 impl ObjectSubclass for CircProgPriv {
-    type Class = subclass::simple::ClassStruct<Self>;
-    type Instance = subclass::simple::InstanceStruct<Self>;
     type ParentType = gtk::Bin;
+    type Type = CircProg;
 
-    const ABSTRACT: bool = false;
     const NAME: &'static str = "CircProg";
-
-    glib_object_subclass!();
-
-    fn class_init(klass: &mut Self::Class) {
-        klass.install_properties(&PROPERTIES);
-        klass.add_signal("added", glib::SignalFlags::RUN_LAST, &[Type::U32], Type::Unit);
-    }
-
-    fn new() -> Self {
-        Self {
-            value: RefCell::new(0f32),
-            start_angle: RefCell::new(0f32),
-            content: RefCell::new(None),
-            thickness: RefCell::new(0f32),
-        }
-    }
 }
+
 impl CircProg {
     pub fn new() -> Self {
-        glib::Object::new(Self::static_type(), &[])
-            .expect("Failed to create MyAwesome Widget")
-            .downcast()
-            .expect("Created MyAwesome Widget is of wrong type")
+        glib::Object::new::<Self>(&[]).expect("Failed to create MyAwesome Widget")
     }
 }
 impl ContainerImpl for CircProgPriv {
-    fn add(&self, container: &gtk::Container, widget: &gtk::Widget) {
+    fn add(&self, container: &Self::Type, widget: &gtk::Widget) {
         self.parent_add(container, widget);
         self.content.replace(Some(widget.clone()));
     }
@@ -113,33 +106,38 @@ impl BinImpl for CircProgPriv {}
 impl WidgetImpl for CircProgPriv {
     // https://sourcegraph.com/github.com/GNOME/fractal/-/blob/fractal-gtk/src/widgets/clip_container.rs?L119 ???
     // https://stackoverflow.com/questions/50283367/drawingarea-fill-area-outside-a-region
-    fn draw(&self, widget: &gtk::Widget, cr: &cairo::Context) -> Inhibit {
-        let styles = widget.get_style_context();
+    fn draw(&self, widget: &Self::Type, cr: &cairo::Context) -> Inhibit {
+        let styles = widget.style_context();
         let value = *self.value.borrow();
         let start_angle = *self.start_angle.borrow() as f64;
         let thickness = *self.thickness.borrow() as f64;
-        let width = widget.get_allocated_width() as f64;
-        let height = widget.get_allocated_height() as f64;
+        let width = widget.allocated_width() as f64;
+        let height = widget.allocated_height() as f64;
 
-        #[allow(deprecated)]
-        let bg_color = styles.get_background_color(gtk::StateFlags::NORMAL);
+        let res: Result<()> = try {
+            let bg_color: gdk::RGBA = styles.style_property_for_state("background-color", gtk::StateFlags::NORMAL).get()?;
 
-        cr.save();
-        cr.translate(width / 2.0, height / 2.0);
-        cr.rotate(perc_to_rad(start_angle as f64));
-        cr.translate(-width / 2.0, -height / 2.0);
-        cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
-        cr.move_to(width / 2.0, height / 2.0);
-        cr.arc(width / 2.0, height / 2.0, f64::min(width, height) / 2.0, 0.0, perc_to_rad(value as f64));
-        cr.set_source_rgba(20.0, bg_color.green, bg_color.blue, bg_color.alpha);
-        cr.move_to(width / 2.0, height / 2.0);
-        cr.arc(width / 2.0, height / 2.0, (f64::min(width, height) - thickness) / 2.0, 0.0, perc_to_rad(value as f64));
-        cr.set_fill_rule(cairo::FillRule::EvenOdd); // Substract one circle from the other
-        cr.fill();
-        cr.restore();
+            cr.save()?;
+            cr.translate(width / 2.0, height / 2.0);
+            cr.rotate(perc_to_rad(start_angle as f64));
+            cr.translate(-width / 2.0, -height / 2.0);
+            cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
+            cr.move_to(width / 2.0, height / 2.0);
+            cr.arc(width / 2.0, height / 2.0, f64::min(width, height) / 2.0, 0.0, perc_to_rad(value as f64));
+            cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
+            cr.move_to(width / 2.0, height / 2.0);
+            cr.arc(width / 2.0, height / 2.0, (f64::min(width, height) - thickness) / 2.0, 0.0, perc_to_rad(value as f64));
+            cr.set_fill_rule(cairo::FillRule::EvenOdd); // Substract one circle from the other
+            cr.fill()?;
+            cr.restore()?;
+        };
+
+        if let Err(error) = res {
+            error_handling_ctx::print_error(error)
+        };
 
         if let Some(child) = &*self.content.borrow() {
-            widget.downcast_ref::<gtk::Container>().unwrap().propagate_draw(child, &cr);
+            widget.propagate_draw(child, &cr);
         }
         gtk::Inhibit(false)
     }

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use anyhow::{Result, anyhow};
 use glib::{object_subclass, wrapper};
-use gtk::{prelude::*, subclass::prelude::*};
+use gtk::{Requisition, prelude::*, subclass::prelude::*};
 
 use crate::error_handling_ctx;
 
@@ -112,6 +112,7 @@ impl CircProg {
         glib::Object::new::<Self>(&[]).expect("Failed to create CircularProgress Widget")
     }
 }
+
 impl ContainerImpl for CircProgPriv {
     fn add(&self, container: &Self::Type, widget: &gtk::Widget) {
         if let Some(content) = &*self.content.borrow() {
@@ -124,8 +125,26 @@ impl ContainerImpl for CircProgPriv {
     }
 }
 
+
 impl BinImpl for CircProgPriv {}
 impl WidgetImpl for CircProgPriv {
+    // We overwrite preferred_* so that overflowing content from the children gets cropped
+    fn preferred_width(&self, _widget: &Self::Type) -> (i32, i32) {
+        (0,0)
+    }
+
+    fn preferred_width_for_height(&self, _widget: &Self::Type, _height: i32) -> (i32, i32) {
+        (0,0)
+    }
+
+    fn preferred_height(&self, _widget: &Self::Type) -> (i32, i32) {
+        (0,0)
+    }
+
+    fn preferred_height_for_width(&self, _widget: &Self::Type, _width: i32) -> (i32, i32) {
+        (0,0)
+    }
+
     fn draw(&self, widget: &Self::Type, cr: &cairo::Context) -> Inhibit {
         let styles = widget.style_context();
         let value = *self.value.borrow();

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -98,6 +98,10 @@ impl ObjectSubclass for CircProgPriv {
     type Type = CircProg;
 
     const NAME: &'static str = "CircProg";
+
+    fn class_init(klass: &mut Self::Class) {
+        klass.set_css_name("circular-progress");
+    }
 }
 
 impl CircProg {
@@ -118,6 +122,14 @@ impl ContainerImpl for CircProgPriv {
     }
 }
 
+fn calc_widget_lowest_preferred_dimension(widget: &gtk::Widget) -> (i32, i32) {
+    let preferred_width = widget.preferred_width();
+    let preferred_height = widget.preferred_height();
+    let min_lowest = i32::min(preferred_width.0, preferred_height.0);
+    let natural_lowest = i32::min(preferred_width.1, preferred_height.1);
+    (min_lowest, natural_lowest)
+}
+
 impl BinImpl for CircProgPriv {}
 impl WidgetImpl for CircProgPriv {
     // We overwrite preferred_* so that overflowing content from the children gets cropped
@@ -127,14 +139,11 @@ impl WidgetImpl for CircProgPriv {
         let margin = styles.margin(gtk::StateFlags::NORMAL);
 
         if let Some(child) = &*self.content.borrow() {
-            let child_preferred_width = child.preferred_width();
-            let child_preferred_height = child.preferred_height();
-            let min_child = i32::min(child_preferred_width.0, child_preferred_height.0);
-            let natural_child = i32::min(child_preferred_width.1, child_preferred_height.1);
+            let (min_child, natural_child) = calc_widget_lowest_preferred_dimension(child);
             (min_child + margin.right as i32 + margin.left as i32, natural_child + margin.right as i32 + margin.left as i32)
         } else {
             let empty_width = (2 * *self.thickness.borrow() as i32) + margin.right as i32 + margin.left as i32;
-            (empty_width , empty_width)
+            (empty_width, empty_width)
         }
     }
 
@@ -147,10 +156,7 @@ impl WidgetImpl for CircProgPriv {
         let margin = styles.margin(gtk::StateFlags::NORMAL);
 
         if let Some(child) = &*self.content.borrow() {
-            let child_preferred_width = child.preferred_width();
-            let child_preferred_height = child.preferred_height();
-            let min_child = i32::min(child_preferred_width.0, child_preferred_height.0);
-            let natural_child = i32::min(child_preferred_width.1, child_preferred_height.1);
+            let (min_child, natural_child) = calc_widget_lowest_preferred_dimension(child);
             (min_child + margin.bottom as i32 + margin.top as i32, natural_child + margin.bottom as i32 + margin.top as i32)
         } else {
             let empty_height = (2 * *self.thickness.borrow() as i32) + margin.right as i32 + margin.left as i32;

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -9,7 +9,7 @@ glib_wrapper! {
         Object<subclass::simple::InstanceStruct<CircProgPriv>,
         subclass::simple::ClassStruct<CircProgPriv>,
         CircProgClass>)
-        @extends gtk::Bin, gtk::Container, gtk::Widget;
+        @extends gtk::Box, gtk::Container, gtk::Widget;
 
     match fn {
         get_type => || CircProgPriv::get_type().to_glib(),
@@ -64,7 +64,7 @@ impl ObjectImpl for CircProgPriv {
 impl ObjectSubclass for CircProgPriv {
     type Class = subclass::simple::ClassStruct<Self>;
     type Instance = subclass::simple::InstanceStruct<Self>;
-    type ParentType = gtk::Bin;
+    type ParentType = gtk::Box;
 
     const ABSTRACT: bool = false;
     const NAME: &'static str = "CircProg";
@@ -89,20 +89,36 @@ impl CircProg {
     }
 }
 
-impl BinImpl for CircProgPriv {}
+impl BoxImpl for CircProgPriv {}
+//impl BinImpl for CircProgPriv {}
 impl ContainerImpl for CircProgPriv {}
 impl WidgetImpl for CircProgPriv {
+    // https://sourcegraph.com/github.com/GNOME/fractal/-/blob/fractal-gtk/src/widgets/clip_container.rs?L119 ???
     fn draw(&self, widget: &gtk::Widget, cr: &cairo::Context) -> Inhibit {
+        let styles = widget.get_style_context();
         let value = *self.value.borrow();
         cr.save();
         let width = widget.get_allocated_width() as f64;
         let height = widget.get_allocated_height() as f64;
-        cr.set_source_rgb(0.1f64, 1f64, 0.5f64);
+
+        #[allow(deprecated)]
+        let bg_color = styles.get_background_color(gtk::StateFlags::NORMAL);
+        cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
+
         cr.move_to(width / 2.0, height / 2.0);
         cr.arc(width / 2.0, height / 2.0, height / 4.0, 0.0, perc_to_rad(value as f64));
         cr.fill();
         gtk::Inhibit(false)
     }
+
+    fn get_request_mode(&self, widget: &gtk::Widget) -> gtk::SizeRequestMode {
+        self.parent_get_request_mode(widget)
+    }
+
+    //fn size_allocate(&self, widget: &gtk::Widget, allocation: &gdk::Rectangle) {
+        ////self.parent_size_allocate(widget, allocation);
+        ////widget.downcast_ref::<gtk::Box>().unwrap().size_allocate(allocation)
+    //}
 }
 
 fn perc_to_rad(n: f64) -> f64 {

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -14,14 +14,25 @@ wrapper! {
 
 // wrapper! { pub struct CircProg(ObjectSubclass<CircProgPriv>) @extends gtk::Box, gtk::Container, gtk::Widget; }
 
-#[derive(Default)]
 pub struct CircProgPriv {
     start_at: RefCell<f32>,
     value: RefCell<f32>,
     thickness: RefCell<f32>,
     clockwise: RefCell<bool>,
-
     content: RefCell<Option<gtk::Widget>>,
+}
+
+// This should match the default values from the ParamSpecs
+impl Default for CircProgPriv {
+    fn default() -> Self {
+        CircProgPriv {
+            start_at: RefCell::new(0.0),
+            value: RefCell::new(0.0),
+            thickness: RefCell::new(1.0),
+            clockwise: RefCell::new(true),
+            content: RefCell::new(None),
+        }
+    }
 }
 
 impl ObjectImpl for CircProgPriv {
@@ -37,7 +48,7 @@ impl ObjectImpl for CircProgPriv {
                     "Thickness",
                     0f32,
                     100f32,
-                    0f32,
+                    1f32,
                     glib::ParamFlags::READWRITE,
                 ),
                 glib::ParamSpec::new_float(

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -123,19 +123,18 @@ impl WidgetImpl for CircProgPriv {
     // We overwrite preferred_* so that overflowing content from the children gets cropped
     //  We return min(child_width, child_height)
     fn preferred_width(&self, widget: &Self::Type) -> (i32, i32) {
-        if let Some(child) = &*self.content.borrow() {
-            let styles = widget.style_context();
-            let margin = styles.margin(gtk::StateFlags::NORMAL);
+        let styles = widget.style_context();
+        let margin = styles.margin(gtk::StateFlags::NORMAL);
 
+        if let Some(child) = &*self.content.borrow() {
             let child_preferred_width = child.preferred_width();
             let child_preferred_height = child.preferred_height();
             let min_child = i32::min(child_preferred_width.0, child_preferred_height.0);
             let natural_child = i32::min(child_preferred_width.1, child_preferred_height.1);
-
             (min_child + margin.right as i32 + margin.left as i32, natural_child + margin.right as i32 + margin.left as i32)
         } else {
-            let min_empty_size = 2 * *self.thickness.borrow() as i32;
-            (min_empty_size, min_empty_size)
+            let empty_width = (2 * *self.thickness.borrow() as i32) + margin.right as i32 + margin.left as i32;
+            (empty_width , empty_width)
         }
     }
 
@@ -144,19 +143,18 @@ impl WidgetImpl for CircProgPriv {
     }
 
     fn preferred_height(&self, widget: &Self::Type) -> (i32, i32) {
-        if let Some(child) = &*self.content.borrow() {
-            let styles = widget.style_context();
-            let margin = styles.margin(gtk::StateFlags::NORMAL);
+        let styles = widget.style_context();
+        let margin = styles.margin(gtk::StateFlags::NORMAL);
 
+        if let Some(child) = &*self.content.borrow() {
             let child_preferred_width = child.preferred_width();
             let child_preferred_height = child.preferred_height();
             let min_child = i32::min(child_preferred_width.0, child_preferred_height.0);
             let natural_child = i32::min(child_preferred_width.1, child_preferred_height.1);
-
             (min_child + margin.bottom as i32 + margin.top as i32, natural_child + margin.bottom as i32 + margin.top as i32)
         } else {
-            let min_empty_size = 2 * *self.thickness.borrow() as i32;
-            (min_empty_size, min_empty_size)
+            let empty_height = (2 * *self.thickness.borrow() as i32) + margin.right as i32 + margin.left as i32;
+            (empty_height, empty_height)
         }
     }
 

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -131,7 +131,10 @@ impl WidgetImpl for CircProgPriv {
         let clockwise = *self.clockwise.borrow() as bool;
 
         let res: Result<()> = try {
+            let ring_color: gdk::RGBA = styles.color(gtk::StateFlags::NORMAL);
             let bg_color: gdk::RGBA = styles.style_property_for_state("background-color", gtk::StateFlags::NORMAL).get()?;
+            let outer_ring =  f64::min(width, height) / 2.0;
+            let inner_ring =  (f64::min(width, height) / 2.0) - thickness;
             let c = (width / 2.0, height / 2.0); // Center
             let (start_angle, end_angle) = if clockwise {
                 (0.0, perc_to_rad(value as f64))
@@ -141,17 +144,26 @@ impl WidgetImpl for CircProgPriv {
             };
 
             cr.save()?;
+
+            // Centering
             cr.translate(c.0, c.1);
             cr.rotate(perc_to_rad(start_at as f64));
             cr.translate(-c.0, -c.1);
+
+            // Center circle
+            cr.arc(c.0, c.1, inner_ring+1.0, 0.0, perc_to_rad(100.0));
             cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
+            cr.fill()?;
+
+            // Ring
             cr.move_to(c.0, c.1);
-            cr.arc(c.0, c.1, f64::min(width, height) / 2.0, start_angle, end_angle);
-            cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
+            cr.arc(c.0, c.1, outer_ring, start_angle, end_angle);
+            cr.set_source_rgba(ring_color.red, ring_color.green, ring_color.blue, ring_color.alpha);
             cr.move_to(c.0, c.1);
-            cr.arc(c.0, c.1, (f64::min(width, height) - thickness) / 2.0, start_angle, end_angle);
+            cr.arc(c.0, c.1, inner_ring, start_angle, end_angle);
             cr.set_fill_rule(cairo::FillRule::EvenOdd); // Substract one circle from the other
             cr.fill()?;
+
             cr.restore()?;
         };
 

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,0 +1,110 @@
+use std::cell::RefCell;
+// https://www.figuiere.net/technotes/notes/tn002/
+// https://github.com/gtk-rs/examples/blob/master/src/bin/listbox_model.rs
+use glib::{glib_object_impl, glib_object_subclass, glib_wrapper, subclass, translate::*, Type};
+use gtk::{prelude::*, subclass::prelude::*};
+
+glib_wrapper! {
+    pub struct CircProg(
+        Object<subclass::simple::InstanceStruct<CircProgPriv>,
+        subclass::simple::ClassStruct<CircProgPriv>,
+        CircProgClass>)
+        @extends gtk::Bin, gtk::Container, gtk::Widget;
+
+    match fn {
+        get_type => || CircProgPriv::get_type().to_glib(),
+    }
+}
+
+pub struct CircProgPriv {
+    start_angle: RefCell<f32>,
+    value: RefCell<f32>,
+}
+
+static PROPERTIES: [subclass::Property; 2] = [
+    subclass::Property("value", |v| {
+        glib::ParamSpec::float(v, "Value", "The value", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE)
+    }),
+    subclass::Property("start-angle", |v| {
+        glib::ParamSpec::float(v, "Starting angle", "Starting angle", 0f32, 100f32, 0f32, glib::ParamFlags::READWRITE)
+    }),
+];
+
+impl ObjectImpl for CircProgPriv {
+    glib_object_impl!();
+
+    fn constructed(&self, obj: &glib::Object) {
+        self.parent_constructed(obj);
+        dbg!("constructed");
+    }
+
+    fn set_property(&self, _obj: &glib::Object, id: usize, value: &glib::Value) {
+        let prop = &PROPERTIES[id];
+        match prop.0 {
+            "value" => {
+                self.value.replace(value.get_some().unwrap());
+            }
+            "start-angle" => {
+                self.start_angle.replace(value.get_some().unwrap());
+            }
+            x => panic!("Tried to set inexistant property of CircProg: {}", x,),
+        }
+    }
+
+    fn get_property(&self, _obj: &glib::Object, id: usize) -> Result<glib::Value, ()> {
+        let prop = &PROPERTIES[id];
+        match prop.0 {
+            "value" => Ok(self.value.borrow().to_value()),
+            "start-angle" => Ok(self.start_angle.borrow().to_value()),
+            x => panic!("Tried to access inexistant property of CircProg: {}", x,),
+        }
+    }
+}
+
+impl ObjectSubclass for CircProgPriv {
+    type Class = subclass::simple::ClassStruct<Self>;
+    type Instance = subclass::simple::InstanceStruct<Self>;
+    type ParentType = gtk::Bin;
+
+    const ABSTRACT: bool = false;
+    const NAME: &'static str = "CircProg";
+
+    glib_object_subclass!();
+
+    fn class_init(klass: &mut Self::Class) {
+        klass.install_properties(&PROPERTIES);
+        klass.add_signal("added", glib::SignalFlags::RUN_LAST, &[Type::U32], Type::Unit);
+    }
+
+    fn new() -> Self {
+        Self { value: RefCell::new(0f32), start_angle: RefCell::new(0f32) }
+    }
+}
+impl CircProg {
+    pub fn new() -> Self {
+        glib::Object::new(Self::static_type(), &[])
+            .expect("Failed to create MyAwesome Widget")
+            .downcast()
+            .expect("Created MyAwesome Widget is of wrong type")
+    }
+}
+
+impl BinImpl for CircProgPriv {}
+impl ContainerImpl for CircProgPriv {}
+impl WidgetImpl for CircProgPriv {
+    fn draw(&self, widget: &gtk::Widget, cr: &cairo::Context) -> Inhibit {
+        let value = *self.value.borrow();
+        cr.save();
+        let width = widget.get_allocated_width() as f64;
+        let height = widget.get_allocated_height() as f64;
+        cr.set_source_rgb(0.1f64, 1f64, 0.5f64);
+        cr.move_to(width / 2.0, height / 2.0);
+        cr.arc(width / 2.0, height / 2.0, height / 4.0, 0.0, perc_to_rad(value as f64));
+        cr.fill();
+        gtk::Inhibit(false)
+    }
+}
+
+fn perc_to_rad(n: f64) -> f64 {
+    (n / 100f64) * 2f64 * std::f64::consts::PI
+}

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,6 +1,4 @@
 use std::cell::RefCell;
-// https://www.figuiere.net/technotes/notes/tn002/
-// https://github.com/gtk-rs/examples/blob/master/src/bin/listbox_model.rs
 use anyhow::{Result, anyhow};
 use glib::{object_subclass, wrapper};
 use gtk::{prelude::*, subclass::prelude::*};
@@ -34,7 +32,6 @@ impl Default for CircProgPriv {
 }
 
 impl ObjectImpl for CircProgPriv {
-    // glib_object_impl!();
     fn properties() -> &'static [glib::ParamSpec] {
         use once_cell::sync::Lazy;
         static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
@@ -129,8 +126,6 @@ impl ContainerImpl for CircProgPriv {
 
 impl BinImpl for CircProgPriv {}
 impl WidgetImpl for CircProgPriv {
-    // https://sourcegraph.com/github.com/GNOME/fractal/-/blob/fractal-gtk/src/widgets/clip_container.rs?L119 ???
-    // https://stackoverflow.com/questions/50283367/drawingarea-fill-area-outside-a-region
     fn draw(&self, widget: &Self::Type, cr: &cairo::Context) -> Inhibit {
         let styles = widget.style_context();
         let value = *self.value.borrow();
@@ -160,11 +155,6 @@ impl WidgetImpl for CircProgPriv {
             cr.translate(c.0, c.1);
             cr.rotate(perc_to_rad(start_at as f64));
             cr.translate(-c.0, -c.1);
-
-            //// Center circle
-            //cr.arc(c.0, c.1, inner_ring+1.0, 0.0, perc_to_rad(100.0));
-            //cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
-            //cr.fill()?;
 
             // Background Ring
             cr.move_to(c.0, c.1);

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use anyhow::{Result, anyhow};
 use glib::{object_subclass, wrapper};
-use gtk::{Requisition, prelude::*, subclass::prelude::*};
+use gtk::{prelude::*, subclass::prelude::*};
 
 use crate::error_handling_ctx;
 

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -103,18 +103,23 @@ impl WidgetImpl for CircProgPriv {
     fn draw(&self, widget: &gtk::Widget, cr: &cairo::Context) -> Inhibit {
         let styles = widget.get_style_context();
         let value = *self.value.borrow();
+        let start_angle = *self.start_angle.borrow() as f64;
         let width = widget.get_allocated_width() as f64;
         let height = widget.get_allocated_height() as f64;
 
-        // Outer ring
         #[allow(deprecated)]
         let bg_color = styles.get_background_color(gtk::StateFlags::NORMAL);
+
         cr.save();
+        cr.translate(width / 2.0, height / 2.0);
+        cr.rotate(perc_to_rad(start_angle as f64));
+        cr.translate(-width / 2.0, -height / 2.0);
         cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
-        cr.arc(width / 2.0, height / 2.0, f64::min(width, height) / 2.0, 0.0, perc_to_rad(value as f64));
         cr.move_to(width / 2.0, height / 2.0);
-        // cr.set_operator(cairo::Operator::Clear);
-        cr.arc(width / 2.0, height / 2.0, f64::min(width, height) / 4.0, 0.0, perc_to_rad(value as f64));
+        cr.arc(width / 2.0, height / 2.0, f64::min(width, height) / 2.0, 0.0, perc_to_rad(value as f64));
+        cr.set_source_rgba(20.0, bg_color.green, bg_color.blue, bg_color.alpha);
+        cr.move_to(width / 2.0, height / 2.0);
+        cr.arc(width / 2.0, height / 2.0, f64::min(width, height) / 3.0, 0.0, perc_to_rad(value as f64));
         cr.set_fill_rule(cairo::FillRule::EvenOdd); // Substract one circle from the other
         cr.fill();
         cr.restore();

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -184,15 +184,28 @@ impl WidgetImpl for CircProgPriv {
             cr.set_fill_rule(cairo::FillRule::EvenOdd); // Substract one circle from the other
             cr.fill()?;
             cr.restore()?;
+
+            // Draw the children widget clipping it to the center
+            if let Some(child) = &*self.content.borrow() {
+                cr.save()?;
+                // Center circular clip
+                cr.arc(c.0, c.1, inner_ring+1.0, 0.0, perc_to_rad(100.0));
+                cr.set_source_rgba(bg_color.red, 0.0, 0.0, bg_color.alpha);
+                cr.clip();
+
+                // Children widget
+                widget.propagate_draw(child, &cr);
+
+                cr.reset_clip();
+                cr.restore()?;
+            }
         };
+
 
         if let Err(error) = res {
             error_handling_ctx::print_error(error)
         };
 
-        if let Some(child) = &*self.content.borrow() {
-            widget.propagate_draw(child, &cr);
-        }
         gtk::Inhibit(false)
     }
 }

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -12,8 +12,6 @@ wrapper! {
     @extends gtk::Bin, gtk::Container, gtk::Widget;
 }
 
-// wrapper! { pub struct CircProg(ObjectSubclass<CircProgPriv>) @extends gtk::Box, gtk::Container, gtk::Widget; }
-
 pub struct CircProgPriv {
     start_at: RefCell<f32>,
     value: RefCell<f32>,

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -178,6 +178,7 @@ impl WidgetImpl for CircProgPriv {
             // Draw the children widget clipping it to the center
             if let Some(child) = &*self.content.borrow() {
                 cr.save()?;
+
                 // Center circular clip
                 cr.arc(center.0, center.1, inner_ring+1.0, 0.0, perc_to_rad(100.0));
                 cr.set_source_rgba(bg_color.red, 0.0, 0.0, bg_color.alpha);
@@ -190,7 +191,6 @@ impl WidgetImpl for CircProgPriv {
                 cr.restore()?;
             }
         };
-
 
         if let Err(error) = res {
             error_handling_ctx::print_error(error)

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -141,7 +141,7 @@ impl WidgetImpl for CircProgPriv {
             let bg_color: gdk::RGBA = styles.style_property_for_state("background-color", gtk::StateFlags::NORMAL).get()?;
             let outer_ring =  f64::min(width, height) / 2.0;
             let inner_ring =  (f64::min(width, height) / 2.0) - thickness;
-            let c = (width / 2.0, height / 2.0); // Center
+            let center = (width / 2.0, height / 2.0);
             let (start_angle, end_angle) = if clockwise {
                 (0.0, perc_to_rad(value as f64))
             }
@@ -152,25 +152,25 @@ impl WidgetImpl for CircProgPriv {
             cr.save()?;
 
             // Centering
-            cr.translate(c.0, c.1);
+            cr.translate(center.0, center.1);
             cr.rotate(perc_to_rad(start_at as f64));
-            cr.translate(-c.0, -c.1);
+            cr.translate(-center.0, -center.1);
 
             // Background Ring
-            cr.move_to(c.0, c.1);
-            cr.arc(c.0, c.1, outer_ring, 0.0, perc_to_rad(100.0));
+            cr.move_to(center.0, center.1);
+            cr.arc(center.0, center.1, outer_ring, 0.0, perc_to_rad(100.0));
             cr.set_source_rgba(bg_color.red, bg_color.green, bg_color.blue, bg_color.alpha);
-            cr.move_to(c.0, c.1);
-            cr.arc(c.0, c.1, inner_ring, 0.0, perc_to_rad(100.0));
+            cr.move_to(center.0, center.1);
+            cr.arc(center.0, center.1, inner_ring, 0.0, perc_to_rad(100.0));
             cr.set_fill_rule(cairo::FillRule::EvenOdd); // Substract one circle from the other
             cr.fill()?;
 
             // Foreground Ring
-            cr.move_to(c.0, c.1);
-            cr.arc(c.0, c.1, outer_ring, start_angle, end_angle);
+            cr.move_to(center.0, center.1);
+            cr.arc(center.0, center.1, outer_ring, start_angle, end_angle);
             cr.set_source_rgba(fg_color.red, fg_color.green, fg_color.blue, fg_color.alpha);
-            cr.move_to(c.0, c.1);
-            cr.arc(c.0, c.1, inner_ring, start_angle, end_angle);
+            cr.move_to(center.0, center.1);
+            cr.arc(center.0, center.1, inner_ring, start_angle, end_angle);
             cr.set_fill_rule(cairo::FillRule::EvenOdd); // Substract one circle from the other
             cr.fill()?;
             cr.restore()?;
@@ -179,7 +179,7 @@ impl WidgetImpl for CircProgPriv {
             if let Some(child) = &*self.content.borrow() {
                 cr.save()?;
                 // Center circular clip
-                cr.arc(c.0, c.1, inner_ring+1.0, 0.0, perc_to_rad(100.0));
+                cr.arc(center.0, center.1, inner_ring+1.0, 0.0, perc_to_rad(100.0));
                 cr.set_source_rgba(bg_color.red, 0.0, 0.0, bg_color.alpha);
                 cr.clip();
 

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 // https://www.figuiere.net/technotes/notes/tn002/
 // https://github.com/gtk-rs/examples/blob/master/src/bin/listbox_model.rs
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use glib::{object_subclass, wrapper};
 use gtk::{prelude::*, subclass::prelude::*};
 
@@ -117,6 +117,11 @@ impl CircProg {
 }
 impl ContainerImpl for CircProgPriv {
     fn add(&self, container: &Self::Type, widget: &gtk::Widget) {
+        if let Some(content) = &*self.content.borrow() {
+            // TODO: Handle this error when populating children widgets instead
+            error_handling_ctx::print_error(anyhow!("Error, trying to add multiple children to a circular-progress widget"));
+            self.parent_remove(container, content);
+        }
         self.parent_add(container, widget);
         self.content.replace(Some(widget.clone()));
     }

--- a/crates/eww/src/widgets/mod.rs
+++ b/crates/eww/src/widgets/mod.rs
@@ -10,6 +10,7 @@ use yuck::{config::widget_definition::WidgetDefinition, gen_diagnostic};
 use std::process::Command;
 use widget_definitions::*;
 
+pub mod circular_progressbar;
 pub mod widget_definitions;
 pub mod widget_node;
 

--- a/crates/eww/src/widgets/mod.rs
+++ b/crates/eww/src/widgets/mod.rs
@@ -132,13 +132,23 @@ macro_rules! resolve_block {
                 $args.eww_state.resolve(
                     $args.window_name,
                     attr_map,
-                    ::glib::clone!(@strong $gtk_widget => move |attrs| {
-                        $(
-                            let $attr_name = attrs.get( ::std::stringify!($attr_name) ).context("something went terribly wrong....")?.$typecast_func()?;
-                        )*
-                        $code
-                        Ok(())
-                    })
+                    //::glib::clone!(@strong $gtk_widget => move |attrs| {
+                    //    $(
+                    //        let $attr_name = attrs.get( ::std::stringify!($attr_name) ).context("something went terribly wrong....")?.$typecast_func()?;
+                    //    )*
+                    //    $code
+                    //    Ok(())
+                    //})
+                    {
+                        let $gtk_widget = $gtk_widget.clone();
+                        move |attrs| {
+                            $(
+                                let $attr_name = attrs.get( ::std::stringify!($attr_name) ).context("something went terribly wrong....")?.$typecast_func()?;
+                            )*
+                            $code
+                            Ok(())
+                        }
+                    }
                 );
             }
         })+

--- a/crates/eww/src/widgets/mod.rs
+++ b/crates/eww/src/widgets/mod.rs
@@ -132,13 +132,6 @@ macro_rules! resolve_block {
                 $args.eww_state.resolve(
                     $args.window_name,
                     attr_map,
-                    //::glib::clone!(@strong $gtk_widget => move |attrs| {
-                    //    $(
-                    //        let $attr_name = attrs.get( ::std::stringify!($attr_name) ).context("something went terribly wrong....")?.$typecast_func()?;
-                    //    )*
-                    //    $code
-                    //    Ok(())
-                    //})
                     {
                         let $gtk_widget = $gtk_widget.clone();
                         move |attrs| {

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -755,13 +755,13 @@ fn build_circular_progress_bar(bargs: &mut BuilderArgs) -> Result<CircProg> {
     let w = CircProg::new();
     resolve_block!(bargs, w, {
         // @prop value - the value, between 0 - 100
-        prop(value: as_f64) { w.set_property("value", &(value as f32))?; },
+        prop(value: as_f64) { w.set_property("value", value)?; },
         // @prop start-angle - the angle that the circle should start at
-        prop(start_at: as_f64) { w.set_property("start-at", &(start_at as f32))?; },
+        prop(start_at: as_f64) { w.set_property("start-at", start_at)?; },
         // @prop thickness - the thickness of the circle
-        prop(thickness: as_f64) { w.set_property("thickness", &(thickness as f32))?; },
+        prop(thickness: as_f64) { w.set_property("thickness", thickness)?; },
         // @prop clockwise - wether the progress bar spins clockwise or counter clockwise
-        prop(clockwise: as_bool) { w.set_property("clockwise", &(clockwise as bool))?; },
+        prop(clockwise: as_bool) { w.set_property("clockwise", &clockwise)?; },
     });
     Ok(w)
 }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -759,6 +759,8 @@ fn build_circular_progress_bar(bargs: &mut BuilderArgs) -> Result<CircProg> {
         prop(value: as_f64) { w.set_property("value", &(value as f32))?; },
         // @prop start-angle - the angle that the circle should start at
         prop(start_angle: as_f64) { w.set_property("start-angle", &(start_angle as f32))?; },
+        // @prop thickness - the thickness of the circle
+        prop(thickness: as_f64) { w.set_property("thickness", &(thickness as f32))?; },
     });
     Ok(w)
 }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -757,9 +757,11 @@ fn build_circular_progress_bar(bargs: &mut BuilderArgs) -> Result<CircProg> {
         // @prop value - the value, between 0 - 100
         prop(value: as_f64) { w.set_property("value", &(value as f32))?; },
         // @prop start-angle - the angle that the circle should start at
-        prop(start_angle: as_f64) { w.set_property("start-angle", &(start_angle as f32))?; },
+        prop(start_at: as_f64) { w.set_property("start-at", &(start_at as f32))?; },
         // @prop thickness - the thickness of the circle
         prop(thickness: as_f64) { w.set_property("thickness", &(thickness as f32))?; },
+        // @prop clockwise - wether the progress bar spins clockwise or counter clockwise
+        prop(clockwise: as_bool) { w.set_property("clockwise", &(clockwise as bool))?; },
     });
     Ok(w)
 }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -6,8 +6,7 @@ use crate::{
 use anyhow::*;
 use codespan_reporting::diagnostic::Severity;
 use gdk::NotifyType;
-use glib;
-use gtk::{self, prelude::*};
+use gtk::{self, glib, prelude::*};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use std::{

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -35,7 +35,7 @@ pub(super) fn widget_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::Widge
         "box" => build_gtk_box(bargs)?.upcast(),
         "centerbox" => build_center_box(bargs)?.upcast(),
         "eventbox" => build_gtk_event_box(bargs)?.upcast(),
-        "circle-progress" => build_circular_progress_bar(bargs)?.upcast(),
+        "circular-progress" => build_circular_progress_bar(bargs)?.upcast(),
         "scale" => build_gtk_scale(bargs)?.upcast(),
         "progress" => build_gtk_progress(bargs)?.upcast(),
         "image" => build_gtk_image(bargs)?.upcast(),

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::option_map_unit_fn)]
-use super::{run_command, BuilderArgs};
+use super::{circular_progressbar::*, run_command, BuilderArgs};
 use crate::{
     enum_parse, error::DiagError, error_handling_ctx, eww_state, resolve_block, util::list_difference, widgets::widget_node,
 };
@@ -36,6 +36,7 @@ pub(super) fn widget_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::Widge
         "box" => build_gtk_box(bargs)?.upcast(),
         "centerbox" => build_center_box(bargs)?.upcast(),
         "eventbox" => build_gtk_event_box(bargs)?.upcast(),
+        "circle-progress" => build_circular_progress_bar(bargs)?.upcast(),
         "scale" => build_gtk_scale(bargs)?.upcast(),
         "progress" => build_gtk_progress(bargs)?.upcast(),
         "image" => build_gtk_image(bargs)?.upcast(),
@@ -749,6 +750,17 @@ fn build_gtk_calendar(bargs: &mut BuilderArgs) -> Result<gtk::Calendar> {
     });
 
     Ok(gtk_widget)
+}
+
+fn build_circular_progress_bar(bargs: &mut BuilderArgs) -> Result<CircProg> {
+    let w = CircProg::new();
+    resolve_block!(bargs, w, {
+        // @prop value - the value, between 0 - 100
+        prop(value: as_f64) { w.set_property("value", &(value as f32))?; },
+        // @prop start-angle - the angle that the circle should start at
+        prop(start_angle: as_f64) { w.set_property("start-angle", &(start_angle as f32))?; },
+    });
+    Ok(w)
 }
 
 /// @var orientation - "vertical", "v", "horizontal", "h"


### PR DESCRIPTION
## Description

This PR implements circular progress widgets as mentioned in #233. 

## Usage

```lisp 
(box :class "bar"
     :space-evenly true
  (circular-progress :class "thingy"
                   :value {round(EWW_CPU.avg, 0)}
                   :thickness 5
                   :clockwise true
                   :start-at 30
         (label :text "${round(EWW_CPU.avg, 0)}"))))
```

### Showcase
![image](https://user-images.githubusercontent.com/43417195/139730969-2b534e72-b09a-4f68-95c6-fc10933bea54.png)

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
