### PR TITLE
fix: limit ipc socket filename length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,6 @@ name = "eww"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "base64",
  "bincode",
  "cairo-rs",
  "cairo-sys-rs",

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -62,7 +62,6 @@ tokio-util = "0.6"
 sysinfo = "0.16.1"
 
 dyn-clone = "1.0"
-base64 = "0.13"
 wait-timeout = "0.2"
 
 notify = "5.0.0-pre.7"

--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -219,16 +219,23 @@ impl EwwPaths {
         // the absolute path to the socket stays under the 108 bytes limit. (see #387, man 7 unix)
         let daemon_id = format!("{:x}", hasher.finish());
 
+        let ipc_socket_file = std::env::var("XDG_RUNTIME_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"))
+            .join(format!("eww-server_{}", daemon_id));
+
+        // 100 as the limit isn't quite 108 everywhere (i.e 104 on BSD or mac)
+        if format!("{}", ipc_socket_file.display()).len() > 100 {
+            log::warn!("The IPC socket file's absolute path exceeds 100 bytes, the socket may fail to create.");
+        }
+
         Ok(EwwPaths {
             config_dir,
             log_file: std::env::var("XDG_CACHE_HOME")
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| PathBuf::from(std::env::var("HOME").unwrap()).join(".cache"))
                 .join(format!("eww_{}.log", daemon_id)),
-            ipc_socket_file: std::env::var("XDG_RUNTIME_DIR")
-                .map(std::path::PathBuf::from)
-                .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"))
-                .join(format!("eww-server_{}", daemon_id)),
+            ipc_socket_file,
         })
     }
 

--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -210,7 +210,10 @@ impl EwwPaths {
         }
 
         let config_dir = config_dir.canonicalize()?;
-        let daemon_id = base64::encode(format!("{}", config_dir.display()));
+
+        let mut daemon_id = base64::encode(format!("{}", config_dir.display()));
+        // truncate to avoid hitting the 108 char max name length for unix sockets (man 7 unix)
+        daemon_id.truncate(90);
 
         Ok(EwwPaths {
             config_dir,


### PR DESCRIPTION
## Description

This PR changes how the ipc socket file is named to make sure that it doesn't exceed the 108 bytes limit for socket filenames on linux, which could be hit with a long configuration path.

This is done by changing how `daemon_id` (variable dictating the eww log and ipc socket filenames) is made: by hashing the config directory path instead of base64 encoding it.

### Additional Notes

This also adds a warning when the path still ends up longer than 100 bytes, in the (**very**) rare case that someone changed their `XDG_RUNTIME_DIR` to something pretty long.

## Checklist

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing

> This is probably not a notable change.

### Tested

 - [x] compiling
 - [x] running the daemon
 - [x] sending commands (opening and closing windows)  
