### PR TITLE
Allow for floating-point percentages in window geometry (fixes #601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ### Features
 - Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)
+- Allow floating-point numbers in percentages for window-geometry
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -23,7 +23,7 @@ mod backend {
 
     use super::*;
 
-    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize)]
     pub struct BackendWindowOptions {
         pub wm_ignore: bool,
         pub sticky: bool,
@@ -94,7 +94,7 @@ mod backend {
     }
 
     // Surface definition if the backend for X11 is enable
-    #[derive(Debug, Clone, Copy, Eq, PartialEq, Default, serde::Serialize)]
+    #[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize)]
     pub struct StrutDefinition {
         pub side: Side,
         pub dist: NumWithUnit,

--- a/crates/yuck/src/config/config.rs
+++ b/crates/yuck/src/config/config.rs
@@ -89,7 +89,7 @@ impl FromAst for TopLevel {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, serde::Serialize)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Config {
     pub widget_definitions: HashMap<String, WidgetDefinition>,
     pub window_definitions: HashMap<String, WindowDefinition>,

--- a/crates/yuck/src/config/window_definition.rs
+++ b/crates/yuck/src/config/window_definition.rs
@@ -17,7 +17,7 @@ use eww_shared_util::{AttrName, Span, VarName};
 
 use super::{backend_window_options::BackendWindowOptions, widget_use::WidgetUse, window_geometry::WindowGeometry};
 
-#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Serialize, PartialEq)]
 pub struct WindowDefinition {
     pub name: String,
     pub geometry: Option<WindowGeometry>,

--- a/crates/yuck/src/config/window_geometry.rs
+++ b/crates/yuck/src/config/window_geometry.rs
@@ -110,7 +110,7 @@ impl std::str::FromStr for AnchorPoint {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct WindowGeometry {
     pub anchor_point: AnchorPoint,
     pub offset: Coords,


### PR DESCRIPTION
## Description

Allows floating-point numbers in percentage values in window geometry.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
