### PR TITLE
Update clap to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -145,6 +145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+
+[[package]]
 name = "cfg-expr"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,26 +167,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -191,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -370,6 +374,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -867,6 +892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +950,28 @@ dependencies = [
  "linked-hash-map",
  "similar",
  "yaml-rust",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1017,6 +1073,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "lock_api"
@@ -1177,7 +1239,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1576,6 +1638,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,12 +1933,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -35,7 +35,7 @@ bincode = "1.3"
 anyhow = "1.0"
 derive_more = "0.99"
 maplit = "1"
-clap = {version = "3.2", features = ["derive"] }
+clap = {version = "4.0", features = ["derive"] }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 extend = "1"

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -29,46 +29,46 @@ pub struct Opt {
 #[clap(version, about)]
 struct RawOpt {
     /// Write out debug logs. (To read the logs, run `eww logs`).
-    #[clap(long = "debug", global = true)]
+    #[arg(long = "debug", global = true)]
     log_debug: bool,
 
     /// override path to configuration directory (directory that contains eww.yuck and eww.scss)
-    #[clap(short, long, global = true)]
+    #[arg(short, long, global = true)]
     config: Option<std::path::PathBuf>,
 
     /// Watch the log output after executing the command
-    #[clap(long = "logs", global = true)]
+    #[arg(long = "logs", global = true)]
     show_logs: bool,
 
     /// Avoid daemonizing eww.
-    #[clap(long = "no-daemonize", global = true)]
+    #[arg(long = "no-daemonize", global = true)]
     no_daemonize: bool,
 
     /// Restart the daemon completely before running the command
-    #[clap(long = "restart", global = true)]
+    #[arg(long = "restart", global = true)]
     restart: bool,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     action: Action,
 }
 
 #[derive(Subcommand, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Action {
     /// Start the Eww daemon.
-    #[clap(name = "daemon", alias = "d")]
+    #[command(name = "daemon", alias = "d")]
     Daemon,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     ClientOnly(ActionClientOnly),
 
-    #[clap(flatten)]
+    #[command(flatten)]
     WithServer(ActionWithServer),
 }
 
 #[derive(Subcommand, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ActionClientOnly {
     /// Print and watch the eww logs
-    #[clap(name = "logs")]
+    #[command(name = "logs")]
     Logs,
 }
 
@@ -82,12 +82,12 @@ pub enum ActionWithServer {
     #[clap(name = "update", alias = "u")]
     Update {
         /// variable_name="new_value"-pairs that will be updated
-        #[clap(parse(try_from_str = parse_var_update_arg))]
+        #[arg(value_parser = parse_var_update_arg)]
         mappings: Vec<(VarName, DynVal)>,
     },
 
     /// Open the GTK debugger
-    #[clap(name = "inspector", alias = "debugger")]
+    #[command(name = "inspector", alias = "debugger")]
     OpenInspector,
 
     /// Open a window
@@ -97,78 +97,78 @@ pub enum ActionWithServer {
         window_name: String,
 
         /// The identifier of the monitor the window should open on
-        #[clap(long)]
+        #[arg(long)]
         screen: Option<MonitorIdentifier>,
 
         /// The position of the window, where it should open. (i.e.: 200x100)
-        #[clap(short, long)]
+        #[arg(short, long)]
         pos: Option<Coords>,
 
         /// The size of the window to open (i.e.: 200x100)
-        #[clap(short, long)]
+        #[arg(short, long)]
         size: Option<Coords>,
 
         /// Sidepoint of the window, formatted like "top right"
-        #[clap(short, long)]
+        #[arg(short, long)]
         anchor: Option<AnchorPoint>,
 
         /// If the window is already open, close it instead
-        #[clap(long = "toggle")]
+        #[arg(long = "toggle")]
         should_toggle: bool,
     },
 
     /// Open multiple windows at once.
     /// NOTE: This will in the future be part of eww open, and will then be removed.
-    #[clap(name = "open-many")]
+    #[command(name = "open-many")]
     OpenMany {
         windows: Vec<String>,
 
         /// If a window is already open, close it instead
-        #[clap(long = "toggle")]
+        #[arg(long = "toggle")]
         should_toggle: bool,
     },
 
     /// Close the given windows
-    #[clap(name = "close", alias = "c")]
+    #[command(name = "close", alias = "c")]
     CloseWindows { windows: Vec<String> },
 
     /// Reload the configuration
-    #[clap(name = "reload", alias = "r")]
+    #[command(name = "reload", alias = "r")]
     Reload,
 
     /// Kill the eww daemon
-    #[clap(name = "kill", alias = "k")]
+    #[command(name = "kill", alias = "k")]
     KillServer,
 
     /// Close all windows, without killing the daemon
-    #[clap(name = "close-all", alias = "ca")]
+    #[command(name = "close-all", alias = "ca")]
     CloseAll,
 
     /// Prints the variables used in all currently open window
-    #[clap(name = "state")]
+    #[command(name = "state")]
     ShowState {
         /// Shows all variables, including not currently used ones
-        #[clap(short, long)]
+        #[arg(short, long)]
         all: bool,
     },
 
     /// Get the value of a variable if defined
-    #[clap(name = "get")]
+    #[command(name = "get")]
     GetVar { name: String },
 
     /// Print the names of all configured windows. Windows with a * in front of them are currently opened.
-    #[clap(name = "windows")]
+    #[command(name = "windows")]
     ShowWindows,
 
     /// Print out the widget structure as seen by eww.
     ///
     /// This may be useful if you are facing issues with how eww is interpreting your configuration,
     /// and to provide additional context to the eww developers if you are filing a bug.
-    #[clap(name = "debug")]
+    #[command(name = "debug")]
     ShowDebug,
 
     /// Print out the scope graph structure in graphviz dot format.
-    #[clap(name = "graph")]
+    #[command(name = "graph")]
     ShowGraph,
 }
 


### PR DESCRIPTION
Please follow this template, if applicable.

## Description

Bigger clap number.
Gets rid of RUSTSEC-2021-0145.

## Usage

Same as before.

### Showcase

no

## Additional Notes

no

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [X] All widgets I've added are correctly documented.
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
