### PR TITLE
Implement loop widget

### DIFF
--- a/crates/eww/src/widgets/build_widget.rs
+++ b/crates/eww/src/widgets/build_widget.rs
@@ -1,16 +1,20 @@
 use anyhow::{Context, Result};
 use codespan_reporting::diagnostic::Severity;
-use eww_shared_util::AttrName;
+use eww_shared_util::{AttrName, Spanned};
 use gdk::prelude::Cast;
 use gtk::{
     prelude::{BoxExt, ContainerExt, WidgetExt, WidgetExtManual},
     Orientation,
 };
 use itertools::Itertools;
-use simplexpr::SimplExpr;
-use std::{collections::HashMap, rc::Rc};
+use maplit::hashmap;
+use simplexpr::{dynval::DynVal, SimplExpr};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use yuck::{
-    config::{widget_definition::WidgetDefinition, widget_use::WidgetUse},
+    config::{
+        widget_definition::WidgetDefinition,
+        widget_use::{BasicWidgetUse, ChildrenWidgetUse, LoopWidgetUse, WidgetUse},
+    },
     gen_diagnostic,
 };
 
@@ -28,7 +32,7 @@ use super::widget_definitions::{resolve_orientable_attrs, resolve_range_attrs, r
 
 pub struct BuilderArgs<'a> {
     pub calling_scope: ScopeIndex,
-    pub widget_use: WidgetUse,
+    pub widget_use: BasicWidgetUse,
     pub scope_graph: &'a mut ScopeGraph,
     pub unhandled_attrs: Vec<AttrName>,
     pub widget_defs: Rc<HashMap<String, WidgetDefinition>>,
@@ -45,7 +49,26 @@ pub fn build_gtk_widget(
     graph: &mut ScopeGraph,
     widget_defs: Rc<HashMap<String, WidgetDefinition>>,
     calling_scope: ScopeIndex,
-    mut widget_use: WidgetUse,
+    widget_use: WidgetUse,
+    custom_widget_invocation: Option<Rc<CustomWidgetInvocation>>,
+) -> Result<gtk::Widget> {
+    match widget_use {
+        WidgetUse::Basic(widget_use) => {
+            build_basic_gtk_widget(graph, widget_defs, calling_scope, widget_use, custom_widget_invocation)
+        }
+        WidgetUse::Loop(_) | WidgetUse::Children(_) => Err(anyhow::anyhow!(DiagError::new(gen_diagnostic! {
+            msg = "This widget can only be used as a child of some container widget such as box",
+            label = widget_use.span(),
+            note = "Hint: try wrapping this in a `box`"
+        }))),
+    }
+}
+
+fn build_basic_gtk_widget(
+    graph: &mut ScopeGraph,
+    widget_defs: Rc<HashMap<String, WidgetDefinition>>,
+    calling_scope: ScopeIndex,
+    mut widget_use: BasicWidgetUse,
     custom_widget_invocation: Option<Rc<CustomWidgetInvocation>>,
 ) -> Result<gtk::Widget> {
     if let Some(custom_widget) = widget_defs.clone().get(&widget_use.name) {
@@ -100,7 +123,7 @@ fn build_builtin_gtk_widget(
     graph: &mut ScopeGraph,
     widget_defs: Rc<HashMap<String, WidgetDefinition>>,
     calling_scope: ScopeIndex,
-    widget_use: WidgetUse,
+    widget_use: BasicWidgetUse,
     custom_widget_invocation: Option<Rc<CustomWidgetInvocation>>,
 ) -> Result<gtk::Widget> {
     let mut bargs = BuilderArgs {
@@ -160,23 +183,91 @@ fn populate_widget_children(
     custom_widget_invocation: Option<Rc<CustomWidgetInvocation>>,
 ) -> Result<()> {
     for child in widget_use_children {
-        if child.name == "children" {
-            let custom_widget_invocation = custom_widget_invocation.clone().context("Not in a custom widget invocation")?;
-            build_children_special_widget(
-                tree,
-                widget_defs.clone(),
-                calling_scope,
-                child,
-                gtk_container,
-                custom_widget_invocation,
-            )?;
-        } else {
-            let child_widget =
-                build_gtk_widget(tree, widget_defs.clone(), calling_scope, child, custom_widget_invocation.clone())?;
-            gtk_container.add(&child_widget);
+        match child {
+            WidgetUse::Children(child) => {
+                build_children_special_widget(
+                    tree,
+                    widget_defs.clone(),
+                    calling_scope,
+                    child,
+                    gtk_container,
+                    custom_widget_invocation.clone().context("Not in a custom widget invocation")?,
+                )?;
+            }
+            WidgetUse::Loop(child) => {
+                build_loop_special_widget(
+                    tree,
+                    widget_defs.clone(),
+                    calling_scope,
+                    child,
+                    gtk_container,
+                    custom_widget_invocation.clone(),
+                )?;
+            }
+            _ => {
+                let child_widget =
+                    build_gtk_widget(tree, widget_defs.clone(), calling_scope, child, custom_widget_invocation.clone())?;
+                gtk_container.add(&child_widget);
+            }
         }
     }
     Ok(())
+}
+
+fn build_loop_special_widget(
+    tree: &mut ScopeGraph,
+    widget_defs: Rc<HashMap<String, WidgetDefinition>>,
+    calling_scope: ScopeIndex,
+    widget_use: LoopWidgetUse,
+    gtk_container: &gtk::Container,
+    custom_widget_invocation: Option<Rc<CustomWidgetInvocation>>,
+) -> Result<()> {
+    tree.register_listener(
+        calling_scope,
+        Listener {
+            needed_variables: widget_use.elements_expr.collect_var_refs(),
+            f: Box::new({
+                let custom_widget_invocation = custom_widget_invocation.clone();
+                let widget_defs = widget_defs.clone();
+                let elements_expr = widget_use.elements_expr.clone();
+                let elements_expr_span = widget_use.elements_expr_span.clone();
+                let element_name = widget_use.element_name.clone();
+                let body: WidgetUse = widget_use.body.as_ref().clone();
+                let created_children = Rc::new(RefCell::new(Vec::<gtk::Widget>::new()));
+                let gtk_container = gtk_container.clone();
+                move |tree, values| {
+                    let elements_value = elements_expr
+                        .eval(&values)?
+                        .as_json_value()?
+                        .as_array()
+                        .context("Not an array value")?
+                        .into_iter()
+                        .map(DynVal::from)
+                        .collect_vec();
+                    let mut created_children = created_children.borrow_mut();
+                    for old_child in created_children.drain(..) {
+                        unsafe { old_child.destroy() };
+                    }
+                    for element in elements_value {
+                        let scope = tree.register_new_scope(
+                            format!("for {} = {}", element_name.0, element),
+                            Some(calling_scope),
+                            calling_scope,
+                            hashmap! {
+                                element_name.clone().into() => SimplExpr::Literal(DynVal(element.0, elements_expr_span))
+                            },
+                        )?;
+                        let new_child_widget =
+                            build_gtk_widget(tree, widget_defs.clone(), scope, body.clone(), custom_widget_invocation.clone())?;
+                        gtk_container.add(&new_child_widget);
+                        created_children.push(new_child_widget);
+                    }
+
+                    Ok(())
+                }
+            }),
+        },
+    )
 }
 
 /// Handle an invocation of the special `children` [`WidgetUse`].
@@ -187,13 +278,12 @@ fn build_children_special_widget(
     tree: &mut ScopeGraph,
     widget_defs: Rc<HashMap<String, WidgetDefinition>>,
     calling_scope: ScopeIndex,
-    mut widget_use: WidgetUse,
+    widget_use: ChildrenWidgetUse,
     gtk_container: &gtk::Container,
     custom_widget_invocation: Rc<CustomWidgetInvocation>,
 ) -> Result<()> {
-    assert_eq!(&widget_use.name, "children");
-
-    if let Some(nth) = widget_use.attrs.ast_optional::<SimplExpr>("nth")? {
+    if let Some(nth) = widget_use.nth_expr {
+        // TODORW this might not be necessary, if I can keep a copy of the widget I can destroy it directly, no need to go through the container.
         // This should be a custom gtk::Bin subclass,..
         let child_container = gtk::Box::new(Orientation::Horizontal, 0);
         child_container.set_homogeneous(true);
@@ -250,7 +340,7 @@ pub struct CustomWidgetInvocation {
 }
 
 /// Make sure that [`gtk::Bin`] widgets only get a single child.
-fn validate_container_children_count(container: &gtk::Container, widget_use: &WidgetUse) -> Result<(), DiagError> {
+fn validate_container_children_count(container: &gtk::Container, widget_use: &BasicWidgetUse) -> Result<(), DiagError> {
     if container.dynamic_cast_ref::<gtk::Bin>().is_some() && widget_use.children.len() > 1 {
         Err(DiagError::new(gen_diagnostic! {
             kind =  Severity::Error,

--- a/crates/simplexpr/src/dynval.rs
+++ b/crates/simplexpr/src/dynval.rs
@@ -185,6 +185,7 @@ impl DynVal {
         }
     }
 
+    // TODO this should return Result<Vec<DynVal>> and use json parsing
     pub fn as_vec(&self) -> Result<Vec<String>> {
         if self.0.is_empty() {
             Ok(Vec::new())

--- a/crates/yuck/src/error.rs
+++ b/crates/yuck/src/error.rs
@@ -170,13 +170,17 @@ pub enum FormFormatError {
 
     #[error("Widget definition has more than one child widget")]
     WidgetDefMultipleChildren(Span),
+
+    #[error("Expected 'in' in this position, but got '{}'", .1)]
+    ExpectedInInForLoop(Span, String),
 }
 
 impl Spanned for FormFormatError {
     fn span(&self) -> Span {
         match self {
-            FormFormatError::WidgetDefArglistMissing(span) => *span,
-            FormFormatError::WidgetDefMultipleChildren(span) => *span,
+            FormFormatError::WidgetDefArglistMissing(span)
+            | FormFormatError::WidgetDefMultipleChildren(span)
+            | FormFormatError::ExpectedInInForLoop(span, _) => *span,
         }
     }
 }

--- a/crates/yuck/src/format_diagnostic.rs
+++ b/crates/yuck/src/format_diagnostic.rs
@@ -298,6 +298,10 @@ impl ToDiagnostic for FormFormatError {
                         To include multiple elements, wrap these elements in a single container widget such as `box`.\n\
                         This is necessary as eww can't know how you want these elements to be layed out otherwise."
             },
+            FormFormatError::ExpectedInInForLoop(span, got) => gen_diagnostic! {
+                msg = self,
+                label = span,
+            },
         }
     }
 }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -239,7 +239,7 @@ For this, you can make use of one of eww's most powerful features: the `literal`
 (defvar variable_containing_yuck
   "(box (button 'foo') (button 'bar'))")
 
-; then, inside your widget, use:
+; Then, inside your widget, use:
 (literal :content variable_containing_yuck)
 ```
 
@@ -247,6 +247,22 @@ Here, you specify the content of your literal by providing it a string (most lik
 Eww then reads the provided value and renders the resulting widget. Whenever it changes, the widget will be rerendered.
 
 Note that this is not all that efficient. Make sure to only use `literal` when necessary!
+
+## Generating a list of widgets from JSON using `for`
+
+If you want to display a list of values, you can use the `for`-Element to fill a container with a list of elements generated from a JSON-array.
+```lisp
+(defvar my-json "[1, 2, 3]")
+
+; Then, inside your widget, you can use
+(box
+  (for entry in my-json
+    (button :onclick "notify-send 'click' 'button ${entry}'"
+      entry)))
+```
+
+This can be useful in many situations, for example when generating a workspace list from a JSON representation of your workspaces.
+In many cases, this can be used instead of `literal`, and should most likely be preferred in those cases.
 
 ## Splitting up your configuration
 


### PR DESCRIPTION
This PR adds a new special widget: `for`.
This widget allows you to iterate over a json list of data, rendering a new widget child for each element.

This could be used like this, for example:
```lisp
(defwidget workspaces []
  (box
    (for wsp in workspaces
      (button :class {wsp.state}
              :onclick "wmctrl -s ${wsp.id}"
        "[${wsp.name}]"))))
```

To achieve this, we restructure the WidgetUse struct to be an enum that may be a basic widgetuse
(which is what prior to this PR, all widgetUse instances where), or some special WidgetUse such as Children or Loop

Still todo:
- [ ] some testing
- [x] Documentation
