### PR TITLE
EWW_BATTERY is empty string when its {total_avg} property would be NaN

### DIFF
--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -149,9 +149,11 @@ pub fn get_battery_capacity() -> Result<String> {
             }
         }
     }
-    json.pop();
-    json.push_str(&format!(r#", "total_avg": {:.1}}}"#, (current / total) * 100_f64));
+    if total == 0_f64 {
+        return Ok(String::from(""));
+    }
 
+    json.push_str(&format!(r#" "total_avg": {:.1}}}"#, (current / total) * 100_f64));
     Ok(json)
 }
 


### PR DESCRIPTION
Fixes #373

I followed [the suggestion in this comment](https://github.com/elkowar/eww/issues/373#issuecomment-997439825) from [the linked issue](https://github.com/elkowar/eww/issues/373).

> IMHO it should just completely be null then, when there is no battery, there isn't much use to having the json values in the first place.

## Description

`EWW_BATTERY` will be `{ total_avg: ... }` or `""` if `total_avg` would otherwise have been `NaN`, which can occur if the path `/sys/class/power_supply` is empty.

## Usage

```
(defwidget battery []
  (box :class "battery"
    {EWW_BATTERY == "" ? "" : EWW_BATTERY.total_avg}))
```

## Additional Notes

I removed [`json.pop()`](https://github.com/elkowar/eww/blob/ee07598a039e191239a143407bf934b3781ee675/crates/eww/src/config/system_stats.rs#L152), because I believe it always removed "," only to add it back in the next line. which I removed as well.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
