### PR TITLE
Resolves #501 Add password prop to input

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -440,6 +440,10 @@ fn build_gtk_input(bargs: &mut BuilderArgs) -> Result<gtk::Entry> {
             connect_signal_handler!(gtk_widget, gtk_widget.connect_activate(move |gtk_widget| {
                 run_command(timeout, &onaccept, &[gtk_widget.text().to_string()]);
             }));
+        },
+        // @prop password - if the input is obscured
+        prop(password: as_bool = false) {
+            gtk_widget.set_visibility(!password);
         }
     });
     Ok(gtk_widget)


### PR DESCRIPTION
## Description

This adds the `password` prop to input widgets, setting this prop to true hides the characters in the input

## Usage

```clojure
(input :password true)
```

## Checklist

- [x] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
