### PR TITLE
Make some operators lazily evaluated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ### Features
 - Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)
 - Allow floating-point numbers in percentages for window-geometry
+- Made `and`, `or` and `?:` lazily evaluated in simplexpr (By: ModProg)
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -179,35 +179,43 @@ impl SimplExpr {
             }
             SimplExpr::BinOp(span, a, op, b) => {
                 let a = a.eval(values)?;
-                let b = b.eval(values)?;
+                let b = || b.eval(values);
+                // Lazy operators
                 let dynval = match op {
-                    BinOp::Equals => DynVal::from(a == b),
-                    BinOp::NotEquals => DynVal::from(a != b),
-                    BinOp::And => DynVal::from(a.as_bool()? && b.as_bool()?),
-                    BinOp::Or => DynVal::from(a.as_bool()? || b.as_bool()?),
-                    BinOp::Plus => match (a.as_f64(), b.as_f64()) {
-                        (Ok(a), Ok(b)) => DynVal::from(a + b),
-                        _ => DynVal::from(format!("{}{}", a.as_string()?, b.as_string()?)),
-                    },
-                    BinOp::Minus => DynVal::from(a.as_f64()? - b.as_f64()?),
-                    BinOp::Times => DynVal::from(a.as_f64()? * b.as_f64()?),
-                    BinOp::Div => DynVal::from(a.as_f64()? / b.as_f64()?),
-                    BinOp::Mod => DynVal::from(a.as_f64()? % b.as_f64()?),
-                    BinOp::GT => DynVal::from(a.as_f64()? > b.as_f64()?),
-                    BinOp::LT => DynVal::from(a.as_f64()? < b.as_f64()?),
-                    BinOp::GE => DynVal::from(a.as_f64()? >= b.as_f64()?),
-                    BinOp::LE => DynVal::from(a.as_f64()? <= b.as_f64()?),
+                    BinOp::And => DynVal::from(a.as_bool()? && b()?.as_bool()?),
+                    BinOp::Or => DynVal::from(a.as_bool()? || b()?.as_bool()?),
                     BinOp::Elvis => {
                         let is_null = matches!(serde_json::from_str(&a.0), Ok(serde_json::Value::Null));
                         if a.0.is_empty() || is_null {
-                            b
+                            b()?
                         } else {
                             a
                         }
                     }
-                    BinOp::RegexMatch => {
-                        let regex = regex::Regex::new(&b.as_string()?)?;
-                        DynVal::from(regex.is_match(&a.as_string()?))
+                    // Eager operators
+                    _ => {
+                        let b = b()?;
+                        match op {
+                            BinOp::Equals => DynVal::from(a == b),
+                            BinOp::NotEquals => DynVal::from(a != b),
+                            BinOp::Plus => match (a.as_f64(), b.as_f64()) {
+                                (Ok(a), Ok(b)) => DynVal::from(a + b),
+                                _ => DynVal::from(format!("{}{}", a.as_string()?, b.as_string()?)),
+                            },
+                            BinOp::Minus => DynVal::from(a.as_f64()? - b.as_f64()?),
+                            BinOp::Times => DynVal::from(a.as_f64()? * b.as_f64()?),
+                            BinOp::Div => DynVal::from(a.as_f64()? / b.as_f64()?),
+                            BinOp::Mod => DynVal::from(a.as_f64()? % b.as_f64()?),
+                            BinOp::GT => DynVal::from(a.as_f64()? > b.as_f64()?),
+                            BinOp::LT => DynVal::from(a.as_f64()? < b.as_f64()?),
+                            BinOp::GE => DynVal::from(a.as_f64()? >= b.as_f64()?),
+                            BinOp::LE => DynVal::from(a.as_f64()? <= b.as_f64()?),
+                            BinOp::RegexMatch => {
+                                let regex = regex::Regex::new(&b.as_string()?)?;
+                                DynVal::from(regex.is_match(&a.as_string()?))
+                            }
+                            _ => unreachable!("Lazy operators already handled"),
+                        }
                     }
                 };
                 Ok(dynval.at(*span))
@@ -395,5 +403,8 @@ mod tests {
         safe_access_to_missing(r#"{ "a": { "b": 2 } }.b?.b"#) => Ok(DynVal::from(&serde_json::Value::Null)),
         normal_access_to_existing(r#"{ "a": { "b": 2 } }.a.b"#) => Ok(DynVal::from(2)),
         normal_access_to_missing(r#"{ "a": { "b": 2 } }.b.b"#) => Err(super::EvalError::CannotIndex("null".to_string())),
+        lazy_evaluation_and(r#"false && "null".test"#) => Ok(DynVal::from(false)),
+        lazy_evaluation_or(r#"true || "null".test"#) => Ok(DynVal::from(true)),
+        lazy_evaluation_elvis(r#""test"?: "null".test"#) => Ok(DynVal::from("test")),
     }
 }


### PR DESCRIPTION
Fixes #624

## Description

Implemented lazy evaluation for the operators where it makes sense: `and`, `or` and `elvis`.

## Usage

No change in usage, but now expressions like these will succeed, evaluating to the left hand side:

```js
false  && "null".test
true   || "null".test
"test" ?: "null".test
```

## Additional Notes

This could also be implemented by making all operators lazy, but it really only makes sense for these, 
unless we'd want to error on the number conversion of the left operand before evaluating the right operand on
e.g. `add`

## Checklist

Please make sure you can check all the boxes that apply to this PR.

<!-- - [x] All widgets I've added are correctly documented. -->
- [x] I added my changes to CHANGELOG.md, if appropriate.
<!-- - [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes. -->
- [x] I used `cargo fmt` to automatically format all code before committing
