### PR TITLE
Add drag and drop functionality to eventbox (Implements #409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ## [Unreleased]
 
+### BREAKING CHANGES
+- Change the onclick command API to support multiple placeholders.
+  This changes. the behaviour of the calendar widget's onclick as well as the onhover and onhoverlost
+  events. Instead of providing the entire date (or, respecively, the x and y mouse coordinates) in
+  a single value (`day.month.year`, `x y`), the values are now provided as separate placeholders.
+  The day can now be accessed with `{0}`, the month with `{1}`, and the year with `{2}`, and
+  similarly x and y are accessed with `{0}` and `{1}`.
+
 ### Features
 - Add `eww inspector` command
 - Add `--no-daemonize` flag
@@ -18,7 +26,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `desktop` window type (By: Alvaro Lopez)
 - Add `scroll` widget (By: viandoxdev)
 - Add `notification` window type
-- Add drag and drop functionality
+- Add drag and drop functionality to eventbox
 
 ### Notable Internal changes
 - Rework state management completely, now making local state and dynamic widget hierarchy changes possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `desktop` window type (By: Alvaro Lopez)
 - Add `scroll` widget (By: viandoxdev)
 - Add `notification` window type
+- Add drag and drop functionality
 
 ### Notable Internal changes
 - Rework state management completely, now making local state and dynamic widget hierarchy changes possible.

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -207,7 +207,7 @@ pub(super) fn resolve_range_attrs(bargs: &mut BuilderArgs, gtk_widget: &gtk::Ran
             gtk_widget.set_sensitive(true);
             gtk_widget.add_events(gdk::EventMask::PROPERTY_CHANGE_MASK);
             connect_single_handler!(gtk_widget, gtk_widget.connect_value_changed(move |gtk_widget| {
-                run_command(timeout, &onchange, gtk_widget.value());
+                run_command(timeout, &onchange, &[gtk_widget.value()]);
             }));
         }
     });
@@ -241,7 +241,7 @@ fn build_gtk_combo_box_text(bargs: &mut BuilderArgs) -> Result<gtk::ComboBoxText
         // @prop onchange - runs the code when a item was selected, replacing {} with the item as a string
         prop(timeout: as_duration = Duration::from_millis(200), onchange: as_string) {
             connect_single_handler!(gtk_widget, gtk_widget.connect_changed(move |gtk_widget| {
-                run_command(timeout, &onchange, gtk_widget.active_text().unwrap_or_else(|| "".into()));
+                run_command(timeout, &onchange, &[gtk_widget.active_text().unwrap_or_else(|| "".into())]);
             }));
         },
     });
@@ -285,7 +285,7 @@ fn build_gtk_checkbox(bargs: &mut BuilderArgs) -> Result<gtk::CheckButton> {
         // @prop onunchecked - similar to onchecked but when the widget is unchecked
         prop(timeout: as_duration = Duration::from_millis(200), onchecked: as_string = "", onunchecked: as_string = "") {
             connect_single_handler!(gtk_widget, gtk_widget.connect_toggled(move |gtk_widget| {
-                run_command(timeout, if gtk_widget.is_active() { &onchecked } else { &onunchecked }, "");
+                run_command(timeout, if gtk_widget.is_active() { &onchecked } else { &onunchecked }, &[""]);
             }));
        }
     });
@@ -305,7 +305,7 @@ fn build_gtk_color_button(bargs: &mut BuilderArgs) -> Result<gtk::ColorButton> {
         // @prop timeout - timeout of the command
         prop(timeout: as_duration = Duration::from_millis(200), onchange: as_string) {
             connect_single_handler!(gtk_widget, gtk_widget.connect_color_set(move |gtk_widget| {
-                run_command(timeout, &onchange, gtk_widget.rgba());
+                run_command(timeout, &onchange, &[gtk_widget.rgba()]);
             }));
         }
     });
@@ -325,7 +325,7 @@ fn build_gtk_color_chooser(bargs: &mut BuilderArgs) -> Result<gtk::ColorChooserW
         // @prop timeout - timeout of the command
         prop(timeout: as_duration = Duration::from_millis(200), onchange: as_string) {
             connect_single_handler!(gtk_widget, gtk_widget.connect_color_activated(move |_a, color| {
-                run_command(timeout, &onchange, *color);
+                run_command(timeout, &onchange, &[*color]);
             }));
         }
     });
@@ -387,7 +387,7 @@ fn build_gtk_input(bargs: &mut BuilderArgs) -> Result<gtk::Entry> {
         // @prop timeout - timeout of the command
         prop(timeout: as_duration = Duration::from_millis(200), onchange: as_string) {
             connect_single_handler!(gtk_widget, gtk_widget.connect_changed(move |gtk_widget| {
-                run_command(timeout, &onchange, gtk_widget.text().to_string());
+                run_command(timeout, &onchange, &[gtk_widget.text().to_string()]);
             }));
         }
     });
@@ -413,9 +413,9 @@ fn build_gtk_button(bargs: &mut BuilderArgs) -> Result<gtk::Button> {
             gtk_widget.add_events(gdk::EventMask::BUTTON_PRESS_MASK);
             connect_single_handler!(gtk_widget, gtk_widget.connect_button_press_event(move |_, evt| {
                 match evt.button() {
-                    1 => run_command(timeout, &onclick, ""),
-                    2 => run_command(timeout, &onmiddleclick, ""),
-                    3 => run_command(timeout, &onrightclick, ""),
+                    1 => run_command(timeout, &onclick, &[""]),
+                    2 => run_command(timeout, &onmiddleclick, &[""]),
+                    3 => run_command(timeout, &onrightclick, &[""]),
                     _ => {},
                 }
                 gtk::Inhibit(false)
@@ -559,7 +559,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
             connect_single_handler!(gtk_widget, gtk_widget.connect_scroll_event(move |_, evt| {
                 let delta = evt.delta().1;
                 if delta != 0f64 { // Ignore the first event https://bugzilla.gnome.org/show_bug.cgi?id=675959
-                    run_command(timeout, &onscroll, if delta < 0f64 { "up" } else { "down" });
+                    run_command(timeout, &onscroll, &[if delta < 0f64 { "up" } else { "down" }]);
                 }
                 gtk::Inhibit(false)
             }));
@@ -570,7 +570,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
             gtk_widget.add_events(gdk::EventMask::ENTER_NOTIFY_MASK);
             connect_single_handler!(gtk_widget, gtk_widget.connect_enter_notify_event(move |_, evt| {
                 if evt.detail() != NotifyType::Inferior {
-                    run_command(timeout, &onhover, format!("{} {}", evt.position().0, evt.position().1));
+                    run_command(timeout, &onhover, &[evt.position().0, evt.position().1]);
                 }
                 gtk::Inhibit(false)
             }));
@@ -581,7 +581,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
             gtk_widget.add_events(gdk::EventMask::LEAVE_NOTIFY_MASK);
             connect_single_handler!(gtk_widget, gtk_widget.connect_leave_notify_event(move |_, evt| {
                 if evt.detail() != NotifyType::Inferior {
-                    run_command(timeout, &onhoverlost, format!("{} {}", evt.position().0, evt.position().1));
+                    run_command(timeout, &onhoverlost, &[evt.position().0, evt.position().1]);
                 }
                 gtk::Inhibit(false)
             }));
@@ -623,9 +623,10 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
                 gdk::DragAction::COPY,
             );
             connect_single_handler!(gtk_widget, gtk_widget.connect_drag_data_received(move |_, _, _x, _y, selection_data, _target_type, _timestamp| {
-                if let Some(data) = selection_data.uris().first().cloned().or_else(|| selection_data.text()) {
-                    // TODO provide the target type to the command somehow
-                    run_command(timeout, &ondropped, format!("{}", data));
+                if let Some(data) = selection_data.uris().first(){
+                    run_command(timeout, &ondropped, &[data.to_string(), "file".to_string()]);
+                } else if let Some(data) = selection_data.text(){
+                    run_command(timeout, &ondropped, &[data.to_string(), "text".to_string()]);
                 }
             }));
         },
@@ -760,14 +761,15 @@ fn build_gtk_calendar(bargs: &mut BuilderArgs) -> Result<gtk::Calendar> {
         prop(show_day_names: as_bool) { gtk_widget.set_show_day_names(show_day_names) },
         // @prop show-week-numbers - show week numbers
         prop(show_week_numbers: as_bool) { gtk_widget.set_show_week_numbers(show_week_numbers) },
-        // @prop onclick - command to run when the user selects a date. The `{}` placeholder will be replaced by the selected date.
+        // @prop onclick - command to run when the user selects a date. The `{0}` placeholder will be replaced by the selected day, `{1}` will be replaced by the month, and `{2}` by the year.
         // @prop timeout - timeout of the command
         prop(timeout: as_duration = Duration::from_millis(200), onclick: as_string) {
             connect_single_handler!(gtk_widget, gtk_widget.connect_day_selected(move |w| {
+                log::warn!("BREAKING CHANGE: The date is now provided via three values, set by the placeholders {{0}}, {{1}} and {{2}}. If you're currently using the onclick date, you will need to change this.");
                 run_command(
                     timeout,
                     &onclick,
-                    format!("{}.{}.{}", w.day(), w.month(), w.year())
+                    &[w.day(), w.month(), w.year()]
                 )
             }));
         }


### PR DESCRIPTION


## Description
This PR adds two new properties to eventbox: `dragvalue` and `ondropped`. These allow you to drag and drop onto/from an eventbox.

## Usage

```
(eventbox :ondropped "eww update tmp_value={}" :dragvalue {tmp_value} "drag & drop here"))
```



## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
