### PR TITLE
Add support for null safe indexing e.g. for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ### Features
 - Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)
 - Allow floating-point numbers in percentages for window-geometry
+- Add support for safe access with index (`?.[n]`) (By: ModProg)
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -395,6 +395,7 @@ mod tests {
         safe_access_to_missing(r#"{ "a": { "b": 2 } }.b?.b"#) => Ok(DynVal::from(&serde_json::Value::Null)),
         safe_access_index_to_existing(r#"[1, 2]?.[1]"#) => Ok(DynVal::from(2)),
         safe_access_index_to_missing(r#""null"?.[1]"#) => Ok(DynVal::from(&serde_json::Value::Null)),
+        safe_access_index_to_non_indexable(r#"32?.[1]"#) => Err(super::EvalError::CannotIndex("32".to_string())),
         normal_access_to_existing(r#"{ "a": { "b": 2 } }.a.b"#) => Ok(DynVal::from(2)),
         normal_access_to_missing(r#"{ "a": { "b": 2 } }.b.b"#) => Err(super::EvalError::CannotIndex("null".to_string())),
     }

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -393,6 +393,8 @@ mod tests {
         string_to_string(r#""Hello""#) => Ok(DynVal::from("Hello".to_string())),
         safe_access_to_existing(r#"{ "a": { "b": 2 } }.a?.b"#) => Ok(DynVal::from(2)),
         safe_access_to_missing(r#"{ "a": { "b": 2 } }.b?.b"#) => Ok(DynVal::from(&serde_json::Value::Null)),
+        safe_access_index_to_existing(r#"[1, 2]?.[1]"#) => Ok(DynVal::from(2)),
+        safe_access_index_to_missing(r#""null"?.[1]"#) => Ok(DynVal::from(&serde_json::Value::Null)),
         normal_access_to_existing(r#"{ "a": { "b": 2 } }.a.b"#) => Ok(DynVal::from(2)),
         normal_access_to_missing(r#"{ "a": { "b": 2 } }.b.b"#) => Err(super::EvalError::CannotIndex("null".to_string())),
     }

--- a/crates/simplexpr/src/simplexpr_parser.lalrpop
+++ b/crates/simplexpr/src/simplexpr_parser.lalrpop
@@ -76,8 +76,12 @@ pub Expr: SimplExpr = {
 
   #[precedence(level="1")] #[assoc(side="right")]
   <l:@L> <ident:"identifier"> "(" <args: Comma<ExprReset>> ")" <r:@R> => FunctionCall(Span(l, r, fid), ident, args),
+
   <l:@L> <value:Expr>         "[" <index: ExprReset>       "]" <r:@R> => {
     JsonAccess(Span(l, r, fid), AccessType::Normal, b(value), b(index))
+  },
+  <l:@L> <value:Expr>    "?." "[" <index: ExprReset>       "]" <r:@R> => {
+    JsonAccess(Span(l, r, fid), AccessType::Safe, b(value), b(index))
   },
 
   <l:@L> <value:Expr> "." <lit_l:@L> <index:"identifier"> <r:@R> => {

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -26,7 +26,7 @@ Supported currently are the following features:
 - elvis operator (`?:`)
     - if the left side is `""` or a JSON `null`, then returns the right side,
       otherwise evaluates to the left side.
-- Safe Access operator (`?.`)
+- Safe Access operator (`?.`) or (`?.[index]`)
     - if the left side is `""` or a JSON `null`, then return `null`. Otherwise,
       attempt to index.
     - This can still cause an error to occur if the left hand side exists but is


### PR DESCRIPTION

Please follow this template, if applicable.

## Description

Null-safe access with indexing

This follows the JavaScript syntax:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#syntax

## Usage

`smth?.[1]`

## Checklist

Please make sure you can check all the boxes that apply to this PR.

<!-- - [ ] All widgets I've added are correctly documented. -->
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
