### PR TITLE
Make onclick trigger for both mouse and keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ### Features
 - Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)
 - Allow floating-point numbers in percentages for window-geometry
+- Make button onclick handler trigger for both mouse and keyboard
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -474,20 +474,24 @@ fn build_gtk_button(bargs: &mut BuilderArgs) -> Result<gtk::Button> {
     let gtk_widget = gtk::Button::new();
 
     def_widget!(bargs, _g, gtk_widget, {
+        // @prop onclick - command to run when the button is clicked using mouse or keyboard
+        // @prop timeout - timeout of the command
+        prop(timeout: as_duration = Duration::from_millis(200), onclick: as_string) {
+            connect_signal_handler!(gtk_widget, gtk_widget.connect_clicked(move |_| {
+                run_command(timeout, &onclick, &[] as &[&str]);
+            }));
+        },
         prop(
             // @prop timeout - timeout of the command
             timeout: as_duration = Duration::from_millis(200),
-            // @prop onclick - a command that get's run when the button is clicked
-            onclick: as_string = "",
-            // @prop onmiddleclick - a command that get's run when the button is middleclicked
+            // @prop onmiddleclick - command to run when the button is middleclicked
             onmiddleclick: as_string = "",
-            // @prop onrightclick - a command that get's run when the button is rightclicked
+            // @prop onrightclick - command to run when the button is rightclicked
             onrightclick: as_string = ""
         ) {
             gtk_widget.add_events(gdk::EventMask::BUTTON_PRESS_MASK);
             connect_signal_handler!(gtk_widget, gtk_widget.connect_button_press_event(move |_, evt| {
                 match evt.button() {
-                    1 => run_command(timeout, &onclick, &[] as &[&str]),
                     2 => run_command(timeout, &onmiddleclick, &[] as &[&str]),
                     3 => run_command(timeout, &onrightclick, &[] as &[&str]),
                     _ => {},
@@ -495,7 +499,6 @@ fn build_gtk_button(bargs: &mut BuilderArgs) -> Result<gtk::Button> {
                 gtk::Inhibit(false)
             }));
         }
-
     });
     Ok(gtk_widget)
 }
@@ -787,11 +790,11 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
         prop(
             // @prop timeout - timeout of the command
             timeout: as_duration = Duration::from_millis(200),
-            // @prop onclick - a command that get's run when the button is clicked
+            // @prop onclick - command to run when the widget is clicked
             onclick: as_string = "",
-            // @prop onmiddleclick - a command that get's run when the button is middleclicked
+            // @prop onmiddleclick - command to run when the widget is middleclicked
             onmiddleclick: as_string = "",
-            // @prop onrightclick - a command that get's run when the button is rightclicked
+            // @prop onrightclick - command to run when the widget is rightclicked
             onrightclick: as_string = ""
         ) {
             gtk_widget.add_events(gdk::EventMask::BUTTON_PRESS_MASK);


### PR DESCRIPTION
## Description

Currently, the `onclick` command for buttons is only executed when the button is clicked using the left mouse button. This pull request changes the behavior of the `onclick` handler to also be executed if the button is activated using the keyboard (with enter or space).

## Usage

Here is a simple example button:

```
(defwindow example
  :monitor 0
  :focusable true
  (button :onclick "notify-send 'Hello'"
    "Test button")
)
```

Add the snippet to your `eww.yuck` and open the widget using

```
eww open example
```

You will see a notification for both a left click as well as enter and space.

## Additional Notes

Currently, the `onclick` command is activated as soon as the button is pressed. A side effect of the new implementation is that the command is now executed after the button is released.

Furthermore I was not able to find an equivalent signal handler for the event box widget, hence the keyboard support is only present for the button widget.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
