### PR TITLE
fixes #424 allow tabs in simplexpr

### DIFF
--- a/crates/simplexpr/src/parser/lexer.rs
+++ b/crates/simplexpr/src/parser/lexer.rs
@@ -106,8 +106,7 @@ regex_rules! {
     escape(r"true")  => |_| Token::True,
     escape(r"false") => |_| Token::False,
 
-    // Why two \n ?
-    r"[ \t\n\n\f]+" => |_| Token::Skip,
+    r"\s+" => |_| Token::Skip,
     r";.*"=> |_| Token::Comment,
 
     r"[a-zA-Z_][a-zA-Z0-9_-]*" => |x| Token::Ident(x),

--- a/crates/simplexpr/src/parser/lexer.rs
+++ b/crates/simplexpr/src/parser/lexer.rs
@@ -106,7 +106,8 @@ regex_rules! {
     escape(r"true")  => |_| Token::True,
     escape(r"false") => |_| Token::False,
 
-    r"[ \n\n\f]+" => |_| Token::Skip,
+    // Why two \n ?
+    r"[ \t\n\n\f]+" => |_| Token::Skip,
     r";.*"=> |_| Token::Comment,
 
     r"[a-zA-Z_][a-zA-Z0-9_-]*" => |x| Token::Ident(x),


### PR DESCRIPTION
Please follow this template, if applicable.

## Description

Allow tabs in simplexpr

## Additional Notes

Why is `\n` put twice into the skip regex in `lexer.rs` ? Should I remove one ?

## Checklist

- [x] I used `cargo fmt` to automatically format all code before committing
