### PR TITLE
Add support for `:active` on event box

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -634,7 +634,7 @@ fn build_gtk_scrolledwindow(bargs: &mut BuilderArgs) -> Result<gtk::ScrolledWind
 
 const WIDGET_NAME_EVENTBOX: &str = "eventbox";
 /// @widget eventbox
-/// @desc a container which can receive events and must contain exactly one child. Supports `:hover` css selectors.
+/// @desc a container which can receive events and must contain exactly one child. Supports `:hover` and `:active` css selectors.
 fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
     let gtk_widget = gtk::EventBox::new();
 
@@ -650,6 +650,17 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
         if evt.detail() != NotifyType::Inferior {
             gtk_widget.clone().unset_state_flags(gtk::StateFlags::PRELIGHT);
         }
+        gtk::Inhibit(false)
+    });
+
+    // Support :active selector
+    gtk_widget.connect_button_press_event(|gtk_widget, _| {
+        gtk_widget.clone().set_state_flags(gtk::StateFlags::ACTIVE, false);
+        gtk::Inhibit(false)
+    });
+
+    gtk_widget.connect_button_release_event(|gtk_widget, _| {
+        gtk_widget.clone().unset_state_flags(gtk::StateFlags::ACTIVE);
         gtk::Inhibit(false)
     });
 


### PR DESCRIPTION
## Description

This PR adds support for the `:active` pseudo class on event boxes

## Usage

```scss
// or any selector to an event box
.event-box:active {
  // ...
}
```

## Checklist

- [X] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
