### PR TITLE
Add window arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Remove `eww windows` command, replace with `eww active-windows` and `eww list-windows`
+
 ### Features
 - Add `:namespace` window option
 - Default to building with x11 and wayland support simultaneously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `:onaccept` to input field, add `:onclick` to eventbox
 - Add `EWW_CMD`, `EWW_CONFIG_DIR`, `EWW_EXECUTABLE` magic variables
 - Add `overlay` widget (By: viandoxdev)
+- Add arguments option to `defwindow` (By: WilfSilver)
 
 ### Notable Internal changes
 - Rework state management completely, now making local state and dynamic widget hierarchy changes possible.

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -18,7 +18,7 @@ use gdk::Monitor;
 use glib::ObjectExt;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
-use simplexpr::dynval::DynVal;
+use simplexpr::{dynval::DynVal, SimplExpr};
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
@@ -85,6 +85,9 @@ pub enum DaemonCommand {
 /// An opened window.
 #[derive(Debug)]
 pub struct EwwWindow {
+    /// Every window has an id, uniquely identifying it.
+    /// If no specific ID was specified whilst starting the window,
+    /// this will be the same as the window name.
     pub instance_id: String,
     pub name: String,
     pub scope_index: ScopeIndex,
@@ -135,7 +138,7 @@ impl<B> std::fmt::Debug for App<B> {
             .field("eww_config", &self.eww_config)
             .field("open_windows", &self.open_windows)
             .field("failed_windows", &self.failed_windows)
-            .field("window_argumentss", &self.window_argumentss)
+            .field("window_arguments", &self.window_argumentss)
             .field("paths", &self.paths)
             .finish()
     }
@@ -195,15 +198,10 @@ impl<B: DisplayBackend> App<B> {
                                 self.close_window(id)
                             } else {
                                 log::debug!("Config: {}, id: {}", config_name, id);
-                                let window_args: Vec<(VarName, DynVal)> = args
+                                let window_args = args
                                     .iter()
-                                    .filter_map(|(win_id, n, v)| {
-                                        if win_id.is_empty() || win_id == id {
-                                            Some((n.clone(), v.clone()))
-                                        } else {
-                                            None
-                                        }
-                                    })
+                                    .filter(|(win_id, ..)| win_id.is_empty() || win_id == id)
+                                    .map(|(_, n, v)| (n.clone(), v.clone()))
                                     .collect();
                                 self.open_window(&WindowArguments::new_from_args(
                                     id.to_string(),
@@ -227,23 +225,23 @@ impl<B: DisplayBackend> App<B> {
                     sender,
                     args,
                 } => {
-                    let id = instance_id.unwrap_or_else(|| window_name.clone());
+                    let instance_id = instance_id.unwrap_or_else(|| window_name.clone());
 
-                    let is_open = self.open_windows.contains_key(&id);
+                    let is_open = self.open_windows.contains_key(&instance_id);
 
                     let result = if should_toggle && is_open {
-                        self.close_window(&id)
+                        self.close_window(&instance_id)
                     } else {
-                        self.open_window(&WindowArguments::new(
-                            id,
+                        self.open_window(&WindowArguments {
+                            instance_id,
                             window_name,
                             pos,
                             size,
                             monitor,
                             anchor,
                             duration,
-                            args.unwrap_or_default(),
-                        ))
+                            args: args.unwrap_or_default().into_iter().collect(),
+                        })
                     };
 
                     sender.respond_with_result(result)?;
@@ -350,7 +348,7 @@ impl<B: DisplayBackend> App<B> {
         let eww_window = self
             .open_windows
             .remove(instance_id)
-            .with_context(|| format!("Tried to close window named '{}', but no such window was open", instance_id))?;
+            .with_context(|| format!("Tried to close window with id '{instance_id}', but no such window was open"))?;
 
         let scope_index = eww_window.scope_index;
         eww_window.close();
@@ -369,9 +367,9 @@ impl<B: DisplayBackend> App<B> {
     }
 
     fn open_window(&mut self, window_args: &WindowArguments) -> Result<()> {
-        let instance_id = &window_args.id;
+        let instance_id = &window_args.instance_id;
         self.failed_windows.remove(instance_id);
-        log::info!("Opening window {} as '{}'", window_args.config_name, instance_id);
+        log::info!("Opening window {} as '{}'", window_args.window_name, instance_id);
 
         // if an instance of this is already running, close it
         if self.open_windows.contains_key(instance_id) {
@@ -381,7 +379,7 @@ impl<B: DisplayBackend> App<B> {
         self.window_argumentss.insert(instance_id.to_string(), window_args.clone());
 
         let open_result: Result<_> = try {
-            let window_name: &str = &window_args.config_name;
+            let window_name: &str = &window_args.window_name;
 
             let window_def = self.eww_config.get_window(window_name)?.clone();
             assert_eq!(window_def.name, window_name, "window definition name did not equal the called window");
@@ -390,11 +388,13 @@ impl<B: DisplayBackend> App<B> {
 
             let root_index = self.scope_graph.borrow().root_index;
 
+            let scoped_vars_literal = initiator.get_scoped_vars().into_iter().map(|(k, v)| (k, SimplExpr::Literal(v))).collect();
+
             let window_scope = self.scope_graph.borrow_mut().register_new_scope(
                 instance_id.to_string(),
                 Some(root_index),
                 root_index,
-                initiator.get_scoped_vars(),
+                scoped_vars_literal,
             )?;
 
             let root_widget = crate::widgets::build_widget::build_gtk_widget(
@@ -407,7 +407,7 @@ impl<B: DisplayBackend> App<B> {
 
             root_widget.style_context().add_class(window_name);
 
-            let monitor = get_monitor(initiator.monitor.clone())?;
+            let monitor = get_gdk_monitor(initiator.monitor.clone())?;
             let mut eww_window = initialize_window::<B>(&initiator, monitor, root_widget, window_scope)?;
             eww_window.gtk_window.style_context().add_class(window_name);
 
@@ -487,19 +487,13 @@ impl<B: DisplayBackend> App<B> {
         self.eww_config = config;
         self.scope_graph.borrow_mut().clear(self.eww_config.generate_initial_state()?);
 
-        let instances: Vec<String> =
+        let open_window_ids: Vec<String> =
             self.open_windows.keys().cloned().chain(self.failed_windows.iter().cloned()).dedup().collect();
-        let initiators = self.window_argumentss.clone();
-        for instance_id in &instances {
-            let window_arguments;
-            match initiators.get(instance_id) {
-                Some(x) => window_arguments = x,
-                None => {
-                    return Err(anyhow!("Cannot reopen window, initial parameters were not saved correctly for {}", instance_id))
-                }
-            };
-
-            self.open_window(window_arguments)?;
+        for instance_id in &open_window_ids {
+            let window_arguments = self.window_argumentss.get(instance_id).with_context(|| {
+                format!("Cannot reopen window, initial parameters were not saved correctly for {instance_id}")
+            })?;
+            self.open_window(&window_arguments.clone())?;
         }
         Ok(())
     }
@@ -610,7 +604,7 @@ fn on_screen_changed(window: &gtk::Window, _old_screen: Option<&gdk::Screen>) {
 }
 
 /// Get the monitor geometry of a given monitor, or the default if none is given
-fn get_monitor(identifier: Option<MonitorIdentifier>) -> Result<Monitor> {
+fn get_gdk_monitor(identifier: Option<MonitorIdentifier>) -> Result<Monitor> {
     let display = gdk::Display::default().expect("could not get default display");
     let monitor = match identifier {
         Some(ident) => {

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -171,12 +171,7 @@ mod platform_x11 {
             Ok(X11BackendConnection { conn, root_window: screen.root, atoms })
         }
 
-        fn set_xprops_for(
-            &self,
-            window: &gtk::Window,
-            monitor: Monitor,
-            window_init: &WindowInitiator,
-        ) -> Result<()> {
+        fn set_xprops_for(&self, window: &gtk::Window, monitor: Monitor, window_init: &WindowInitiator) -> Result<()> {
             let monitor_rect = monitor.geometry();
             let scale_factor = monitor.scale_factor() as u32;
             let gdk_window = window.window().context("Couldn't get gdk window from gtk window")?;
@@ -191,8 +186,8 @@ mod platform_x11 {
             let mon_end_y = scale_factor * (monitor_rect.y() + monitor_rect.height()) as u32 - 1u32;
 
             let dist = match strut_def.side {
-                Side::Left | Side::Right => strut_def.dist.pixels_relative_to(monitor_rect.width()) as u32,
-                Side::Top | Side::Bottom => strut_def.dist.pixels_relative_to(monitor_rect.height()) as u32,
+                Side::Left | Side::Right => strut_def.distance.pixels_relative_to(monitor_rect.width()) as u32,
+                Side::Top | Side::Bottom => strut_def.distance.pixels_relative_to(monitor_rect.height()) as u32,
             };
 
             // don't question it,.....

--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -36,6 +36,8 @@ mod server;
 mod state;
 mod util;
 mod widgets;
+mod window_arguments;
+mod window_initiator;
 
 fn main() {
     let eww_binary_name = std::env::args().next().unwrap();

--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -4,6 +4,7 @@
 #![feature(slice_concat_trait)]
 #![feature(try_blocks)]
 #![feature(hash_extract_if)]
+#![feature(let_chains)]
 #![allow(rustdoc::private_intra_doc_links)]
 
 extern crate gtk;

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -179,9 +179,13 @@ pub enum ActionWithServer {
     #[command(name = "get")]
     GetVar { name: String },
 
-    /// Print the names of all configured windows. Windows with a * in front of them are currently opened.
-    #[command(name = "windows")]
-    ShowWindows,
+    /// List the names of active windows
+    #[command(name = "list-windows")]
+    ListWindows,
+
+    /// Show active window IDs, formatted linewise `<window_id>: <window_name>`
+    #[command(name = "active-windows")]
+    ListActiveWindows,
 
     /// Print out the widget structure as seen by eww.
     ///
@@ -273,7 +277,8 @@ impl ActionWithServer {
                 return with_response_channel(|sender| app::DaemonCommand::CloseWindows { windows, sender });
             }
             ActionWithServer::Reload => return with_response_channel(app::DaemonCommand::ReloadConfigAndCss),
-            ActionWithServer::ShowWindows => return with_response_channel(app::DaemonCommand::PrintWindows),
+            ActionWithServer::ListWindows => return with_response_channel(app::DaemonCommand::ListWindows),
+            ActionWithServer::ListActiveWindows => return with_response_channel(app::DaemonCommand::ListActiveWindows),
             ActionWithServer::ShowState { all } => {
                 return with_response_channel(|sender| app::DaemonCommand::PrintState { all, sender })
             }

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -226,7 +226,7 @@ fn parse_window_id_args(s: &str) -> Result<(String, VarName, DynVal)> {
     // Parse the = first so we know if an id has not been given
     let (name, value) = parse_var_update_arg(s)?;
 
-    let (id, var_name) = (&name.0).split_once(':').unwrap_or((&"", &name.0));
+    let (id, var_name) = name.0.split_once(':').unwrap_or(("", &name.0));
 
     Ok((id.to_string(), var_name.into(), value))
 }

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -81,7 +81,7 @@ pub fn initialize_server<B: DisplayBackend>(
         eww_config,
         open_windows: HashMap::new(),
         failed_windows: HashSet::new(),
-        window_argumentss: HashMap::new(),
+        instance_id_to_args: HashMap::new(),
         css_provider: gtk::CssProvider::new(),
         script_var_handler,
         app_evt_send: ui_send.clone(),

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -81,6 +81,7 @@ pub fn initialize_server<B: DisplayBackend>(
         eww_config,
         open_windows: HashMap::new(),
         failed_windows: HashSet::new(),
+        window_argumentss: HashMap::new(),
         css_provider: gtk::CssProvider::new(),
         script_var_handler,
         app_evt_send: ui_send.clone(),

--- a/crates/eww/src/window_arguments.rs
+++ b/crates/eww/src/window_arguments.rs
@@ -77,8 +77,7 @@ impl WindowArguments {
         }
 
         if local_variables.len() != window_def.expected_args.len() {
-            let unexpected_vars: Vec<_> =
-                local_variables.iter().map(|(name, _)| name.clone()).filter(|n| !expected_args.contains(&n.0)).collect();
+            let unexpected_vars: Vec<_> = local_variables.keys().cloned().filter(|n| !expected_args.contains(&n.0)).collect();
             bail!(
                 "variables {} unexpectedly defined when creating window with id '{}'",
                 unexpected_vars.join(", "),

--- a/crates/eww/src/window_arguments.rs
+++ b/crates/eww/src/window_arguments.rs
@@ -1,0 +1,122 @@
+use anyhow::{anyhow, Context, Result};
+use eww_shared_util::VarName;
+use simplexpr::dynval::DynVal;
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
+use yuck::{
+    config::{monitor::MonitorIdentifier, window_definition::WindowDefinition, window_geometry::AnchorPoint},
+    value::Coords,
+};
+
+fn extract_value_from_args(name: &str, args: &mut Vec<(VarName, DynVal)>) -> Option<DynVal> {
+    let var_name = name.to_string();
+    let pos = args.iter().position(|(n, _)| n.0 == var_name);
+
+    if let Some(unwrapped_pos) = pos {
+        let (_, val) = args.remove(unwrapped_pos);
+        Some(val)
+    } else {
+        None
+    }
+}
+
+fn parse_value_from_args<T: FromStr>(name: &str, args: &mut Vec<(VarName, DynVal)>) -> Result<Option<T>, T::Err> {
+    extract_value_from_args(name, args).map(|x| FromStr::from_str(&x.as_string().unwrap())).transpose()
+}
+
+/// This stores the arguments given in the command line to create a window
+/// While creating a window, we combine this with information from the
+/// WindowDefinition to create a WindowInitiator, which stores all the
+/// information required to start a window
+#[derive(Debug, Clone)]
+pub struct WindowArguments {
+    pub anchor: Option<AnchorPoint>,
+    pub args: Vec<(VarName, DynVal)>,
+    pub config_name: String,
+    pub duration: Option<std::time::Duration>,
+    pub id: String,
+    pub monitor: Option<MonitorIdentifier>,
+    pub pos: Option<Coords>,
+    pub size: Option<Coords>,
+}
+
+impl WindowArguments {
+    pub fn new(
+        id: String,
+        config_name: String,
+        pos: Option<Coords>,
+        size: Option<Coords>,
+        monitor: Option<MonitorIdentifier>,
+        anchor: Option<AnchorPoint>,
+        duration: Option<std::time::Duration>,
+        args: Vec<(VarName, DynVal)>,
+    ) -> Self {
+        WindowArguments { id, config_name, pos, size, monitor, anchor, duration, args }
+    }
+
+    pub fn new_from_args(id: String, config_name: String, mut args: Vec<(VarName, DynVal)>) -> Result<Self> {
+        let initiator = WindowArguments {
+            config_name,
+            id,
+            pos: parse_value_from_args::<Coords>("pos", &mut args)?,
+            size: parse_value_from_args::<Coords>("size", &mut args)?,
+            monitor: parse_value_from_args::<MonitorIdentifier>("screen", &mut args)?,
+            anchor: parse_value_from_args::<AnchorPoint>("anchor", &mut args)?,
+            duration: extract_value_from_args("duration", &mut args)
+                .map(|x| x.as_duration())
+                .transpose()
+                .context("Not a valid duration")?,
+            args,
+        };
+
+        Ok(initiator)
+    }
+
+    pub fn get_local_window_variables(&self, window_def: &WindowDefinition) -> Result<HashMap<VarName, DynVal>> {
+        let expected_args: HashSet<&String> = window_def.expected_args.iter().map(|x| &x.name.0).collect();
+        let mut local_variables: HashMap<VarName, DynVal> = HashMap::new();
+
+        // Inserts these first so they can be overridden
+        if expected_args.contains(&"id".to_string()) {
+            local_variables.insert(VarName::from("id"), DynVal::from(self.id.clone()));
+        }
+        if self.monitor.is_some() && expected_args.contains(&"screen".to_string()) {
+            let mon_dyn = self.monitor.clone().unwrap().to_dynval();
+            local_variables.insert(VarName::from("screen"), mon_dyn);
+        }
+
+        local_variables.extend(self.args.clone());
+
+        for attr in &window_def.expected_args {
+            let name = VarName::from(attr.name.clone());
+
+            // This is here to get around the map_entry warning
+            let mut inserted = false;
+            local_variables.entry(name).or_insert_with(|| {
+                inserted = true;
+                DynVal::from_string(String::new())
+            });
+
+            if inserted && !attr.optional {
+                return Err(anyhow!("Error, {} was required when creating {} but was not given", attr.name, self.config_name));
+            }
+        }
+
+        if local_variables.len() != window_def.expected_args.len() {
+            let unexpected_vars: Vec<VarName> = local_variables
+                .iter()
+                .filter_map(|(n, _)| if !expected_args.contains(&n.0) { Some(n.clone()) } else { None })
+                .collect();
+            return Err(anyhow!(
+                "'{}' {} unexpectedly defined when creating window {}",
+                unexpected_vars.join(","),
+                if unexpected_vars.len() == 1 { "was" } else { "were" },
+                self.config_name
+            ));
+        }
+
+        Ok(local_variables)
+    }
+}

--- a/crates/eww/src/window_arguments.rs
+++ b/crates/eww/src/window_arguments.rs
@@ -10,12 +10,8 @@ use yuck::{
     value::Coords,
 };
 
-pub fn extract_value_from_args(name: &str, args: &mut HashMap<VarName, DynVal>) -> Option<DynVal> {
-    args.remove(&VarName(name.to_string()))
-}
-
 fn parse_value_from_args<T: FromStr>(name: &str, args: &mut HashMap<VarName, DynVal>) -> Result<Option<T>, T::Err> {
-    extract_value_from_args(name, args).map(|x| FromStr::from_str(&x.as_string().unwrap())).transpose()
+    args.remove(&VarName(name.to_string())).map(|x| FromStr::from_str(&x.as_string().unwrap())).transpose()
 }
 
 /// This stores the arguments given in the command line to create a window
@@ -45,7 +41,7 @@ impl WindowArguments {
             size: parse_value_from_args::<Coords>("size", &mut args)?,
             monitor: parse_value_from_args::<MonitorIdentifier>("screen", &mut args)?,
             anchor: parse_value_from_args::<AnchorPoint>("anchor", &mut args)?,
-            duration: extract_value_from_args("duration", &mut args)
+            duration: parse_value_from_args::<DynVal>("duration", &mut args)?
                 .map(|x| x.as_duration())
                 .transpose()
                 .context("Not a valid duration")?,

--- a/crates/eww/src/window_initiator.rs
+++ b/crates/eww/src/window_initiator.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use eww_shared_util::{AttrName, VarName};
+use simplexpr::{dynval::DynVal, SimplExpr};
+use std::collections::HashMap;
+use yuck::config::{
+    backend_window_options::BackendWindowOptions,
+    monitor::MonitorIdentifier,
+    window_definition::{WindowDefinition, WindowStacking},
+    window_geometry::WindowGeometry,
+};
+
+use crate::window_arguments::WindowArguments;
+
+/// This stores all the information required to create a window and is created
+/// via combining information from the WindowDefinition and the WindowInitiator
+#[derive(Debug, Clone)]
+pub struct WindowInitiator {
+    pub backend_options: BackendWindowOptions,
+    pub geometry: Option<WindowGeometry>,
+    pub id: String,
+    pub local_variables: HashMap<VarName, DynVal>,
+    pub monitor: Option<MonitorIdentifier>,
+    pub name: String,
+    pub resizable: bool,
+    pub stacking: WindowStacking,
+}
+
+impl WindowInitiator {
+    pub fn new(window_def: &WindowDefinition, args: &WindowArguments) -> Result<Self> {
+        let vars = args.get_local_window_variables(window_def)?;
+        let geometry = window_def.geometry.map(|x| x.override_if_given(args.anchor, args.pos, args.size));
+
+        let monitor = if args.monitor.is_none() { window_def.get_monitor(&vars)? } else { args.monitor.clone() };
+
+        Ok(WindowInitiator {
+            backend_options: window_def.backend_options.clone(),
+            geometry,
+            id: args.id.clone(),
+            local_variables: vars,
+            monitor,
+            name: window_def.name.clone(),
+            resizable: window_def.resizable,
+            stacking: window_def.stacking,
+        })
+    }
+
+    pub fn get_scoped_vars(&self) -> HashMap<AttrName, SimplExpr> {
+        self.local_variables.iter().map(|(k, v)| (AttrName::from(k.clone()), SimplExpr::Literal(v.clone()))).collect()
+    }
+}

--- a/crates/eww/src/window_initiator.rs
+++ b/crates/eww/src/window_initiator.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use eww_shared_util::{AttrName, VarName};
-use simplexpr::{dynval::DynVal, SimplExpr};
+use simplexpr::dynval::DynVal;
 use std::collections::HashMap;
 use yuck::config::{
     backend_window_options::BackendWindowOptions,
@@ -12,7 +12,7 @@ use yuck::config::{
 use crate::window_arguments::WindowArguments;
 
 /// This stores all the information required to create a window and is created
-/// via combining information from the WindowDefinition and the WindowInitiator
+/// via combining information from the [`WindowDefinition`] and the [`WindowInitiator`]
 #[derive(Debug, Clone)]
 pub struct WindowInitiator {
     pub backend_options: BackendWindowOptions,
@@ -29,28 +29,24 @@ impl WindowInitiator {
     pub fn new(window_def: &WindowDefinition, args: &WindowArguments) -> Result<Self> {
         let vars = args.get_local_window_variables(window_def)?;
 
-        let backend_options = window_def.backend_options.eval(&vars)?;
         let geometry = match &window_def.geometry {
             Some(geo) => Some(geo.eval(&vars)?.override_if_given(args.anchor, args.pos, args.size)),
             None => None,
         };
         let monitor = if args.monitor.is_none() { window_def.eval_monitor(&vars)? } else { args.monitor.clone() };
-        let resizable = window_def.eval_resizable(&vars)?;
-        let stacking = window_def.eval_stacking(&vars)?;
-
         Ok(WindowInitiator {
-            backend_options,
+            backend_options: window_def.backend_options.eval(&vars)?,
             geometry,
-            id: args.id.clone(),
-            local_variables: vars,
+            id: args.instance_id.clone(),
             monitor,
             name: window_def.name.clone(),
-            resizable,
-            stacking,
+            resizable: window_def.eval_resizable(&vars)?,
+            stacking: window_def.eval_stacking(&vars)?,
+            local_variables: vars,
         })
     }
 
-    pub fn get_scoped_vars(&self) -> HashMap<AttrName, SimplExpr> {
-        self.local_variables.iter().map(|(k, v)| (AttrName::from(k.clone()), SimplExpr::Literal(v.clone()))).collect()
+    pub fn get_scoped_vars(&self) -> HashMap<AttrName, DynVal> {
+        self.local_variables.iter().map(|(k, v)| (AttrName::from(k.clone()), v.clone())).collect()
     }
 }

--- a/crates/simplexpr/src/dynval.rs
+++ b/crates/simplexpr/src/dynval.rs
@@ -106,6 +106,14 @@ impl TryFrom<serde_json::Value> for DynVal {
     }
 }
 
+impl From<Vec<DynVal>> for DynVal {
+    fn from(v: Vec<DynVal>) -> Self {
+        let span = if let (Some(first), Some(last)) = (v.first(), v.last()) { first.span().to(last.span()) } else { Span::DUMMY };
+        let elements = v.into_iter().map(|x| x.as_string().unwrap()).collect::<Vec<_>>();
+        DynVal(serde_json::to_string(&elements).unwrap(), span)
+    }
+}
+
 impl From<std::time::Duration> for DynVal {
     fn from(d: std::time::Duration) -> Self {
         DynVal(format!("{}ms", d.as_millis()), Span::DUMMY)

--- a/crates/yuck/src/config/attributes.rs
+++ b/crates/yuck/src/config/attributes.rs
@@ -110,6 +110,7 @@ impl Attributes {
     }
 }
 
+/// Specification of an argument to a widget or window
 #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize)]
 pub struct AttrSpec {
     pub name: AttrName,

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -1,7 +1,11 @@
-use std::{str::FromStr, collections::HashMap};
+use std::{collections::HashMap, str::FromStr};
 
 use anyhow::Result;
-use simplexpr::{SimplExpr, dynval::{DynVal, FromDynVal}, eval::EvalError};
+use simplexpr::{
+    dynval::{DynVal, FromDynVal},
+    eval::EvalError,
+    SimplExpr,
+};
 
 use crate::{
     enum_parse,
@@ -25,7 +29,8 @@ pub enum Error {
     EvalError(#[from] EvalError),
 }
 
-/// Backend-specific options of a window that are backend
+/// Backend-specific options of a window
+/// Unevaluated form of [`BackendWindowOptions`]
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 pub struct BackendWindowOptionsDef {
     pub wayland: WlBackendWindowOptionsDef,
@@ -34,10 +39,7 @@ pub struct BackendWindowOptionsDef {
 
 impl BackendWindowOptionsDef {
     pub fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<BackendWindowOptions, Error> {
-        Ok(BackendWindowOptions {
-            wayland: self.wayland.eval(local_variables)?,
-            x11: self.x11.eval(local_variables)?,
-        })
+        Ok(BackendWindowOptions { wayland: self.wayland.eval(local_variables)?, x11: self.x11.eval(local_variables)? })
     }
 
     pub fn from_attrs(attrs: &mut Attributes) -> DiagResult<Self> {
@@ -55,7 +57,7 @@ impl BackendWindowOptionsDef {
             namespace: attrs.ast_optional("namespace")?,
         };
 
-        Ok(Self { wayland, x11  })
+        Ok(Self { wayland, x11 })
     }
 }
 
@@ -74,6 +76,7 @@ pub struct X11BackendWindowOptions {
     pub struts: X11StrutDefinition,
 }
 
+/// Unevaluated form of [`X11BackendWindowOptions`]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct X11BackendWindowOptionsDef {
     pub sticky: Option<SimplExpr>,
@@ -94,7 +97,11 @@ impl X11BackendWindowOptionsDef {
                 Some(expr) => X11WindowType::from_dynval(&expr.eval(local_variables)?)?,
                 None => X11WindowType::default(),
             },
-            wm_ignore: eval_opt_expr_as_bool(&self.wm_ignore, self.window_type.is_none() && self.struts.is_none(), local_variables)?,
+            wm_ignore: eval_opt_expr_as_bool(
+                &self.wm_ignore,
+                self.window_type.is_none() && self.struts.is_none(),
+                local_variables,
+            )?,
         })
     }
 }
@@ -106,6 +113,7 @@ pub struct WlBackendWindowOptions {
     pub namespace: Option<String>,
 }
 
+/// Unevaluated form of [`WlBackendWindowOptions`]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct WlBackendWindowOptionsDef {
     pub exclusive: Option<SimplExpr>,
@@ -121,12 +129,16 @@ impl WlBackendWindowOptionsDef {
             namespace: match &self.namespace {
                 Some(expr) => Some(expr.eval(local_variables)?.as_string()?),
                 None => None,
-            }
+            },
         })
     }
 }
 
-fn eval_opt_expr_as_bool(opt_expr: &Option<SimplExpr>, default: bool, local_variables: &HashMap<VarName, DynVal>) -> Result<bool, EvalError> {
+fn eval_opt_expr_as_bool(
+    opt_expr: &Option<SimplExpr>,
+    default: bool,
+    local_variables: &HashMap<VarName, DynVal>,
+) -> Result<bool, EvalError> {
     Ok(match opt_expr {
         Some(expr) => expr.eval(local_variables)?.as_bool()?,
         None => default,
@@ -183,10 +195,11 @@ impl std::str::FromStr for Side {
     }
 }
 
+/// Unevaluated form of [`X11StrutDefinition`]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct X11StrutDefinitionExpr {
     pub side: Option<SimplExpr>,
-    pub dist: SimplExpr,
+    pub distance: SimplExpr,
 }
 
 impl X11StrutDefinitionExpr {
@@ -196,7 +209,7 @@ impl X11StrutDefinitionExpr {
                 Some(expr) => Side::from_dynval(&expr.eval(local_variables)?)?,
                 None => Side::default(),
             },
-            dist: NumWithUnit::from_dynval(&self.dist.eval(local_variables)?)?,
+            distance: NumWithUnit::from_dynval(&self.distance.eval(local_variables)?)?,
         })
     }
 }
@@ -207,15 +220,12 @@ impl FromAstElementContent for X11StrutDefinitionExpr {
     fn from_tail<I: Iterator<Item = Ast>>(_span: Span, mut iter: AstIterator<I>) -> DiagResult<Self> {
         let mut attrs = iter.expect_key_values()?;
         iter.expect_done().map_err(DiagError::from).note("Check if you are missing a colon in front of a key")?;
-        Ok(X11StrutDefinitionExpr {
-            side: attrs.ast_optional("side")?,
-            dist: attrs.ast_required("distance")?
-        })
+        Ok(X11StrutDefinitionExpr { side: attrs.ast_optional("side")?, distance: attrs.ast_required("distance")? })
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize)]
 pub struct X11StrutDefinition {
     pub side: Side,
-    pub dist: NumWithUnit,
+    pub distance: NumWithUnit,
 }

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -1,43 +1,69 @@
-use std::str::FromStr;
+use std::{str::FromStr, collections::HashMap};
 
 use anyhow::Result;
+use simplexpr::{SimplExpr, dynval::{DynVal, FromDynVal}, eval::EvalError};
 
 use crate::{
     enum_parse,
     error::DiagResult,
     parser::{ast::Ast, ast_iterator::AstIterator, from_ast::FromAstElementContent},
-    value::NumWithUnit,
+    value::{coords, NumWithUnit},
 };
-use eww_shared_util::Span;
+use eww_shared_util::{Span, VarName};
 
 use super::{attributes::Attributes, window_definition::EnumParseError};
 
 use crate::error::{DiagError, DiagResultExt};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    EnumParseError(#[from] EnumParseError),
+    #[error(transparent)]
+    CoordsError(#[from] coords::Error),
+    #[error(transparent)]
+    EvalError(#[from] EvalError),
+}
+
+/// Backend-specific options of a window that are backend
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub struct BackendWindowOptionsDef {
+    pub wayland: WlBackendWindowOptionsDef,
+    pub x11: X11BackendWindowOptionsDef,
+}
+
+impl BackendWindowOptionsDef {
+    pub fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<BackendWindowOptions, Error> {
+        Ok(BackendWindowOptions {
+            wayland: self.wayland.eval(local_variables)?,
+            x11: self.x11.eval(local_variables)?,
+        })
+    }
+
+    pub fn from_attrs(attrs: &mut Attributes) -> DiagResult<Self> {
+        let struts = attrs.ast_optional("reserve")?;
+        let window_type = attrs.ast_optional("windowtype")?;
+        let x11 = X11BackendWindowOptionsDef {
+            sticky: attrs.ast_optional("sticky")?,
+            struts,
+            window_type,
+            wm_ignore: attrs.ast_optional("wm-ignore")?,
+        };
+        let wayland = WlBackendWindowOptionsDef {
+            exclusive: attrs.ast_optional("exclusive")?,
+            focusable: attrs.ast_optional("focusable")?,
+            namespace: attrs.ast_optional("namespace")?,
+        };
+
+        Ok(Self { wayland, x11  })
+    }
+}
 
 /// Backend-specific options of a window that are backend
 #[derive(Debug, Clone, serde::Serialize, PartialEq)]
 pub struct BackendWindowOptions {
     pub x11: X11BackendWindowOptions,
     pub wayland: WlBackendWindowOptions,
-}
-
-impl BackendWindowOptions {
-    pub fn from_attrs(attrs: &mut Attributes) -> DiagResult<Self> {
-        let struts = attrs.ast_optional("reserve")?;
-        let window_type = attrs.primitive_optional("windowtype")?;
-        let x11 = X11BackendWindowOptions {
-            wm_ignore: attrs.primitive_optional("wm-ignore")?.unwrap_or(window_type.is_none() && struts.is_none()),
-            window_type: window_type.unwrap_or_default(),
-            sticky: attrs.primitive_optional("sticky")?.unwrap_or(true),
-            struts: struts.unwrap_or_default(),
-        };
-        let wayland = WlBackendWindowOptions {
-            exclusive: attrs.primitive_optional("exclusive")?.unwrap_or(false),
-            focusable: attrs.primitive_optional("focusable")?.unwrap_or(false),
-            namespace: attrs.primitive_optional("namespace")?,
-        };
-        Ok(Self { x11, wayland })
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -49,10 +75,62 @@ pub struct X11BackendWindowOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct X11BackendWindowOptionsDef {
+    pub sticky: Option<SimplExpr>,
+    pub struts: Option<X11StrutDefinitionExpr>,
+    pub window_type: Option<SimplExpr>,
+    pub wm_ignore: Option<SimplExpr>,
+}
+
+impl X11BackendWindowOptionsDef {
+    fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<X11BackendWindowOptions, Error> {
+        Ok(X11BackendWindowOptions {
+            sticky: eval_opt_expr_as_bool(&self.sticky, true, local_variables)?,
+            struts: match &self.struts {
+                Some(expr) => expr.eval(local_variables)?,
+                None => X11StrutDefinition::default(),
+            },
+            window_type: match &self.window_type {
+                Some(expr) => X11WindowType::from_dynval(&expr.eval(local_variables)?)?,
+                None => X11WindowType::default(),
+            },
+            wm_ignore: eval_opt_expr_as_bool(&self.wm_ignore, self.window_type.is_none() && self.struts.is_none(), local_variables)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct WlBackendWindowOptions {
     pub exclusive: bool,
     pub focusable: bool,
     pub namespace: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct WlBackendWindowOptionsDef {
+    pub exclusive: Option<SimplExpr>,
+    pub focusable: Option<SimplExpr>,
+    pub namespace: Option<SimplExpr>,
+}
+
+impl WlBackendWindowOptionsDef {
+    fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<WlBackendWindowOptions, EvalError> {
+        Ok(WlBackendWindowOptions {
+            exclusive: eval_opt_expr_as_bool(&self.exclusive, false, local_variables)?,
+            focusable: eval_opt_expr_as_bool(&self.focusable, false, local_variables)?,
+            namespace: match &self.namespace {
+                Some(expr) => Some(expr.eval(local_variables)?.as_string()?),
+                None => None,
+            }
+        })
+    }
+}
+
+fn eval_opt_expr_as_bool(opt_expr: &Option<SimplExpr>, default: bool, local_variables: &HashMap<VarName, DynVal>) -> Result<bool, EvalError> {
+    Ok(match opt_expr {
+        Some(expr) => expr.eval(local_variables)?.as_bool()?,
+        None => default,
+    })
 }
 
 /// Window type of an x11 window
@@ -105,18 +183,39 @@ impl std::str::FromStr for Side {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize)]
-pub struct X11StrutDefinition {
-    pub side: Side,
-    pub dist: NumWithUnit,
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct X11StrutDefinitionExpr {
+    pub side: Option<SimplExpr>,
+    pub dist: SimplExpr,
 }
 
-impl FromAstElementContent for X11StrutDefinition {
+impl X11StrutDefinitionExpr {
+    fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<X11StrutDefinition, Error> {
+        Ok(X11StrutDefinition {
+            side: match &self.side {
+                Some(expr) => Side::from_dynval(&expr.eval(local_variables)?)?,
+                None => Side::default(),
+            },
+            dist: NumWithUnit::from_dynval(&self.dist.eval(local_variables)?)?,
+        })
+    }
+}
+
+impl FromAstElementContent for X11StrutDefinitionExpr {
     const ELEMENT_NAME: &'static str = "struts";
 
     fn from_tail<I: Iterator<Item = Ast>>(_span: Span, mut iter: AstIterator<I>) -> DiagResult<Self> {
         let mut attrs = iter.expect_key_values()?;
         iter.expect_done().map_err(DiagError::from).note("Check if you are missing a colon in front of a key")?;
-        Ok(X11StrutDefinition { side: attrs.primitive_required("side")?, dist: attrs.primitive_required("distance")? })
+        Ok(X11StrutDefinitionExpr {
+            side: attrs.ast_optional("side")?,
+            dist: attrs.ast_required("distance")?
+        })
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize)]
+pub struct X11StrutDefinition {
+    pub side: Side,
+    pub dist: NumWithUnit,
 }

--- a/crates/yuck/src/config/monitor.rs
+++ b/crates/yuck/src/config/monitor.rs
@@ -29,17 +29,19 @@ impl MonitorIdentifier {
         }
     }
 
-    pub fn to_dynval(&self) -> DynVal {
-        match self {
-            Self::List(l) => l.iter().map(|x| x.to_dynval()).collect::<Vec<_>>().into(),
-            Self::Numeric(n) => DynVal::from(*n),
-            Self::Name(n) => DynVal::from(n.clone()),
-            Self::Primary => DynVal::from("<primary>"),
-        }
-    }
-
     pub fn is_numeric(&self) -> bool {
         matches!(self, Self::Numeric(_))
+    }
+}
+
+impl From<&MonitorIdentifier> for DynVal {
+    fn from(val: &MonitorIdentifier) -> Self {
+        match val {
+            MonitorIdentifier::List(l) => l.iter().map(|x| x.into()).collect::<Vec<_>>().into(),
+            MonitorIdentifier::Numeric(n) => DynVal::from(*n),
+            MonitorIdentifier::Name(n) => DynVal::from(n.clone()),
+            MonitorIdentifier::Primary => DynVal::from("<primary>"),
+        }
     }
 }
 

--- a/crates/yuck/src/config/monitor.rs
+++ b/crates/yuck/src/config/monitor.rs
@@ -1,6 +1,11 @@
-use std::{convert::Infallible, fmt, str};
+use std::{
+    convert::Infallible,
+    fmt,
+    str::{self, FromStr},
+};
 
 use serde::{Deserialize, Serialize};
+use simplexpr::dynval::{ConversionError, DynVal};
 
 /// The type of the identifier used to select a monitor
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -12,6 +17,27 @@ pub enum MonitorIdentifier {
 }
 
 impl MonitorIdentifier {
+    pub fn from_dynval(val: &DynVal) -> Result<Self, ConversionError> {
+        match val.as_json_array() {
+            Ok(arr) => Ok(MonitorIdentifier::List(
+                arr.iter().map(|x| MonitorIdentifier::from_dynval(&x.into())).collect::<Result<_, _>>()?,
+            )),
+            Err(_) => match val.as_i32() {
+                Ok(x) => Ok(MonitorIdentifier::Numeric(x)),
+                Err(_) => Ok(MonitorIdentifier::from_str(&val.as_string().unwrap()).unwrap()),
+            },
+        }
+    }
+
+    pub fn to_dynval(&self) -> DynVal {
+        match self {
+            Self::List(l) => l.iter().map(|x| x.to_dynval()).collect::<Vec<_>>().into(),
+            Self::Numeric(n) => DynVal::from(*n),
+            Self::Name(n) => DynVal::from(n.clone()),
+            Self::Primary => DynVal::from("<primary>"),
+        }
+    }
+
     pub fn is_numeric(&self) -> bool {
         matches!(self, Self::Numeric(_))
     }

--- a/crates/yuck/src/config/snapshots/yuck__config__test__config.snap
+++ b/crates/yuck/src/config/snapshots/yuck__config__test__config.snap
@@ -41,6 +41,8 @@ Config(
   window_definitions: {
     "some-window": WindowDefinition(
       name: "some-window",
+      expected_args: [],
+      args_span: Span(18446744073709551615, 18446744073709551615, 18446744073709551615),
       geometry: Some(WindowGeometry(
         anchor_point: AnchorPoint(
           x: START,
@@ -56,7 +58,7 @@ Config(
         ),
       )),
       stacking: Foreground,
-      monitor_number: Some(12),
+      monitor_number: Some(Literal(DynVal("12", Span(278, 280, 0)))),
       widget: Basic(BasicWidgetUse(
         name: "bar",
         attrs: Attributes(
@@ -71,6 +73,63 @@ Config(
         children: [],
         span: Span(463, 479, 0),
         name_span: Span(464, 467, 0),
+      )),
+      resizable: true,
+      backend_options: BackendWindowOptions(
+        wm_ignore: false,
+        sticky: true,
+        window_type: Dock,
+        struts: StrutDefinition(
+          side: Left,
+          dist: Pixels(30),
+        ),
+      ),
+    ),
+    "some-window-with-args": WindowDefinition(
+      name: "some-window-with-args",
+      expected_args: [
+        AttrSpec(
+          name: AttrName("arg"),
+          optional: false,
+          span: Span(523, 526, 0),
+        ),
+        AttrSpec(
+          name: AttrName("arg2"),
+          optional: false,
+          span: Span(527, 531, 0),
+        ),
+      ],
+      args_span: Span(522, 532, 0),
+      geometry: Some(WindowGeometry(
+        anchor_point: AnchorPoint(
+          x: START,
+          y: START,
+        ),
+        offset: Coords(
+          x: Pixels(0),
+          y: Pixels(0),
+        ),
+        size: Coords(
+          x: Percent(12),
+          y: Pixels(20),
+        ),
+      )),
+      stacking: Foreground,
+      monitor_number: Some(Literal(DynVal("12", Span(595, 597, 0)))),
+      widget: Basic(BasicWidgetUse(
+        name: "bar",
+        attrs: Attributes(
+          span: Span(784, 795, 0),
+          attrs: {
+            AttrName("arg"): AttrEntry(
+              key_span: Span(785, 789, 0),
+              value: SimplExpr(Span(790, 795, 0), Literal(DynVal("bla", Span(790, 795, 0)))),
+            ),
+          },
+        ),
+        children: [],
+        span: Span(780, 796, 0),
+        name_span: Span(781, 784, 0),
       )),
       resizable: true,
       backend_options: BackendWindowOptions(

--- a/crates/yuck/src/config/validate.rs
+++ b/crates/yuck/src/config/validate.rs
@@ -33,13 +33,17 @@ impl Spanned for ValidationError {
 }
 
 pub fn validate(config: &Config, additional_globals: Vec<VarName>) -> Result<(), ValidationError> {
-    let var_names = std::iter::empty()
+    let var_names: HashSet<VarName> = std::iter::empty()
         .chain(additional_globals.iter().cloned())
         .chain(config.script_vars.keys().cloned())
         .chain(config.var_definitions.keys().cloned())
         .collect();
     for window in config.window_definitions.values() {
-        validate_variables_in_widget_use(&config.widget_definitions, &var_names, &window.widget, false)?;
+        let local_var_names: HashSet<VarName> = std::iter::empty()
+            .chain(var_names.iter().cloned())
+            .chain(window.expected_args.iter().map(|x| VarName::from(x.name.clone())))
+            .collect();
+        validate_variables_in_widget_use(&config.widget_definitions, &local_var_names, &window.widget, false)?;
     }
     for def in config.widget_definitions.values() {
         validate_widget_definition(&config.widget_definitions, &var_names, def)?;

--- a/crates/yuck/src/config/widget_definition.rs
+++ b/crates/yuck/src/config/widget_definition.rs
@@ -8,25 +8,9 @@ use crate::{
         from_ast::{FromAst, FromAstElementContent},
     },
 };
-use eww_shared_util::{AttrName, Span, Spanned};
+use eww_shared_util::{Span, Spanned};
 
-use super::widget_use::WidgetUse;
-
-#[derive(Debug, PartialEq, Eq, Clone, serde::Serialize)]
-pub struct AttrSpec {
-    pub name: AttrName,
-    pub optional: bool,
-    pub span: Span,
-}
-
-impl FromAst for AttrSpec {
-    fn from_ast(e: Ast) -> DiagResult<Self> {
-        let span = e.span();
-        let symbol = e.as_symbol()?;
-        let (name, optional) = if let Some(name) = symbol.strip_prefix('?') { (name.to_string(), true) } else { (symbol, false) };
-        Ok(Self { name: AttrName(name), optional, span })
-    }
-}
+use super::{attributes::AttrSpec, widget_use::WidgetUse};
 
 #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize)]
 pub struct WidgetDefinition {

--- a/crates/yuck/src/config/window_definition.rs
+++ b/crates/yuck/src/config/window_definition.rs
@@ -10,10 +10,15 @@ use crate::{
     },
 };
 use eww_shared_util::{Span, VarName};
-use simplexpr::{dynval::{DynVal, FromDynVal}, eval::EvalError, SimplExpr};
+use simplexpr::{
+    dynval::{DynVal, FromDynVal},
+    eval::EvalError,
+    SimplExpr,
+};
 
 use super::{
-    attributes::AttrSpec, backend_window_options::BackendWindowOptionsDef, widget_use::WidgetUse, window_geometry::WindowGeometryDef,
+    attributes::AttrSpec, backend_window_options::BackendWindowOptionsDef, widget_use::WidgetUse,
+    window_geometry::WindowGeometryDef,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -38,6 +43,7 @@ pub struct WindowDefinition {
 }
 
 impl WindowDefinition {
+    /// Evaluate the `monitor` field of the window definition
     pub fn eval_monitor(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<Option<MonitorIdentifier>, EvalError> {
         Ok(match &self.monitor {
             Some(monitor_expr) => Some(MonitorIdentifier::from_dynval(&monitor_expr.eval(local_variables)?)?),
@@ -45,6 +51,7 @@ impl WindowDefinition {
         })
     }
 
+    /// Evaluate the `resizable` field of the window definition
     pub fn eval_resizable(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<bool, EvalError> {
         Ok(match &self.resizable {
             Some(expr) => expr.eval(local_variables)?.as_bool()?,
@@ -52,12 +59,16 @@ impl WindowDefinition {
         })
     }
 
-    pub fn eval_stacking(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<WindowStacking, WindowStackingConversionError> {
+    /// Evaluate the `stacking` field of the window definition
+    pub fn eval_stacking(
+        &self,
+        local_variables: &HashMap<VarName, DynVal>,
+    ) -> Result<WindowStacking, WindowStackingConversionError> {
         match &self.stacking {
             Some(stacking_expr) => match stacking_expr.eval(local_variables) {
                 Ok(val) => Ok(WindowStacking::from_dynval(&val)?),
                 Err(err) => Err(WindowStackingConversionError::EvalError(err)),
-            }
+            },
             None => Ok(WindowStacking::Foreground),
         }
     }

--- a/crates/yuck/src/config/window_definition.rs
+++ b/crates/yuck/src/config/window_definition.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, str::FromStr};
+use std::{collections::HashMap, fmt::Display};
 
 use crate::{
     config::monitor::MonitorIdentifier,
@@ -9,26 +9,34 @@ use crate::{
         from_ast::{FromAst, FromAstElementContent},
     },
 };
-use eww_shared_util::Span;
+use eww_shared_util::{Span, VarName};
+use simplexpr::{dynval::DynVal, eval::EvalError, SimplExpr};
 
-use super::{backend_window_options::BackendWindowOptions, widget_use::WidgetUse, window_geometry::WindowGeometry};
+use super::{
+    attributes::AttrSpec, backend_window_options::BackendWindowOptions, widget_use::WidgetUse, window_geometry::WindowGeometry,
+};
 
 #[derive(Debug, Clone, serde::Serialize, PartialEq)]
 pub struct WindowDefinition {
     pub name: String,
+    pub expected_args: Vec<AttrSpec>,
+    pub args_span: Span,
     pub geometry: Option<WindowGeometry>,
     pub stacking: WindowStacking,
-    pub monitor: Option<MonitorIdentifier>,
+    pub monitor: Option<SimplExpr>,
     pub widget: WidgetUse,
     pub resizable: bool,
     pub backend_options: BackendWindowOptions,
 }
 
-impl FromAst for MonitorIdentifier {
-    fn from_ast(x: Ast) -> DiagResult<Self> {
-        match x {
-            Ast::Array(_, x) => Ok(Self::List(x.into_iter().map(MonitorIdentifier::from_ast).collect::<DiagResult<_>>()?)),
-            other => Ok(Self::from_str(&String::from_ast(other)?).unwrap()),
+impl WindowDefinition {
+    pub fn get_monitor(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<Option<MonitorIdentifier>, EvalError> {
+        match &self.monitor {
+            Some(monitor_expr) => match monitor_expr.eval(local_variables) {
+                Ok(val) => Ok(Some(MonitorIdentifier::from_dynval(&val)?)),
+                Err(err) => Err(err),
+            },
+            None => Ok(None),
         }
     }
 }
@@ -38,15 +46,17 @@ impl FromAstElementContent for WindowDefinition {
 
     fn from_tail<I: Iterator<Item = Ast>>(_span: Span, mut iter: AstIterator<I>) -> DiagResult<Self> {
         let (_, name) = iter.expect_symbol()?;
+        let (args_span, expected_args) = iter.expect_array().unwrap_or((Span::DUMMY, Vec::new()));
+        let expected_args = expected_args.into_iter().map(AttrSpec::from_ast).collect::<DiagResult<_>>()?;
         let mut attrs = iter.expect_key_values()?;
-        let monitor = attrs.ast_optional::<MonitorIdentifier>("monitor")?;
+        let monitor = attrs.ast_optional("monitor")?;
         let resizable = attrs.primitive_optional("resizable")?.unwrap_or(true);
         let stacking = attrs.primitive_optional("stacking")?.unwrap_or(WindowStacking::Foreground);
         let geometry = attrs.ast_optional("geometry")?;
         let backend_options = BackendWindowOptions::from_attrs(&mut attrs)?;
         let widget = iter.expect_any().map_err(DiagError::from).and_then(WidgetUse::from_ast)?;
         iter.expect_done()?;
-        Ok(Self { name, monitor, resizable, widget, stacking, geometry, backend_options })
+        Ok(Self { name, expected_args, args_span, monitor, resizable, widget, stacking, geometry, backend_options })
     }
 }
 

--- a/crates/yuck/src/config/window_geometry.rs
+++ b/crates/yuck/src/config/window_geometry.rs
@@ -5,13 +5,17 @@ use crate::{
     error::DiagResult,
     format_diagnostic::ToDiagnostic,
     parser::{ast::Ast, ast_iterator::AstIterator, from_ast::FromAstElementContent},
-    value::{Coords, coords, NumWithUnit},
+    value::{coords, Coords, NumWithUnit},
 };
 
 use super::window_definition::EnumParseError;
 use eww_shared_util::{Span, VarName};
 use serde::{Deserialize, Serialize};
-use simplexpr::{SimplExpr, dynval::{DynVal, FromDynVal}, eval::EvalError};
+use simplexpr::{
+    dynval::{DynVal, FromDynVal},
+    eval::EvalError,
+    SimplExpr,
+};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, smart_default::SmartDefault, Serialize, Deserialize, strum::Display)]
 pub enum AnchorAlignment {
@@ -105,6 +109,7 @@ impl std::str::FromStr for AnchorPoint {
     }
 }
 
+/// Unevaluated variant of [`Coords`]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CoordsDef {
     pub x: Option<SimplExpr>,
@@ -130,13 +135,17 @@ impl CoordsDef {
     }
 }
 
-fn convert_to_num_with_unit(opt_expr: &Option<SimplExpr>, local_variables: &HashMap<VarName, DynVal>) -> Result<NumWithUnit, Error> {
+fn convert_to_num_with_unit(
+    opt_expr: &Option<SimplExpr>,
+    local_variables: &HashMap<VarName, DynVal>,
+) -> Result<NumWithUnit, Error> {
     Ok(match opt_expr {
         Some(expr) => NumWithUnit::from_dynval(&expr.eval(local_variables)?)?,
         None => NumWithUnit::default(),
     })
 }
 
+/// Unevaluated variant of [`WindowGeometry`]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct WindowGeometryDef {
     pub anchor_point: Option<SimplExpr>,
@@ -154,14 +163,8 @@ impl FromAstElementContent for WindowGeometryDef {
 
         Ok(WindowGeometryDef {
             anchor_point: attrs.ast_optional("anchor")?,
-            size: CoordsDef {
-                x: attrs.ast_optional("width")?,
-                y: attrs.ast_optional("height")?,
-            },
-            offset: CoordsDef {
-                x: attrs.ast_optional("x")?,
-                y: attrs.ast_optional("y")?,
-            },
+            size: CoordsDef { x: attrs.ast_optional("width")?, y: attrs.ast_optional("height")? },
+            offset: CoordsDef { x: attrs.ast_optional("x")?, y: attrs.ast_optional("y")? },
         })
     }
 }

--- a/crates/yuck/src/config/window_geometry.rs
+++ b/crates/yuck/src/config/window_geometry.rs
@@ -1,14 +1,17 @@
+use std::collections::HashMap;
+
 use crate::{
     enum_parse,
     error::DiagResult,
     format_diagnostic::ToDiagnostic,
     parser::{ast::Ast, ast_iterator::AstIterator, from_ast::FromAstElementContent},
-    value::Coords,
+    value::{Coords, coords, NumWithUnit},
 };
 
 use super::window_definition::EnumParseError;
-use eww_shared_util::Span;
+use eww_shared_util::{Span, VarName};
 use serde::{Deserialize, Serialize};
+use simplexpr::{SimplExpr, dynval::{DynVal, FromDynVal}, eval::EvalError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, smart_default::SmartDefault, Serialize, Deserialize, strum::Display)]
 pub enum AnchorAlignment {
@@ -102,32 +105,85 @@ impl std::str::FromStr for AnchorPoint {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize)]
-pub struct WindowGeometry {
-    pub anchor_point: AnchorPoint,
-    pub offset: Coords,
-    pub size: Coords,
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CoordsDef {
+    pub x: Option<SimplExpr>,
+    pub y: Option<SimplExpr>,
 }
 
-impl FromAstElementContent for WindowGeometry {
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    AnchorPointParseError(#[from] AnchorPointParseError),
+    #[error(transparent)]
+    CoordsError(#[from] coords::Error),
+    #[error(transparent)]
+    EvalError(#[from] EvalError),
+}
+
+impl CoordsDef {
+    pub fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<Coords, Error> {
+        Ok(Coords {
+            x: convert_to_num_with_unit(&self.x, local_variables)?,
+            y: convert_to_num_with_unit(&self.y, local_variables)?,
+        })
+    }
+}
+
+fn convert_to_num_with_unit(opt_expr: &Option<SimplExpr>, local_variables: &HashMap<VarName, DynVal>) -> Result<NumWithUnit, Error> {
+    Ok(match opt_expr {
+        Some(expr) => NumWithUnit::from_dynval(&expr.eval(local_variables)?)?,
+        None => NumWithUnit::default(),
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WindowGeometryDef {
+    pub anchor_point: Option<SimplExpr>,
+    pub offset: CoordsDef,
+    pub size: CoordsDef,
+}
+
+impl FromAstElementContent for WindowGeometryDef {
     const ELEMENT_NAME: &'static str = "geometry";
 
     fn from_tail<I: Iterator<Item = Ast>>(_span: Span, mut iter: AstIterator<I>) -> DiagResult<Self> {
         let mut attrs = iter.expect_key_values()?;
         iter.expect_done()
             .map_err(|e| e.to_diagnostic().with_notes(vec!["Check if you are missing a colon in front of a key".to_string()]))?;
-        Ok(WindowGeometry {
-            anchor_point: attrs.primitive_optional("anchor")?.unwrap_or_default(),
-            size: Coords {
-                x: attrs.primitive_optional("width")?.unwrap_or_default(),
-                y: attrs.primitive_optional("height")?.unwrap_or_default(),
+
+        Ok(WindowGeometryDef {
+            anchor_point: attrs.ast_optional("anchor")?,
+            size: CoordsDef {
+                x: attrs.ast_optional("width")?,
+                y: attrs.ast_optional("height")?,
             },
-            offset: Coords {
-                x: attrs.primitive_optional("x")?.unwrap_or_default(),
-                y: attrs.primitive_optional("y")?.unwrap_or_default(),
+            offset: CoordsDef {
+                x: attrs.ast_optional("x")?,
+                y: attrs.ast_optional("y")?,
             },
         })
     }
+}
+
+impl WindowGeometryDef {
+    pub fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<WindowGeometry, Error> {
+        Ok(WindowGeometry {
+            anchor_point: match &self.anchor_point {
+                Some(expr) => AnchorPoint::from_dynval(&expr.eval(local_variables)?)?,
+                None => AnchorPoint::default(),
+            },
+            size: self.size.eval(local_variables)?,
+            offset: self.offset.eval(local_variables)?,
+        })
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct WindowGeometry {
+    pub anchor_point: AnchorPoint,
+    pub offset: Coords,
+    pub size: Coords,
 }
 
 impl WindowGeometry {

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -259,28 +259,44 @@ Eww then reads the provided value and renders the resulting widget. Whenever it 
 
 Note that this is not all that efficient. Make sure to only use `literal` when necessary!
 
-## Dynamically generated windows with arguments and ids
+## Using window arguments and IDs
 
-In some cases you may want to use the same window configuration for multiple widgets, e.g. for multiple windows. This is where arugments and ids come in.
+In some cases you may want to use the same window configuration for multiple widgets, e.g. for multiple windows. This is where arguments and ids come in.
 
-Firstly let us start off with ids. An id can be specified in the `open` command with `--id`, by default the id will be set to the name of the window configuration. These ids allow you to spawn multiple of the same windows. So for example you can do:
+### Window ID
+
+Firstly let us start off with ids. An id can be specified in the `open` command
+with `--id`, by default the id will be set to the name of the window
+configuration. These ids allow you to spawn multiple of the same windows. So
+for example you can do:
 
 ```bash
 eww open my_bar --screen 0 --id primary
 eww open my_bar --screen 1 --id secondary
 ```
 
-When using `open-many` you can follow the structure below. Again if no id is given, the id will default to the name of the window configuration.
+When using `open-many` you can follow the structure below. Again if no id is
+given, the id will default to the name of the window configuration.
 
 ```bash
 eww open-many my_config:primary my_config:secondary
 ```
 
-You may notice with this we didn't set `screen`, this is set through the `--arg` system, please see below for more information.
+You may notice with this we didn't set `screen`, this is set through the
+`--arg` system, please see below for more information.
 
-However you may want to have slight changes for each of these bars, e.g. spawning other windows on the same monitor. This is where the arguments come in.
+### Window Arguments
 
-Defining arguments in a window is the exact same as in a widget so you can have:
+However this may not be enough and you want to have slight changes for each of
+these bars, e.g. having a different class for 1080p displays vs 4k or having
+spawning the window in a different size or location. This is where the
+arguments come in.
+
+Please note these arguments are **CONSTANT** and so cannot be update after the
+window has been opened.
+
+Defining arguments in a window is the exact same as in a widget so you can
+have:
 
 ```lisp
 (defwindow my_bar [arg1 ?arg2]
@@ -288,17 +304,19 @@ Defining arguments in a window is the exact same as in a widget so you can have:
                        :x      "0%"
                        :y      "6px"
                        :width  "100%"
-                       :height "30px"
+                       :height { arg1 == "small" ? "30px" : "40px" }
                        :anchor "top center")
           :stacking   "bg"
           :windowtype "dock"
           :reserve    (struts :distance "50px" :side "top")
-    ...)
+    (my_widget :arg2 arg2))
 ```
 
 Here we have two arguments, `arg1` and `arg2` (an optional parameter).
 
-Once we have these parameters, when opening a new window, we must specify them (unless they are required, like `arg2`), but how? Well, we use the `--arg` option when running the `open` command:
+Once we have these parameters, when opening a new window, we must specify them
+(unless they are required, like `arg2`), but how? Well, we use the `--arg`
+option when running the `open` command:
 
 ```bash
 eww open my_bar --id primary --arg arg1=some_value --arg arg2=another_value
@@ -311,26 +329,37 @@ With the `open-many` it looks like this:
 eww open-many my_bar:primary --arg primary:arg1=some_value --arg primary:arg2=another_value
 ```
 
-Using this method you can define `screen`, `anchor`, `pos`, `size` inside the args for each window and it will act like giving `--screen`, `--anchor` etc. in the `open` command.
+Using this method you can define `screen`, `anchor`, `pos`, `size` inside the
+args for each window and it will act like giving `--screen`, `--anchor` etc. in
+the `open` command.
 
-You may notice that this is the same layout to set values with `update` and you'd be correct.
+So, now you know the basics, I shall introduce you to some of these "special"
+parameters, which are set slightly differently. However these can all be
+overridden by the `--arg` option.
 
-So, now you know the basics, I shall introduce you to some of these "special" parameters, which are set slightly differently. However these can all be overridden by the `--arg` option.
-
-- `id` - If `id` is included in the argument list, it will be set to the id specified by `--id` or will be set to the name of the config. This can be used when closing the current window through eww commands.
-- `screen` - If `screen` is specified it will be set to the value given by `--screen`, so you can use this in other widgets to access screen specific information.
+- `id` - If `id` is included in the argument list, it will be set to the id
+  specified by `--id` or will be set to the name of the config. This can be
+  used when closing the current window through eww commands.
+- `screen` - If `screen` is specified it will be set to the value given by
+  `--screen`, so you can use this in other widgets to access screen specific
+  information.
 
 ### Further insight into args in `open-many`
 
-Now due to the system behind processing the `open-many` `--arg` option you don't have to specify an id for each argument. If you do not, that argument will be applied across all windows e.g.
+Now due to the system behind processing the `open-many` `--arg` option you
+don't have to specify an id for each argument. If you do not, that argument
+will be applied across all windows e.g.
 
 ```bash
-eww open-many -c "~/.config/eww/bars" my_bar:primary my_bar:secondary --arg config="~/.config/eww/bars"
+eww open-many my_bar:primary my_bar:secondary --arg gui_size="small"
 ```
 
 This will mean the config is the same throughout the bars.
 
-Furthermore if you didn't specify an id for the window, you can still set args specifically for that window - following the idea that the id will be set to the window configuration if not given - by just using the name of the window configuration e.g.
+Furthermore if you didn't specify an id for the window, you can still set args
+specifically for that window - following the idea that the id will be set to
+the window configuration if not given - by just using the name of the window
+configuration e.g.
 
 ```bash
 eww open-many my_primary_bar --arg my_primary_bar:screen=0

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -259,6 +259,83 @@ Eww then reads the provided value and renders the resulting widget. Whenever it 
 
 Note that this is not all that efficient. Make sure to only use `literal` when necessary!
 
+## Dynamically generated windows with arguments and ids
+
+In some cases you may want to use the same window configuration for multiple widgets, e.g. for multiple windows. This is where arugments and ids come in.
+
+Firstly let us start off with ids. An id can be specified in the `open` command with `--id`, by default the id will be set to the name of the window configuration. These ids allow you to spawn multiple of the same windows. So for example you can do:
+
+```bash
+eww open my_bar --screen 0 --id primary
+eww open my_bar --screen 1 --id secondary
+```
+
+When using `open-many` you can follow the structure below. Again if no id is given, the id will default to the name of the window configuration.
+
+```bash
+eww open-many my_config:primary my_config:secondary
+```
+
+You may notice with this we didn't set `screen`, this is set through the `--arg` system, please see below for more information.
+
+However you may want to have slight changes for each of these bars, e.g. spawning other windows on the same monitor. This is where the arguments come in.
+
+Defining arguments in a window is the exact same as in a widget so you can have:
+
+```lisp
+(defwindow my_bar [arg1 ?arg2]
+          :geometry (geometry
+                       :x      "0%"
+                       :y      "6px"
+                       :width  "100%"
+                       :height "30px"
+                       :anchor "top center")
+          :stacking   "bg"
+          :windowtype "dock"
+          :reserve    (struts :distance "50px" :side "top")
+    ...)
+```
+
+Here we have two arguments, `arg1` and `arg2` (an optional parameter).
+
+Once we have these parameters, when opening a new window, we must specify them (unless they are required, like `arg2`), but how? Well, we use the `--arg` option when running the `open` command:
+
+```bash
+eww open my_bar --id primary --arg arg1=some_value --arg arg2=another_value
+```
+
+With the `open-many` it looks like this:
+
+```bash
+# Please note that `--arg` option must be given after all the windows names
+eww open-many my_bar:primary --arg primary:arg1=some_value --arg primary:arg2=another_value
+```
+
+Using this method you can define `screen`, `anchor`, `pos`, `size` inside the args for each window and it will act like giving `--screen`, `--anchor` etc. in the `open` command.
+
+You may notice that this is the same layout to set values with `update` and you'd be correct.
+
+So, now you know the basics, I shall introduce you to some of these "special" parameters, which are set slightly differently. However these can all be overridden by the `--arg` option.
+
+- `id` - If `id` is included in the argument list, it will be set to the id specified by `--id` or will be set to the name of the config. This can be used when closing the current window through eww commands.
+- `screen` - If `screen` is specified it will be set to the value given by `--screen`, so you can use this in other widgets to access screen specific information.
+
+### Further insight into args in `open-many`
+
+Now due to the system behind processing the `open-many` `--arg` option you don't have to specify an id for each argument. If you do not, that argument will be applied across all windows e.g.
+
+```bash
+eww open-many -c "~/.config/eww/bars" my_bar:primary my_bar:secondary --arg config="~/.config/eww/bars"
+```
+
+This will mean the config is the same throughout the bars.
+
+Furthermore if you didn't specify an id for the window, you can still set args specifically for that window - following the idea that the id will be set to the window configuration if not given - by just using the name of the window configuration e.g.
+
+```bash
+eww open-many my_primary_bar --arg my_primary_bar:screen=0
+```
+
 ## Generating a list of widgets from JSON using `for`
 
 If you want to display a list of values, you can use the `for`-Element to fill a container with a list of elements generated from a JSON-array.


### PR DESCRIPTION
I've just created this for my config to work so thought I would create a PR to see if this is wanted in the master branch. If it is wanted, I shall flesh out the features a bit more + add docs and update tests

## Description

The main goal of these changes were to make to use the same configuration for multiple bars on different screens

There are two features that I implemented in this as they seemed somewhat similar/linked
- The addition of widget like arguments for `defwindow`, which can be specified when opening a window by function like parameters e.g. `window(param1,param2)`. (this was the first format I was able to come up with, but happy for suggestions, I wanted to allow it so it can be written without spaces.). The config for that would look like: `(defwindow [arg1, arg2] ...)`
  - I have made sure, however, that previous configs which don't include `[]` do still work
  - I have also updated it so that `monitor` option can use these local variables, I think we could also update it so that it can update other options, however I was only looking for setting the screen through this option
  - These options are then used as the unique identifier for the window of a sorts so that you can open up multiple windows as long as the parameters for each one is different as it uses the full `window(param1,param2)` when saving open windows as well as the scope
- Per window variable option: This allows variables to have `:per_window true` option set (the default is false) which will mean that the variable will be stored separately for each window. To do this I have refactored the `super_scope` out into an argument for the build functions so that it has to be specified, which then allows to create a specific "global" scope for each window, which then all the widgets link to instead of directly to the root scope.
  - To then solve the issue of updating these variables as they are no longer stored in the root scope, I added a `--window` option to the update command which allows you to specify the window this is for e.g. `--window primary`, or to also include an example of a window with parameters `--window "secondary(param1,param2)"`

## Usage

Kind of done this above but will show some better examples:

For the window parameters, I use this for a secondary bar, so that whatever number of monitors I have I can have a simple script get the number of monitors connected and generate a secondary bar for each monitor which is not the primary one

```
(defwindow secondary [monitor]
          :geometry (geometry
                       :x      "0%"
                       :y      "6px"
                       :width  "100%"
                       :height "30px"
                       :anchor "top center")
          :monitor    monitor
          :stacking   "bg"
          :windowtype "dock"
          :reserve    (struts :distance "50px" :side "top")
    (secondary_bar :window_num monitor :eww_update "${eww} update --window 'secondary(${monitor})'"))
```

Then my current launch script for each bars uses a function to generate the arguments and spits them in a command:

```
run_eww() {
    secondaries=($(get_secondary_bars))
    ${EWW} open-many \
        primary ${secondaries[@]}
}

get_secondary_bars() {
    raw_info=$(xrandr --listactivemonitors | grep "Monitors: ")
    num_monitors=${raw_info/Monitors: /}
    names=()
    for ((i = 1; i < $num_monitors; i++))
    do
        names[$i]="secondary($i)"
    done
    echo "${names[@]}"
}
```

So then for the local variable, when having an expanding option for a configuration, such as volume control, it allows the bars to work separately without having to have separate instances running in the background. So, currently my config for the volume widget looks like (99% stolen from [saimoom's config](https://github.com/Saimoomedits/eww-widgets)):

```
(defvar vol_reveal :per_window true false)

(defwidget volume [eww_update]
  (eventbox :onhover "${eww_update} vol_reveal=true"
              :onhoverlost "${eww_update} vol_reveal=false"
  (box :class "module-2" :space-evenly "false" :orientation "h" :spacing "3"
    (button   :onclick "scripts/pop audio"   :class "volume_icon" "")
    (revealer :transition "slideleft"
              :reveal vol_reveal
              :duration "350ms"
        (scale    :class "volbar"
                :value volume_percent
                :orientation "h"
                :tooltip "${volume_percent}%"
                :max 100
                :min 0
                :onchange "amixer -D pulse sset Master {}%" )))))
```

As you can see it uses the variable `eww_update` to update the volume, which is set above in the `secondary` config and passed down through the widgets. This then allows to get results such as shown in the showcase where one volume widget is showing the full slider where the other is not.

### Showcase

Apologies for the bad screenshot, my monitors are not aligned but they get the point across

<img width="3000" alt="image" src="https://user-images.githubusercontent.com/67910065/163837222-a4679d89-4bd8-4720-b9ae-b0861d892e45.png">

As you can see the bar on the left is showing the volume slider whereas the bar on the right is not, when both are running through the same instance of `eww` and also using the same widget shown above in the configuration

## Additional Notes

I guess I shall include my idea of "fleshing" the features out here.

- I'm pretty sure that having multiple window arguments breaks everything somehow... I only briefly tried it once when experimenting with something else

Would love some feedback on these:

- I think my next step would be to allow more options to be set by local variables, e.g. `stacking` or `windowtype` , or anything set in the `geometry`
- Error messages, mainly relating to the above as I think currently it won't give the right error, I didn't particularly check, because you can't use global variables in the `defwindow`, instead being stuck with only the local variables defined through the arguments
- Cleaning up the use of `AttrSpec` as `defwindow` does use it but it currently doesn't use the `optional` variable. This might be better off moved back so only `widget_use` uses it and instead `window_definition` uses just a simple Vector of `AttrName`
- Current extraction of window parameters is a bit basic and quite strict of what it needs to that should probably be loosened up.
- Also I shall write this down here, I would love to take suggestions for the current syntax/calling of a window with arguments as it doesn't particularly conform to the current way of specifying arguments, however I did want this to work smoothly with `open-many` command
- I think I have broken one of the tests, when I was skimming through some code, due to the change of making `monitor__num` a `SimplExpr` instead of an `i32`, I've probably broken a lot more, that is just the one I noticed. 
- Also I should probably add some tests

Question:

- I have added `args_span` to the `WindowDefintion` to be consistent with the `WidgetDefintion` , however just looking at it, it seems that this is only referenced in the `validate.rs` as debugging stuff, which I do not use so would this actually be necessary/should I remove it?

## Checklist

I've left most of these blank for now as I wanted to check these features are wanted before updating docs and stuff as I was not able to find anyone mentioning/asking for these features. (Also why its a draft PR)

- [x] Experiment with/Fix the bug related to having multiple arguments
- [x] Flesh out/clean up the code
- [x] Do more testing
- [x] Update/add tests as I think I have broken some
- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing (I must admit this is sad that it gets rid of aligned aligned code)


EDIT: the per window variables have been moved off this MR as a similar but better implementation is currently being worked on, to see my version of it see https://github.com/WilfSilver/eww/tree/per_window_variables