### PR TITLE
feat: add justify property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Made `and`, `or` and `?:` lazily evaluated in simplexpr (By: ModProg)
 - Add Vanilla CSS support (By: Ezequiel Ramis)
 - Add `jq` function, offering jq-style json processing
+- Add `justify` property to the label widget, allowing text justification (By: n3oney)
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -841,7 +841,11 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         // @prop xalign - the alignment of the label text on the x axis (between 0 - 1, 0 -> left, 0.5 -> center, 1 -> right)
         prop(xalign: as_f64 = 0.5) { gtk_widget.set_xalign(xalign as f32) },
         // @prop yalign - the alignment of the label text on the y axis (between 0 - 1, 0 -> bottom, 0.5 -> center, 1 -> top)
-        prop(yalign: as_f64 = 0.5) { gtk_widget.set_yalign(yalign as f32) }
+        prop(yalign: as_f64 = 0.5) { gtk_widget.set_yalign(yalign as f32) },
+        // @prop justify - the justification of the label text (left, right, center, fill)
+        prop(justify: as_string = "left") {
+            gtk_widget.set_justify(parse_justification(&justify)?);
+        },
     });
     Ok(gtk_widget)
 }
@@ -1058,6 +1062,16 @@ fn parse_align(o: &str) -> Result<gtk::Align> {
         "center" => gtk::Align::Center,
         "start" => gtk::Align::Start,
         "end" => gtk::Align::End,
+    }
+}
+
+/// @var justification - "left", "right", "center", "fill"
+fn parse_justification(j: &str) -> Result<gtk::Justification> {
+    enum_parse! { "justification", j,
+        "left" => gtk::Justification::Left,
+        "right" => gtk::Justification::Right,
+        "center" => gtk::Justification::Center,
+        "fill" => gtk::Justification::Fill,
     }
 }
 


### PR DESCRIPTION
## Description

Added a `justify` property on the label widget, allowing justification of the text when it's wrapping. This closes my feature request #706 

## Usage

```lisp
(label :class "song_album" :text song_album :wrap true :width 200 :xalign 0.5 :justify "center")
```

### Showcase

![image](https://user-images.githubusercontent.com/30625554/223570427-b355691b-2d54-48ae-bd58-4ffe3eacc5bf.png)

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
