### PR TITLE
Add regex match operator to documentation

### DIFF
--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -23,6 +23,7 @@ Supported currently are the following features:
 - simple mathematical operations (`+`, `-`, `*`, `/`, `%`)
 - comparisons (`==`, `!=`, `>`, `<`, `<=`, `>=`)
 - boolean operations (`||`, `&&`, `!`)
+- regex match operator (`=~`)
 - elvis operator (`?:`)
     - if the left side is `""` or a JSON `null`, then returns the right side,
       otherwise evaluates to the left side.


### PR DESCRIPTION
## Description
I noticed that the documentation was missing a mention to the regex match operator, so I simply added it.