### PR TITLE
Added desktop window type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add support for `:hover` css selectors for eventbox (By: druskus20)
 - Add `eww get` subcommand (By: druskus20)
 - Add circular progress widget (By: druskus20)
+- Add `desktop` window type (By: Alvaro Lopez)
 
 ### Notable Internal changes
 - Rework state management completely, now making local state and dynamic widget hierarchy changes possible.

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -213,6 +213,7 @@ mod platform {
                     WindowType::Dialog => self.atoms._NET_WM_WINDOW_TYPE_DIALOG,
                     WindowType::Toolbar => self.atoms._NET_WM_WINDOW_TYPE_TOOLBAR,
                     WindowType::Utility => self.atoms._NET_WM_WINDOW_TYPE_UTILITY,
+                    WindowType::Desktop => self.atoms._NET_WM_WINDOW_TYPE_DESKTOP,
                 }],
             )?
             .check()?;
@@ -229,6 +230,7 @@ mod platform {
             _NET_WM_WINDOW_TYPE_DIALOG,
             _NET_WM_WINDOW_TYPE_TOOLBAR,
             _NET_WM_WINDOW_TYPE_UTILITY,
+            _NET_WM_WINDOW_TYPE_DESKTOP,
             _NET_WM_STATE,
             _NET_WM_STATE_STICKY,
             _NET_WM_STATE_ABOVE,

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -47,6 +47,7 @@ mod backend {
         Toolbar,
         Normal,
         Utility,
+        Desktop,
     }
     impl FromStr for WindowType {
         type Err = EnumParseError;
@@ -58,6 +59,7 @@ mod backend {
                 "dialog" => Self::Dialog,
                 "normal" => Self::Normal,
                 "utility" => Self::Utility,
+                "desktop" => Self::Desktop,
             }
         }
     }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -72,7 +72,7 @@ Depending on if you are using X11 or Wayland, some additional properties exist:
 |   `stacking` | Where the window should appear in the stack. Possible values: `fg`, `bg`. |
 |  `wm-ignore` | Whether the window manager should ignore this window. This is useful for dashboard-style widgets that don't need to interact with other windows at all. Note that this makes some of the other properties not have any effect. Either `true` or `false`. |
 |    `reserve` | Specify how the window manager should make space for your window. This is useful for bars, which should not overlap any other windows. |
-| `windowtype` | Specify what type of window this is. This will be used by your window manager to determine how it should handle your window. Possible values: `normal`, `dock`, `toolbar`, `dialog`. Default: `dock` if `reserve` is specified, `normal` otherwise. |
+| `windowtype` | Specify what type of window this is. This will be used by your window manager to determine how it should handle your window. Possible values: `normal`, `dock`, `toolbar`, `dialog`, `desktop`. Default: `dock` if `reserve` is specified, `normal` otherwise. |
 
 #### Wayland
 


### PR DESCRIPTION
## Description

I added a "desktop" window type, which always stays visible.

## Usage

It can be used just like the rest of window types.
```
(defwindow example
  :windowtype "desktop"
  :stacking "bg"
  :monitor 0

...
```

## Additional Notes

This was a quick and dirty job. Feel free to change anything.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
