### PR TITLE
Add overlay widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add transform widget (By: druskus20)
 - Add `:onaccept` to input field, add `:onclick` to eventbox
 - Add `EWW_CMD`, `EWW_CONFIG_DIR`, `EWW_EXECUTABLE` magic variables
+- Add `overlay` widget (By: viandoxdev)
 
 ### Notable Internal changes
 - Rework state management completely, now making local state and dynamic widget hierarchy changes possible.

--- a/crates/eww/src/widgets/build_widget.rs
+++ b/crates/eww/src/widgets/build_widget.rs
@@ -341,6 +341,11 @@ pub struct CustomWidgetInvocation {
 
 /// Make sure that [`gtk::Bin`] widgets only get a single child.
 fn validate_container_children_count(container: &gtk::Container, widget_use: &BasicWidgetUse) -> Result<(), DiagError> {
+    // ignore for overlay as it can take more than one.
+    if container.dynamic_cast_ref::<gtk::Overlay>().is_some() {
+        return Ok(())
+    }
+
     if container.dynamic_cast_ref::<gtk::Bin>().is_some() && widget_use.children.len() > 1 {
         Err(DiagError::new(gen_diagnostic! {
             kind =  Severity::Error,

--- a/crates/eww/src/widgets/build_widget.rs
+++ b/crates/eww/src/widgets/build_widget.rs
@@ -343,7 +343,7 @@ pub struct CustomWidgetInvocation {
 fn validate_container_children_count(container: &gtk::Container, widget_use: &BasicWidgetUse) -> Result<(), DiagError> {
     // ignore for overlay as it can take more than one.
     if container.dynamic_cast_ref::<gtk::Overlay>().is_some() {
-        return Ok(())
+        return Ok(());
     }
 
     if container.dynamic_cast_ref::<gtk::Bin>().is_some() && widget_use.children.len() > 1 {

--- a/crates/eww/src/widgets/def_widget_macro.rs
+++ b/crates/eww/src/widgets/def_widget_macro.rs
@@ -45,7 +45,8 @@ macro_rules! def_widget {
                             f: Box::new({
                                 let $gtk_widget = gdk::glib::clone::Downgrade::downgrade(&$gtk_widget);
                                 move |$scope_graph, values| {
-                                    let $gtk_widget = gdk::glib::clone::Upgrade::upgrade(&$gtk_widget).unwrap();
+                                    let $gtk_widget = gdk::glib::clone::Upgrade::upgrade(&$gtk_widget)
+                                        .ok_or_else(|| anyhow!("Couldn't upgrade reference."))?;
                                     // values is a map of all the variables that are required to evaluate the
                                     // attributes expression.
 

--- a/crates/eww/src/widgets/def_widget_macro.rs
+++ b/crates/eww/src/widgets/def_widget_macro.rs
@@ -45,8 +45,8 @@ macro_rules! def_widget {
                             f: Box::new({
                                 let $gtk_widget = gdk::glib::clone::Downgrade::downgrade(&$gtk_widget);
                                 move |$scope_graph, values| {
-                                    let $gtk_widget = gdk::glib::clone::Upgrade::upgrade(&$gtk_widget)
-                                        .ok_or_else(|| anyhow!("Couldn't upgrade reference."))?;
+                                    // This fails sometimes but I couldn't figure out why
+                                    let $gtk_widget = gdk::glib::clone::Upgrade::upgrade(&$gtk_widget).unwrap();
                                     // values is a map of all the variables that are required to evaluate the
                                     // attributes expression.
 

--- a/crates/eww/src/widgets/def_widget_macro.rs
+++ b/crates/eww/src/widgets/def_widget_macro.rs
@@ -45,7 +45,6 @@ macro_rules! def_widget {
                             f: Box::new({
                                 let $gtk_widget = gdk::glib::clone::Downgrade::downgrade(&$gtk_widget);
                                 move |$scope_graph, values| {
-                                    // This fails sometimes but I couldn't figure out why
                                     let $gtk_widget = gdk::glib::clone::Upgrade::upgrade(&$gtk_widget).unwrap();
                                     // values is a map of all the variables that are required to evaluate the
                                     // attributes expression.

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -518,7 +518,8 @@ fn build_gtk_box(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
 
 const WIDGET_NAME_OVERLAY: &str = "overlay";
 /// @widget overlay
-/// @desc a widget that places its children on top of each other.
+/// @desc a widget that places its children on top of each other. The overlay widget takes the size
+/// of its first child.
 fn build_gtk_overlay(bargs: &mut BuilderArgs) -> Result<gtk::Overlay> {
     let gtk_widget = gtk::Overlay::new();
     

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -518,7 +518,7 @@ fn build_gtk_box(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
 
 const WIDGET_NAME_OVERLAY: &str = "overlay";
 /// @widget overlay
-/// @desc a widget that can overlay its children over its first child
+/// @desc a widget that places its children on top of each other.
 fn build_gtk_overlay(bargs: &mut BuilderArgs) -> Result<gtk::Overlay> {
     let gtk_widget = gtk::Overlay::new();
     

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -522,7 +522,7 @@ const WIDGET_NAME_OVERLAY: &str = "overlay";
 /// of its first child.
 fn build_gtk_overlay(bargs: &mut BuilderArgs) -> Result<gtk::Overlay> {
     let gtk_widget = gtk::Overlay::new();
-    
+
     // no def_widget because this widget has no props.
     // And this widget has no proprs because they would pretty much just be the same as boxes,
     // so you might as well just use a box inside the widget to get them.

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -84,6 +84,7 @@ pub const BUILTIN_WIDGET_NAMES: &[&str] = &[
 //// widget definitions
 pub(super) fn widget_use_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::Widget> {
     let gtk_widget = match bargs.widget_use.name.as_str() {
+<<<<<<< HEAD
         WIDGET_NAME_BOX => build_gtk_box(bargs)?.upcast(),
         WIDGET_NAME_CENTERBOX => build_center_box(bargs)?.upcast(),
         WIDGET_NAME_EVENTBOX => build_gtk_event_box(bargs)?.upcast(),
@@ -105,6 +106,30 @@ pub(super) fn widget_use_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::W
         WIDGET_NAME_CHECKBOX => build_gtk_checkbox(bargs)?.upcast(),
         WIDGET_NAME_REVEALER => build_gtk_revealer(bargs)?.upcast(),
         WIDGET_NAME_SCROLL => build_gtk_scrolledwindow(bargs)?.upcast(),
+=======
+        "box" => build_gtk_box(bargs)?.upcast(),
+        "centerbox" => build_center_box(bargs)?.upcast(),
+        "eventbox" => build_gtk_event_box(bargs)?.upcast(),
+        "circular-progress" => build_circular_progress_bar(bargs)?.upcast(),
+        "graph" => build_graph(bargs)?.upcast(),
+        "transform" => build_transform(bargs)?.upcast(),
+        "scale" => build_gtk_scale(bargs)?.upcast(),
+        "progress" => build_gtk_progress(bargs)?.upcast(),
+        "image" => build_gtk_image(bargs)?.upcast(),
+        "button" => build_gtk_button(bargs)?.upcast(),
+        "label" => build_gtk_label(bargs)?.upcast(),
+        "literal" => build_gtk_literal(bargs)?.upcast(),
+        "input" => build_gtk_input(bargs)?.upcast(),
+        "calendar" => build_gtk_calendar(bargs)?.upcast(),
+        "color-button" => build_gtk_color_button(bargs)?.upcast(),
+        "expander" => build_gtk_expander(bargs)?.upcast(),
+        "color-chooser" => build_gtk_color_chooser(bargs)?.upcast(),
+        "combo-box-text" => build_gtk_combo_box_text(bargs)?.upcast(),
+        "checkbox" => build_gtk_checkbox(bargs)?.upcast(),
+        "revealer" => build_gtk_revealer(bargs)?.upcast(),
+        "scroll" => build_gtk_scrolledwindow(bargs)?.upcast(),
+        "overlay" => build_gtk_overlay(bargs)?.upcast(),
+>>>>>>> 5726fc6 (overlay widget)
         _ => {
             return Err(AstError::ValidationError(ValidationError::UnknownWidget(
                 bargs.widget_use.name_span,
@@ -512,6 +537,44 @@ fn build_gtk_box(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
         prop(space_evenly: as_bool = true) { gtk_widget.set_homogeneous(space_evenly) },
     });
     Ok(gtk_widget)
+}
+
+const WIDGET_NAME_OVERLAY: &str = "overlay";
+/// @widget overlay
+/// @desc a widget that can overlay its children over its first child
+fn build_gtk_overlay(bargs: &mut BuilderArgs) -> Result<gtk::Overlay> {
+    let gtk_widget = gtk::Overlay::new();
+    
+    // no def_widget because this widget has no props.
+    // And this widget has no proprs because they would pretty much just be the same as boxes,
+    // so you might as well just use a box inside the widget to get them.
+
+    match bargs.widget_use.children.len().cmp(&1) {
+        Ordering::Less => {
+            Err(DiagError::new(gen_diagnostic!("overlay must contain at least one element", bargs.widget_use.span)).into())
+        }
+        Ordering::Greater | Ordering::Equal => {
+            let mut children = bargs.widget_use.children.iter().map(|child| {
+                build_gtk_widget(
+                    bargs.scope_graph,
+                    bargs.widget_defs.clone(),
+                    bargs.calling_scope,
+                    child.clone(),
+                    bargs.custom_widget_invocation.clone(),
+                )
+            });
+            // we have more than one children, we can unwrap
+            let first = children.next().unwrap()?;
+            gtk_widget.add(&first);
+            first.show();
+            for child in children {
+                let child = child?;
+                gtk_widget.add_overlay(&child);
+                child.show();
+            }
+            Ok(gtk_widget)
+        }
+    }
 }
 
 const WIDGET_NAME_CENTERBOX: &str = "centerbox";

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -84,7 +84,6 @@ pub const BUILTIN_WIDGET_NAMES: &[&str] = &[
 //// widget definitions
 pub(super) fn widget_use_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::Widget> {
     let gtk_widget = match bargs.widget_use.name.as_str() {
-<<<<<<< HEAD
         WIDGET_NAME_BOX => build_gtk_box(bargs)?.upcast(),
         WIDGET_NAME_CENTERBOX => build_center_box(bargs)?.upcast(),
         WIDGET_NAME_EVENTBOX => build_gtk_event_box(bargs)?.upcast(),
@@ -106,30 +105,7 @@ pub(super) fn widget_use_to_gtk_widget(bargs: &mut BuilderArgs) -> Result<gtk::W
         WIDGET_NAME_CHECKBOX => build_gtk_checkbox(bargs)?.upcast(),
         WIDGET_NAME_REVEALER => build_gtk_revealer(bargs)?.upcast(),
         WIDGET_NAME_SCROLL => build_gtk_scrolledwindow(bargs)?.upcast(),
-=======
-        "box" => build_gtk_box(bargs)?.upcast(),
-        "centerbox" => build_center_box(bargs)?.upcast(),
-        "eventbox" => build_gtk_event_box(bargs)?.upcast(),
-        "circular-progress" => build_circular_progress_bar(bargs)?.upcast(),
-        "graph" => build_graph(bargs)?.upcast(),
-        "transform" => build_transform(bargs)?.upcast(),
-        "scale" => build_gtk_scale(bargs)?.upcast(),
-        "progress" => build_gtk_progress(bargs)?.upcast(),
-        "image" => build_gtk_image(bargs)?.upcast(),
-        "button" => build_gtk_button(bargs)?.upcast(),
-        "label" => build_gtk_label(bargs)?.upcast(),
-        "literal" => build_gtk_literal(bargs)?.upcast(),
-        "input" => build_gtk_input(bargs)?.upcast(),
-        "calendar" => build_gtk_calendar(bargs)?.upcast(),
-        "color-button" => build_gtk_color_button(bargs)?.upcast(),
-        "expander" => build_gtk_expander(bargs)?.upcast(),
-        "color-chooser" => build_gtk_color_chooser(bargs)?.upcast(),
-        "combo-box-text" => build_gtk_combo_box_text(bargs)?.upcast(),
-        "checkbox" => build_gtk_checkbox(bargs)?.upcast(),
-        "revealer" => build_gtk_revealer(bargs)?.upcast(),
-        "scroll" => build_gtk_scrolledwindow(bargs)?.upcast(),
-        "overlay" => build_gtk_overlay(bargs)?.upcast(),
->>>>>>> 5726fc6 (overlay widget)
+        WIDGET_NAME_OVERLAY => build_gtk_overlay(bargs)?.upcast(),
         _ => {
             return Err(AstError::ValidationError(ValidationError::UnknownWidget(
                 bargs.widget_use.name_span,

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -79,6 +79,7 @@ pub const BUILTIN_WIDGET_NAMES: &[&str] = &[
     WIDGET_NAME_CHECKBOX,
     WIDGET_NAME_REVEALER,
     WIDGET_NAME_SCROLL,
+    WIDGET_NAME_OVERLAY,
 ];
 
 //// widget definitions


### PR DESCRIPTION
## Description

This PR adds the overlay widget, that overlays its children instead of placing them next to each others.

## Usage

```
(overlay
  (child 1)
  (overlayed child)
  ...)
```
The overlay widget takes no props, and takes the size of its first child.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
