### PR TITLE
use glob to match workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,5 @@
 [workspace]
-members = [
-    "crates/eww",
-    "crates/simplexpr",
-    "crates/yuck",
-    "crates/eww_shared_util"
-]
+members = ["crates/*"]
 [profile.dev]
 split-debuginfo = "unpacked"
 


### PR DESCRIPTION
This makes it so this doesn't have to be updated if new workspace crates are introduced.