### PR TITLE
Fix temperature values not being accessible due to NaN values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix deflisten scripts not always getting cleaned up properly
 - Add `:round-digits` to scale widget (By: gavynriebau)
 - Fix cirular-progress not properly displaying 100% values when clockwise is false
+- Fix temperatures inside `EWW_TEMPS` not being accessible if at least one value is `NaN`
 
 
 ## 0.3.0 (26.05.2022)

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -60,7 +60,11 @@ pub fn get_temperatures() -> String {
         "{{ {} }}",
         c.components()
             .iter()
-            .map(|c| format!(r#""{}": {}"#, c.label().to_uppercase().replace(' ', "_"), c.temperature()))
+            .map(|c| format!(
+                r#""{}": {}"#,
+                c.label().to_uppercase().replace(' ', "_"),
+                c.temperature().to_string().replace("NaN", "\"null\"")
+            ))
             .join(",")
     )
 }

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -63,6 +63,8 @@ pub fn get_temperatures() -> String {
             .map(|c| format!(
                 r#""{}": {}"#,
                 c.label().to_uppercase().replace(' ', "_"),
+                // It is common for temperatures to report a non-numeric value.
+                // Tolerate it by serializing it as the string "null"
                 c.temperature().to_string().replace("NaN", "\"null\"")
             ))
             .join(",")


### PR DESCRIPTION
Solves issue #646.

The Rust type f32 is converted to a string to build the `EWW_TEMPS` JSON.
If the f32 is `NaN`, the string results in `NaN`, which is not a valid JSON number.
As a consequence, the `EWW_TEMPS` is not accessible.

The solution replaces `NaN` values with the string `"null"`.
This is only done for temperatures. If other values are `NaN`, an error is still reported in the logs.

## Checklist

- [x] I added my changes to CHANGELOG.md.
- [x] I used `cargo fmt` to automatically format all code before committing
