### PR TITLE
Safe Access Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add support for output names in X11 to select `:monitor`.
 - Add support for `:active`-pseudoselector on eventbox (By: viandoxdev)
 - Add support for `:password` on input (By: viandoxdev)
+- Add support for safe access (`?.`) in simplexpr
 
 ### Notable fixes and other changes
 - Scale now only runs the onchange command on changes caused by user-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ## [Unreleased]
 
+### Features
+- Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)
+
 ## [0.4.0] (04.09.2022)
 
 ### BREAKING CHANGES
@@ -14,7 +17,6 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add support for output names in X11 to select `:monitor`.
 - Add support for `:active`-pseudoselector on eventbox (By: viandoxdev)
 - Add support for `:password` on input (By: viandoxdev)
-- Add support for safe access (`?.`) in simplexpr
 
 ### Notable fixes and other changes
 - Scale now only runs the onchange command on changes caused by user-interaction

--- a/crates/simplexpr/src/ast.rs
+++ b/crates/simplexpr/src/ast.rs
@@ -33,9 +33,10 @@ pub enum UnaryOp {
     Negative,
 }
 
+/// Differenciates between regular field access (`foo.bar`) and null-safe field access (`foo?.bar`)
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AccessType {
-    Assert,
+    Normal,
     Safe,
 }
 
@@ -71,7 +72,7 @@ impl std::fmt::Display for SimplExpr {
             SimplExpr::BinOp(_, l, op, r) => write!(f, "({} {} {})", l, op, r),
             SimplExpr::UnaryOp(_, op, x) => write!(f, "{}{}", op, x),
             SimplExpr::IfElse(_, a, b, c) => write!(f, "({} ? {} : {})", a, b, c),
-            SimplExpr::JsonAccess(_, AccessType::Assert, value, index) => write!(f, "{}[{}]", value, index),
+            SimplExpr::JsonAccess(_, AccessType::Normal, value, index) => write!(f, "{}[{}]", value, index),
             SimplExpr::JsonAccess(_, AccessType::Safe, value, index) => write!(f, "{}?.[{}]", value, index),
             SimplExpr::FunctionCall(_, function_name, args) => {
                 write!(f, "{}({})", function_name, args.iter().join(", "))

--- a/crates/simplexpr/src/ast.rs
+++ b/crates/simplexpr/src/ast.rs
@@ -33,7 +33,7 @@ pub enum UnaryOp {
     Negative,
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AccessType {
     Assert,
     Safe,

--- a/crates/simplexpr/src/ast.rs
+++ b/crates/simplexpr/src/ast.rs
@@ -34,6 +34,12 @@ pub enum UnaryOp {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AccessType {
+    Assert,
+    Safe,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SimplExpr {
     Literal(DynVal),
     JsonArray(Span, Vec<SimplExpr>),
@@ -43,7 +49,7 @@ pub enum SimplExpr {
     BinOp(Span, Box<SimplExpr>, BinOp, Box<SimplExpr>),
     UnaryOp(Span, UnaryOp, Box<SimplExpr>),
     IfElse(Span, Box<SimplExpr>, Box<SimplExpr>, Box<SimplExpr>),
-    JsonAccess(Span, Box<SimplExpr>, Box<SimplExpr>),
+    JsonAccess(Span, AccessType, Box<SimplExpr>, Box<SimplExpr>),
     FunctionCall(Span, String, Vec<SimplExpr>),
 }
 
@@ -65,7 +71,8 @@ impl std::fmt::Display for SimplExpr {
             SimplExpr::BinOp(_, l, op, r) => write!(f, "({} {} {})", l, op, r),
             SimplExpr::UnaryOp(_, op, x) => write!(f, "{}{}", op, x),
             SimplExpr::IfElse(_, a, b, c) => write!(f, "({} ? {} : {})", a, b, c),
-            SimplExpr::JsonAccess(_, value, index) => write!(f, "{}[{}]", value, index),
+            SimplExpr::JsonAccess(_, AccessType::Assert, value, index) => write!(f, "{}[{}]", value, index),
+            SimplExpr::JsonAccess(_, AccessType::Safe, value, index) => write!(f, "{}?.[{}]", value, index),
             SimplExpr::FunctionCall(_, function_name, args) => {
                 write!(f, "{}({})", function_name, args.iter().join(", "))
             }
@@ -101,7 +108,7 @@ impl SimplExpr {
             Literal(_) => false,
             Concat(_, x) | FunctionCall(_, _, x) | JsonArray(_, x) => x.iter().any(|x| x.references_var(var)),
             JsonObject(_, x) => x.iter().any(|(k, v)| k.references_var(var) || v.references_var(var)),
-            JsonAccess(_, a, b) | BinOp(_, a, _, b) => a.references_var(var) || b.references_var(var),
+            JsonAccess(_, _, a, b) | BinOp(_, a, _, b) => a.references_var(var) || b.references_var(var),
             UnaryOp(_, _, x) => x.references_var(var),
             IfElse(_, a, b, c) => a.references_var(var) || b.references_var(var) || c.references_var(var),
             VarRef(_, x) => x == var,
@@ -113,7 +120,7 @@ impl SimplExpr {
         match self {
             VarRef(_, x) => dest.push(x.clone()),
             UnaryOp(_, _, x) => x.as_ref().collect_var_refs_into(dest),
-            BinOp(_, a, _, b) | JsonAccess(_, a, b) => {
+            BinOp(_, a, _, b) | JsonAccess(_, _, a, b) => {
                 a.as_ref().collect_var_refs_into(dest);
                 b.as_ref().collect_var_refs_into(dest);
             }

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 
 use crate::{
-    ast::{BinOp, SimplExpr, UnaryOp},
+    ast::{AccessType, BinOp, SimplExpr, UnaryOp},
     dynval::{ConversionError, DynVal},
 };
 use eww_shared_util::{Span, Spanned, VarName};
@@ -221,7 +221,6 @@ impl SimplExpr {
                 }
             }
             SimplExpr::JsonAccess(span, safe, val, index) => {
-                // TODO(josiah) Recover as empty string in the case that call is safe
                 let val = val.eval(values)?;
                 let index = index.eval(values)?;
                 match val.as_json_value()? {
@@ -237,6 +236,7 @@ impl SimplExpr {
                             .unwrap_or(&serde_json::Value::Null);
                         Ok(DynVal::from(indexed_value).at(*span))
                     }
+                    _ if *safe == AccessType::Safe => Ok(DynVal::from(&serde_json::Value::Null).at(*span)),
                     _ => Err(EvalError::CannotIndex(format!("{}", val)).at(*span)),
                 }
             }

--- a/crates/simplexpr/src/parser/lexer.rs
+++ b/crates/simplexpr/src/parser/lexer.rs
@@ -28,6 +28,7 @@ pub enum Token {
     GT,
     LT,
     Elvis,
+    SafeAccess,
     RegexMatch,
 
     Not,
@@ -88,6 +89,7 @@ regex_rules! {
     r">"     => |_| Token::GT,
     r"<"     => |_| Token::LT,
     r"\?:"    => |_| Token::Elvis,
+    r"\?\."    => |_| Token::SafeAccess,
     r"=~"    => |_| Token::RegexMatch,
 
     r"!"     => |_| Token::Not,

--- a/crates/simplexpr/src/parser/lexer.rs
+++ b/crates/simplexpr/src/parser/lexer.rs
@@ -320,5 +320,6 @@ mod test {
             "${ {"hi": "ho"}.hi }".hi
         "#),
         empty_interpolation   => v!(r#""${}""#),
+        safe_interpolation   => v!(r#""${ { "key": "value" }.key1?.key2 ?: "Recovery" }""#),
     }
 }

--- a/crates/simplexpr/src/parser/mod.rs
+++ b/crates/simplexpr/src/parser/mod.rs
@@ -41,6 +41,7 @@ mod tests {
             "foo.bar[2 + 2] * asdf[foo.bar]",
             r#"[1, 2, 3 + 4, "bla", [blub, blo]]"#,
             r#"{ "key": "value", 5: 1+2, true: false }"#,
+            r#"{ "key": "value" }?.key?.does_not_exist"#,
         );
     }
 }

--- a/crates/simplexpr/src/parser/snapshots/simplexpr__parser__lexer__test__safe_interpolation.snap
+++ b/crates/simplexpr/src/parser/snapshots/simplexpr__parser__lexer__test__safe_interpolation.snap
@@ -1,0 +1,5 @@
+---
+source: crates/simplexpr/src/parser/lexer.rs
+expression: "v!(r#\"\"${ { \"key\": \"value\" }.key1?.key2 ?: \"Recovery\" }\"\"#)"
+---
+(0, StringLit([(0, Literal(""), 3), (3, Interp([(4, LCurl, 5), (6, StringLit([(6, Literal("key"), 11)]), 11), (11, Colon, 12), (13, StringLit([(13, Literal("value"), 20)]), 20), (21, RCurl, 22), (22, Dot, 23), (23, Ident("key1"), 27), (27, SafeAccess, 29), (29, Ident("key2"), 33), (34, Elvis, 36), (37, StringLit([(37, Literal("Recovery"), 47)]), 47)]), 48), (48, Literal(""), 50)]), 50)

--- a/crates/simplexpr/src/parser/snapshots/simplexpr__parser__tests__test-16.snap
+++ b/crates/simplexpr/src/parser/snapshots/simplexpr__parser__tests__test-16.snap
@@ -1,0 +1,7 @@
+---
+source: crates/simplexpr/src/parser/mod.rs
+expression: "p.parse(0, Lexer::new(0, 0, r#\"{ \"key\": \"value\" }?.key?.does_not_exist\"#))"
+---
+Ok(
+    {"key": "value"}?.["key"]?.["does_not_exist"],
+)

--- a/crates/simplexpr/src/simplexpr_parser.lalrpop
+++ b/crates/simplexpr/src/simplexpr_parser.lalrpop
@@ -77,11 +77,11 @@ pub Expr: SimplExpr = {
   #[precedence(level="1")] #[assoc(side="right")]
   <l:@L> <ident:"identifier"> "(" <args: Comma<ExprReset>> ")" <r:@R> => FunctionCall(Span(l, r, fid), ident, args),
   <l:@L> <value:Expr>         "[" <index: ExprReset>       "]" <r:@R> => {
-    JsonAccess(Span(l, r, fid), AccessType::Assert, b(value), b(index))
+    JsonAccess(Span(l, r, fid), AccessType::Normal, b(value), b(index))
   },
 
   <l:@L> <value:Expr> "." <lit_l:@L> <index:"identifier"> <r:@R> => {
-    JsonAccess(Span(l, r, fid), AccessType::Assert, b(value), b(Literal(index.into())))
+    JsonAccess(Span(l, r, fid), AccessType::Normal, b(value), b(Literal(index.into())))
   },
 
   <l:@L> <value:Expr> "?." <lit_l:@L> <index:"identifier"> <r:@R> => {

--- a/crates/simplexpr/src/simplexpr_parser.lalrpop
+++ b/crates/simplexpr/src/simplexpr_parser.lalrpop
@@ -1,4 +1,4 @@
-use crate::ast::{SimplExpr::{self, *}, BinOp::*, UnaryOp::*};
+use crate::ast::{SimplExpr::{self, *}, BinOp::*, UnaryOp::*, AccessType};
 use eww_shared_util::{Span, VarName};
 use crate::parser::lexer::{Token, LexicalError, StrLitSegment, Sp};
 use crate::parser::lalrpop_helpers::*;
@@ -25,6 +25,7 @@ extern {
     ">"  => Token::GT,
     "<"  => Token::LT,
     "?:" => Token::Elvis,
+    "?." => Token::SafeAccess,
     "=~" => Token::RegexMatch,
 
     "!"  => Token::Not,
@@ -75,10 +76,16 @@ pub Expr: SimplExpr = {
 
   #[precedence(level="1")] #[assoc(side="right")]
   <l:@L> <ident:"identifier"> "(" <args: Comma<ExprReset>> ")" <r:@R> => FunctionCall(Span(l, r, fid), ident, args),
-  <l:@L> <value:Expr>         "[" <index: ExprReset>       "]" <r:@R> => JsonAccess(Span(l, r, fid), b(value), b(index)),
+  <l:@L> <value:Expr>         "[" <index: ExprReset>       "]" <r:@R> => {
+    JsonAccess(Span(l, r, fid), AccessType::Assert, b(value), b(index))
+  },
 
   <l:@L> <value:Expr> "." <lit_l:@L> <index:"identifier"> <r:@R> => {
-    JsonAccess(Span(l, r, fid), b(value), b(Literal(index.into())))
+    JsonAccess(Span(l, r, fid), AccessType::Assert, b(value), b(Literal(index.into())))
+  },
+
+  <l:@L> <value:Expr> "?." <lit_l:@L> <index:"identifier"> <r:@R> => {
+    JsonAccess(Span(l, r, fid), AccessType::Safe, b(value), b(Literal(index.into())))
   },
 
   #[precedence(level="2")] #[assoc(side="right")]

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -24,7 +24,14 @@ Supported currently are the following features:
 - comparisons (`==`, `!=`, `>`, `<`, `<=`, `>=`)
 - boolean operations (`||`, `&&`, `!`)
 - elvis operator (`?:`)
-    - if the left side is `""`, then returns the right side, otherwise evaluates to the left side.
+    - if the left side is `""` or a JSON `null`, then returns the right side,
+      otherwise evaluates to the left side.
+- Safe Access operator (`?.`)
+    - if the left side is `""` or a JSON `null`, then return `null`. Otherwise,
+      attempt to index.
+    - This can still cause an error to occur if the left hand side exists but is
+      not an object.
+      (`Number` or `String`).
 - conditionals (`condition ? 'value' : 'other value'`)
 - numbers, strings, booleans and variable references (`12`, `'hi'`, `true`, `some_variable`)
 - json access (`object.field`, `array[12]`, `object["field"]`)


### PR DESCRIPTION
## Description

- closes #565
- Updates the elvis operator `?:` to treat a JSON `Null` the same as the empty string `""`  
  This was done, as that is what is returned by an object access for an undefined field.

## Usage

```
:label { labels?.workspaces?.one ?: "Workspace One" }
```

with some varable `labels`. `labels.workspaces.one ?: "Workspace One"` would error if:

- `labels` was not an object
- `labels.workspaces` was not an object

It would also act strangely if either any of `labels`, `.workspaces`, or `.one` were `Null`, as the elvis operator treated that as "already existing".


[Diffs containing full example of usage](https://github.com/oldwomanjosiah/dots/compare/220108101c45d10556dd110b73585b734ead72a0...dc10ecddda61503ec479252a218cf40e40ba1a6c)

## Additional Notes

It might also make sense to allow for `opt-object?.[key-expr]`, but that is left for a follow-up.

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
