### PR TITLE
Fix/signal disconnect

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -11,8 +11,8 @@ use anyhow::{anyhow, Context, Result};
 use codespan_reporting::diagnostic::Severity;
 use eww_shared_util::Spanned;
 use gdk::{ModifierType, NotifyType};
-use gtk::{self, glib, prelude::*, DestDefaults, TargetEntry, TargetList};
 use glib::translate::FromGlib;
+use gtk::{self, glib, prelude::*, DestDefaults, TargetEntry, TargetList};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 
@@ -42,7 +42,7 @@ macro_rules! connect_signal_handler {
             let old = $widget.data::<gtk::glib::SignalHandlerId>(key);
 
             if let Some(old) = old {
-                 let a = old.as_ref().as_raw() ;
+                 let a = old.as_ref().as_raw();
                  $widget.disconnect(gtk::glib::SignalHandlerId::from_glib(a));
             }
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -11,12 +11,10 @@ use anyhow::{anyhow, Context, Result};
 use codespan_reporting::diagnostic::Severity;
 use eww_shared_util::Spanned;
 use gdk::{ModifierType, NotifyType};
-use glib::signal::SignalHandlerId;
 use gtk::{self, glib, prelude::*, DestDefaults, TargetEntry, TargetList};
 use glib::translate::FromGlib;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
-use std::hash::Hasher;
 
 use std::{
     cell::RefCell,

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -37,17 +37,16 @@ use yuck::{
 /// thus not connecting a new handler unless the condition is met.
 macro_rules! connect_signal_handler {
     ($widget:ident, if $cond:expr, $connect_expr:expr) => {{
-        let key = "signal_id";
-
         unsafe {
-            let old = $widget.data::<gtk::glib::SignalHandlerId>(&key);
+            let key = ::std::concat!("signal-handler:", ::std::line!());
+            let old = $widget.data::<gtk::glib::SignalHandlerId>(key);
 
             if let Some(old) = old {
                  let a = old.as_ref().as_raw() ;
                  $widget.disconnect(gtk::glib::SignalHandlerId::from_glib(a));
             }
 
-            $widget.set_data::<gtk::glib::SignalHandlerId>(&key, $connect_expr);
+            $widget.set_data::<gtk::glib::SignalHandlerId>(key, $connect_expr);
         }
     }};
     ($widget:ident, $connect_expr:expr) => {{


### PR DESCRIPTION
## Description

Fix for #443 
Replaces the static variable with the widget internal data field for SignalHandleId storage

## Additional Notes
Fixes #437 as well

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] I used `cargo fmt` to automatically format all code before committing
