### PR TITLE
Add support for "round-digits" property for scale widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `:onaccept` to input field, add `:onclick` to eventbox
 - Add `EWW_CMD`, `EWW_CONFIG_DIR`, `EWW_EXECUTABLE` magic variables
 - Add `overlay` widget (By: viandoxdev)
+- Add `:round-digits` to scale widget (By: gavynriebau)
 
 ### Notable Internal changes
 - Rework state management completely, now making local state and dynamic widget hierarchy changes possible.

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -394,6 +394,10 @@ fn build_gtk_scale(bargs: &mut BuilderArgs) -> Result<gtk::Scale> {
 
         // @prop draw-value - draw the value of the property
         prop(draw_value: as_bool = false) { gtk_widget.set_draw_value(draw_value) },
+
+        // @prop round-digits - Sets the number of digits to round the value to when it changes
+        prop(round_digits: as_i32 = 0) { gtk_widget.set_round_digits(round_digits) }
+
     });
     Ok(gtk_widget)
 }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -395,7 +395,7 @@ fn build_gtk_scale(bargs: &mut BuilderArgs) -> Result<gtk::Scale> {
         // @prop draw-value - draw the value of the property
         prop(draw_value: as_bool = false) { gtk_widget.set_draw_value(draw_value) },
 
-        // @prop round-digits - Sets the number of digits to round the value to when it changes
+        // @prop round-digits - Sets the number of decimals to round the value to when it changes
         prop(round_digits: as_i32 = 0) { gtk_widget.set_round_digits(round_digits) }
 
     });


### PR DESCRIPTION
## Description

This property enables controlling to how many digits the value of a
scale gets rounded to when the value changes.

## Usage

This property can be used on the scale control like the following:

```scheme
(scale :min 0
           :max 101
           :marks true
           :hexpand true
           :value volume
           :draw-value true
           :round-digits "0"
           :onchange "scripts/setvol {}")
```

### Demo

The following shows the behavior of a scale control before and after this change was introduced.
In the "before" video we can see that the value of the "volume" (shown on right) would not consistently update because as the slider is dragged with the mouse the values include decimal values. When a decimal value is included the "setvol" function was not successful.
In the "after" video setting the value is successful because the values are rounded to zero decimal places.

The "volume" variable was setup as follows:
```scheme
(deflisten volume :initial "0"
  "scripts/pollvol")
```

**Before**
https://user-images.githubusercontent.com/11895736/182007096-32a4c08c-9593-40c3-a7d4-152a590a0733.mp4

**After**
https://user-images.githubusercontent.com/11895736/182007111-150d3461-1b75-40f7-bfd9-a152240b8412.mp4


## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [X] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes. (property docs automatically generated??)
- [X] I used `cargo fmt` to automatically format all code before committing
