### PR TITLE
Added gtk-layer-shell as a dependency in the docs

### DIFF
--- a/docs/src/eww.md
+++ b/docs/src/eww.md
@@ -27,6 +27,7 @@ The following list of package names should work for arch linux:
 <summary>Packages</summary>
 
 - gtk3 (libgdk-3, libgtk-3)
+- gtk-layer-shell
 - pango (libpango)
 - gdk-pixbuf2 (libgdk_pixbuf-2)
 - cairo (libcairo, libcairo-gobject)

--- a/docs/src/eww.md
+++ b/docs/src/eww.md
@@ -27,7 +27,7 @@ The following list of package names should work for arch linux:
 <summary>Packages</summary>
 
 - gtk3 (libgdk-3, libgtk-3)
-- gtk-layer-shell
+- gtk-layer-shell (only on Wayland)
 - pango (libpango)
 - gdk-pixbuf2 (libgdk_pixbuf-2)
 - cairo (libcairo, libcairo-gobject)


### PR DESCRIPTION
gtk-layer-shell is a required dependency but is not listed in the docs. This pull request adds gtk-layer-shell to the list of dependencies in the docs.

Closes #370