### PR TITLE
remove box_syntax

### DIFF
--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(trace_macros)]
 #![feature(drain_filter)]
-#![feature(box_syntax)]
 #![feature(box_patterns)]
 #![feature(slice_concat_trait)]
 #![feature(try_blocks)]

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -93,14 +93,14 @@ impl SimplExpr {
     pub fn try_map_var_refs<E, F: Fn(Span, VarName) -> Result<SimplExpr, E> + Copy>(self, f: F) -> Result<Self, E> {
         use SimplExpr::*;
         Ok(match self {
-            BinOp(span, box a, op, box b) => BinOp(span, box a.try_map_var_refs(f)?, op, box b.try_map_var_refs(f)?),
+            BinOp(span, box a, op, box b) => BinOp(span, Box::new(a.try_map_var_refs(f)?), op, Box::new(b.try_map_var_refs(f)?)),
             Concat(span, elems) => Concat(span, elems.into_iter().map(|x| x.try_map_var_refs(f)).collect::<Result<_, _>>()?),
-            UnaryOp(span, op, box a) => UnaryOp(span, op, box a.try_map_var_refs(f)?),
+            UnaryOp(span, op, box a) => UnaryOp(span, op, Box::new(a.try_map_var_refs(f)?)),
             IfElse(span, box a, box b, box c) => {
-                IfElse(span, box a.try_map_var_refs(f)?, box b.try_map_var_refs(f)?, box c.try_map_var_refs(f)?)
+                IfElse(span, Box::new(a.try_map_var_refs(f)?), Box::new(b.try_map_var_refs(f)?), Box::new(c.try_map_var_refs(f)?))
             }
             JsonAccess(span, safe, box a, box b) => {
-                JsonAccess(span, safe, box a.try_map_var_refs(f)?, box b.try_map_var_refs(f)?)
+                JsonAccess(span, safe, Box::new(a.try_map_var_refs(f)?), Box::new(b.try_map_var_refs(f)?))
             }
             FunctionCall(span, name, args) => {
                 FunctionCall(span, name, args.into_iter().map(|x| x.try_map_var_refs(f)).collect::<Result<_, _>>()?)

--- a/crates/simplexpr/src/lib.rs
+++ b/crates/simplexpr/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(box_patterns)]
 #![feature(pattern)]
-#![feature(box_syntax)]
 #![feature(try_blocks)]
 #![feature(unwrap_infallible)]
 #![feature(never_type)]


### PR DESCRIPTION
## Description

Remove `box_syntax` and replace all uses of `box <expr>` with `Box::new(<expr>)`
Fixes #712 

## Additional Notes

`box_syntax` was removed in rust-lang/rust#108471

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
