### PR TITLE
Resolves #247 implement scroll widget

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -67,6 +67,7 @@ pub(super) fn widget_use_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::W
         "combo-box-text" => build_gtk_combo_box_text(bargs)?.upcast(),
         "checkbox" => build_gtk_checkbox(bargs)?.upcast(),
         "revealer" => build_gtk_revealer(bargs)?.upcast(),
+        "scroll" => build_gtk_scrolledwindow(bargs)?.upcast(),
         _ => {
             return Err(AstError::ValidationError(ValidationError::UnknownWidget(
                 bargs.widget_use.name_span,
@@ -500,6 +501,26 @@ fn build_center_box(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
             Ok(gtk_widget)
         }
     }
+}
+
+/// @widget scroll
+/// @desc a container with a single child that can scroll.
+fn build_gtk_scrolledwindow(bargs: &mut BuilderArgs) -> Result<gtk::ScrolledWindow> {
+    // I don't have single idea of what those two generics are supposed to be, but this works.
+    let gtk_widget = gtk::ScrolledWindow::new::<gtk::Adjustment, gtk::Adjustment>(None, None);
+
+    def_widget!(bargs, _g, gtk_widget, {
+        // @prop hscroll - scroll horizontally
+        // @prop vscroll - scroll vertically
+        prop(hscroll: as_bool = true, vscroll: as_bool = true) {
+            gtk_widget.set_policy(
+                if hscroll { gtk::PolicyType::Automatic } else { gtk::PolicyType::Never },
+                if vscroll { gtk::PolicyType::Automatic } else { gtk::PolicyType::Never },
+            )
+        },
+    });
+
+    Ok(gtk_widget)
 }
 
 /// @widget eventbox


### PR DESCRIPTION
## Description

This PR adds the `scroll` widget.

## Usage

The scroll widget lets **its** child be scrolled if it overflows its parent's width / height (as set by the `:width` / `:height` props).
The `:hscroll` and `:vscroll` props are booleans dictating whether can scroll vertically and/or horizontally, defaults to `true`.

### Showcase

The following config:

```yuck
(defwindow test
  :monitor 0
  :geometry (geometry :x 0
              :y 0
              :width "100px"
              :height "100px"
              :anchor "center")
  (scroll :hscroll false
    :width "100"
    :height "100"
    (box :space-evenly false
                :orientation "v"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
    "TEST TEST TEST TEST TEST TEST TEST TEST"
  )))
```

Gives a window with a height of 100px (because the body of the box is cut and a scrollbar is added), and a width determined by the width of the box, because the `hscroll` property is set to `false`.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [x] I used `cargo fmt` to automatically format all code before committing
