### PR TITLE
feat: `truncate-left` for labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ## [Unreleased]
 
 ### Features
+- Add `truncate-left` property on `label` widgets (By: kawaki-san)
 - Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)
 - Allow floating-point numbers in percentages for window-geometry
 - Add support for safe access with index (`?.[n]`) (By: ModProg)

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -822,30 +822,22 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         // @prop truncate_left - whether to truncate on the left side
         // @prop show_truncated - show whether the text was truncated
         prop(text: as_string, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true) {
-            let show_truncation = |mut s: String, is_left: bool| -> String {
-                let delimiter = "...";
-                if is_left {
-                    s.insert_str(0, delimiter);
-                } else {
-                    s.push_str(delimiter);
-                }
-                s
-            };
-
             let limit_width = limit_width as usize;
             let char_count = text.chars().count();
-            let truncated = char_count > limit_width;
-            let text = if truncated {
-                let slice = if truncate_left {
+            let text = if char_count > limit_width {
+                let mut truncated: String = if truncate_left {
                     text.chars().skip(char_count - limit_width).collect()
                 } else {
                     text.chars().take(limit_width).collect()
                 };
                 if show_truncated {
-                    show_truncation(slice, truncate_left)
-                } else {
-                    slice
+                    if truncate_left {
+                        truncated.insert_str(0, "...");
+                    } else {
+                        truncated.push_str("...");
+                    }
                 }
+                truncated
             } else {
                 text
             };


### PR DESCRIPTION
## Description

Adds a flag that allows truncation to the left side of text

## Usage

```yuck
(defwidget center []
  (label :text "ラウトは難しいです"
         :truncate-left true
         :limit-width 2
         :show-truncated true
  )
)
```


### Showcase

The configuration above will result in something like:

![20230325213017](https://user-images.githubusercontent.com/70331483/227737623-76ee2687-af88-40db-add6-ac9bee357427.png)

Likewise, using `false` on the `truncate-left` property or omitting the property completely will default to right hand side truncation.

`:truncate-left true :limit-width 4 :show-truncated false`:

![20230325213350](https://user-images.githubusercontent.com/70331483/227737790-790aecef-63b5-42f1-92f1-1fac8253dc83.png)

`:truncate-left false :limit-width 5 :show-truncated true`:

![20230325213623](https://user-images.githubusercontent.com/70331483/227737899-bced5a12-7e44-4095-9c08-5ce67ffee6a4.png)


`:limit-width 5 :show-truncated true`:

![20230325213623](https://user-images.githubusercontent.com/70331483/227737899-bced5a12-7e44-4095-9c08-5ce67ffee6a4.png)

## Additional Notes

It might also be useful to allow users to specify some text to use instead of the ellipsis?

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
