### PR TITLE
Remove unindent crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "unescape",
- "unindent",
  "wait-timeout",
  "x11rb",
  "yuck",
@@ -2287,12 +2286,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "unindent"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "uuid"

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -53,7 +53,6 @@ nix = "0.20"
 smart-default = "0.6"
 simple-signal = "1.1"
 unescape = "0.1"
-unindent = "0.1"
 
 tokio = { version = "1.0", features = ["full"] }
 futures-core = "0.3"

--- a/crates/eww/src/util.rs
+++ b/crates/eww/src/util.rs
@@ -1,4 +1,5 @@
 use anyhow::*;
+use std::fmt::Write;
 use extend::ext;
 use itertools::Itertools;
 use std::path::Path;
@@ -155,9 +156,26 @@ pub fn replace_env_var_references(input: String) -> String {
         .into_owned()
 }
 
+pub fn unindent(text: &str) -> String {
+    // take all the lines of our text and skip over the first empty ones
+    let lines = text.lines().skip_while(|x| *x == "");
+    // find the smallest indentation
+    let min = lines.clone().fold(None, |min, line| {
+        let min = min.unwrap_or(usize::MAX);
+        Some(min.min(line.chars().take(min).take_while(|&c| c == ' ').count()))
+    }).unwrap_or(0);
+
+    let mut result = String::new();
+    for i in lines {
+        writeln!(result, "{}", &i[min..]).expect("Something went wrong unindenting the string");
+    }
+    result.pop();
+    result
+}
+
 #[cfg(test)]
 mod test {
-    use super::replace_env_var_references;
+    use super::{replace_env_var_references, unindent};
     use std;
 
     #[test]
@@ -168,5 +186,13 @@ mod test {
             replace_env_var_references(String::from(scss)),
             format!("$test: {};", std::env::var("USER").unwrap_or_default())
         )
+    }
+
+    #[test]
+    fn test_unindent() {
+        let indented = "
+            line one
+            line two";
+        assert_eq!("line one\nline two", unindent(indented));
     }
 }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::option_map_unit_fn)]
 use super::{build_widget::BuilderArgs, circular_progressbar::*, run_command};
 use crate::{
-    def_widget, enum_parse, error::DiagError, error_handling_ctx, util::list_difference, widgets::build_widget::build_gtk_widget,
+    def_widget, enum_parse, error::DiagError, error_handling_ctx, util::{list_difference, unindent}, widgets::build_widget::build_gtk_widget,
 };
 use anyhow::*;
 use codespan_reporting::diagnostic::Severity;
@@ -600,7 +600,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
             }
 
             let text = unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))?;
-            let text = unindent::unindent(&text);
+            let text = unindent(&text);
             gtk_widget.set_text(&text);
         },
         // @prop markup - Pango markup to display


### PR DESCRIPTION
We should start cutting down on dependencies, should [improve security](https://kerkour.com/rust-crate-backdoor/) and compile times. This one was also fun to optimize as much as possible