### PR TITLE
Fixes #608 make exclusive more configurable on wayland

### DIFF
--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -14,6 +14,7 @@ mod platform {
     use gdk;
     use gtk::prelude::*;
     use yuck::config::{
+        backend_window_options::ExclusiveZone,
         window_definition::{WindowDefinition, WindowStacking},
         window_geometry::AnchorAlignment,
     };
@@ -84,9 +85,12 @@ mod platform {
                 gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Top, yoffset);
             }
         }
-        if window_def.backend_options.exclusive {
-            gtk_layer_shell::auto_exclusive_zone_enable(&window);
-        }
+        match window_def.backend_options.exclusive {
+            ExclusiveZone::Exclusive => gtk_layer_shell::auto_exclusive_zone_enable(&window),
+            ExclusiveZone::Ignore => gtk_layer_shell::set_exclusive_zone(&window, -1),
+            // Normal means using the default value
+            ExclusiveZone::Normal => {}
+        };
         Some(window)
     }
 }

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -116,15 +116,34 @@ mod backend {
     use super::*;
     #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
     pub struct BackendWindowOptions {
-        pub exclusive: bool,
+        pub exclusive: ExclusiveZone,
         pub focusable: bool,
     }
     impl BackendWindowOptions {
         pub fn from_attrs(attrs: &mut Attributes) -> DiagResult<Self> {
             Ok(Self {
-                exclusive: attrs.primitive_optional("exclusive")?.unwrap_or(false),
+                exclusive: attrs.primitive_optional("exclusive")?.unwrap_or(ExclusiveZone::Normal),
                 focusable: attrs.primitive_optional("focusable")?.unwrap_or(false),
             })
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, smart_default::SmartDefault, serde::Serialize)]
+    pub enum ExclusiveZone {
+        #[default]
+        Normal,
+        Ignore,
+        Exclusive,
+    }
+    impl FromStr for ExclusiveZone {
+        type Err = EnumParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            enum_parse! { "window type", s,
+                "normal" => Self::Normal,
+                "ignore" => Self::Ignore,
+                "exclusive" => Self::Exclusive,
+            }
         }
     }
 }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -79,7 +79,7 @@ Depending on if you are using X11 or Wayland, some additional properties exist:
 |    Property | Description                                                  |
 | ----------: | ------------------------------------------------------------ |
 |  `stacking` | Where the window should appear in the stack. Possible values: `fg`, `bg`, `overlay`, `bottom`. |
-| `exclusive` | Whether the compositor should reserve space for the window automatically. |
+| `exclusive` | Specify if the compositor should reserve space for the window automatically or how the window should interact with windows that do. Possible values: `exclusive` (space should be reserved), `normal` (the window should move if occluding another), `ignore` (the window should not be moved). Default: `normal` |
 | `focusable` | Whether the window should be able to be focused. This is necessary for any widgets that use the keyboard to work. |
 
 


### PR DESCRIPTION
## Description

Changes the exclusive property on wayland to allow for another option: ignore

## Usage

```clojure
  :exclusive "exclusive" ; reserve space
  :exclusive "normal" ; default behavior
  :exclusive "ignore" ; don't move window if occluding another
```

## Additional Notes

Not a fan of the names `exclusive`, `normal`, `ignore`, `:exclusive "exclusive"` looks weird and they're not really explicit.
Also I might have broken a snapshot test, cargo test didn't fail tho.

## Checklist

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
