### PR TITLE
Default to building with both x11 and wayland

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,3 @@ jobs:
            run: cargo check --no-default-features --features=wayland
          - name: Build no-backend
            run: cargo check --no-default-features
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,16 @@ jobs:
               components: rustfmt
          - uses: actions/checkout@v2
          - uses: Swatinem/rust-cache@v1
-         - name: Build x11
+         - uses: r7kamura/rust-problem-matchers@v1
+         - name: Check formatting
+           run: cargo fmt -- --check
+         - name: Check with default features
+           run: cargo check
+         - name: Run tests
+           run: cargo test
+         - name: Build x11 only
            run: cargo check --no-default-features --features=x11
-         - name: Build wayland
+         - name: Build wayland only
            run: cargo check --no-default-features --features=wayland
          - name: Build no-backend
            run: cargo check --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ## [Unreleased]
 
 ### Features
+- Default to building with x11 and wayland support simultaneously
 - Add `truncate-left` property on `label` widgets (By: kawaki-san)
 - Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)
 - Allow floating-point numbers in percentages for window-geometry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "ascii-canvas"
@@ -54,7 +54,7 @@ checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -103,12 +103,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bincode"
@@ -175,7 +169,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -240,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.27"
+version = "4.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
+checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -255,15 +249,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -368,7 +361,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
@@ -394,7 +387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -418,7 +411,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -429,7 +422,7 @@ checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -442,7 +435,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -559,7 +552,7 @@ dependencies = [
  "libc",
  "log",
  "maplit",
- "nix 0.25.0",
+ "nix 0.26.2",
  "notify",
  "once_cell",
  "pretty_env_logger",
@@ -588,14 +581,13 @@ dependencies = [
 
 [[package]]
 name = "extend"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5216e387a76eebaaf11f6d871ec8a4aae0b25f05456ee21f228e024b1b3610"
+checksum = "311a6d2f1f9d60bff73d2c78a0af97ed27f79672f15c238192a5bbb64db56d00"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -604,7 +596,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e1c54951450cbd39f3dbcf1005ac413b49487dabf18a720ad2383eccfeffb92"
 dependencies = [
- "memoffset",
+ "memoffset 0.6.5",
  "rustc_version 0.3.3",
 ]
 
@@ -617,7 +609,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -667,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
@@ -690,32 +682,32 @@ checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -895,7 +887,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -921,17 +913,22 @@ dependencies = [
 
 [[package]]
 name = "grass"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5bedc3dbd71dcdd41900e1f58e4d431fa69dd67c04ae1f86ae1a0339edd849"
+checksum = "f4bfa010e6f9fe2f40727b4aedf67aa54e0439c57f855458efb1f43d730a028f"
 dependencies = [
- "beef",
+ "grass_compiler",
+]
+
+[[package]]
+name = "grass_compiler"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe05b48c9c96f5ec64ad9af20c9016a8d57ec8b979e0f6dbdd9747f32b16df3"
+dependencies = [
  "codemap",
  "indexmap",
  "lasso",
- "num-bigint",
- "num-rational",
- "num-traits",
  "once_cell",
  "phf",
 ]
@@ -1016,7 +1013,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1057,12 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "humantime"
@@ -1138,19 +1132,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.0"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1258,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "lasso"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8647c8a01e5f7878eacb2c323c4c949fdb63773110f0686c7810769874b7e0a"
+checksum = "aeb7b21a526375c5ca55f1a6dfd4e1fad9fa4edd750f530252a718a44b2608f0"
 dependencies = [
  "hashbrown 0.11.2",
 ]
@@ -1273,9 +1267,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.136"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linked-hash-map"
@@ -1330,6 +1324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,7 +1341,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1346,18 +1349,6 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
-name = "nix"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nix"
@@ -1369,15 +1360,28 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
 name = "notify"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
+checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -1388,7 +1392,7 @@ dependencies = [
  "libc",
  "mio",
  "walkdir",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1398,48 +1402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1518,7 +1480,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1543,46 +1505,37 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ac8b67553a7ca9457ce0e526948cad581819238f4a9d1ea74545851fa24f37"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
  "phf_macros",
- "phf_shared 0.9.0",
+ "phf_shared",
  "proc-macro-hack",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43f3220d96e0080cc9ea234978ccd80d904eafb17be31bb0f76daaea6493082"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
- "phf_shared 0.9.0",
+ "phf_shared",
  "rand",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b706f5936eb50ed880ae3009395b43ed19db5bff2ebd459c95e7bf013a89ab86"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
 dependencies = [
  "phf_generator",
- "phf_shared 0.9.0",
+ "phf_shared",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68318426de33640f02be62b4ae8eb1261be2efbc337b60c54d845bf4484e0d9"
-dependencies = [
- "siphasher",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1672,7 +1625,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -1695,9 +1648,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -1710,9 +1663,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1808,14 +1761,14 @@ checksum = "5887de4a01acafd221861463be6113e6e87275e79804e56779f4cdc131c60368"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1824,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rustc_version"
@@ -1848,16 +1801,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.3"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1928,7 +1881,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2018,7 +1971,7 @@ checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2046,7 +1999,7 @@ dependencies = [
  "new_debug_unreachable",
  "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared",
  "precomputed-hash",
 ]
 
@@ -2075,7 +2028,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2090,10 +2043,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.26.5"
+name = "syn"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade661fa5e048ada64ad7901713301c21d2dbc5b65ee7967de8826c111452960"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2164,7 +2128,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2178,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2193,7 +2157,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2204,14 +2168,14 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2353,46 +2317,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "x11"
@@ -2406,12 +2394,12 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
+checksum = "cdf3c79412dd91bae7a7366b8ad1565a85e35dd049affc3a6a2c549e97419617"
 dependencies = [
  "gethostname",
- "nix 0.24.2",
+ "nix 0.25.0",
  "winapi",
  "winapi-wsapoll",
  "x11rb-protocol",
@@ -2419,11 +2407,11 @@ dependencies = [
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
+checksum = "e0b1513b141123073ce54d5bb1d33f801f17508fbd61e02060b1214e96d39c56"
 dependencies = [
- "nix 0.24.2",
+ "nix 0.25.0",
 ]
 
 [[package]]

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -11,11 +11,9 @@ edition = "2021"
 
 
 [features]
-default = ["x11"]
-x11 = ["gdkx11", "x11rb", "yuck/x11"]
-wayland = ["gtk-layer-shell", "yuck/wayland"]
-[dependencies.cairo-sys-rs]
-version = "0.15.1"
+default = ["x11", "wayland"]
+x11 = ["gdkx11", "x11rb"]
+wayland = ["gtk-layer-shell"]
 
 [dependencies]
 gtk = { version = "0.15", features = [ "v3_22" ] }
@@ -23,42 +21,43 @@ gdk = "0.15"
 glib = "0.15"
 
 cairo-rs = "0.15"
+cairo-sys-rs = "0.15.1"
 
 gdk-pixbuf = "0.15"
 
 gtk-layer-shell = { version = "0.4", optional = true}
 gdkx11 = { version = "0.15", optional = true }
-x11rb = { version = "0.10", features = ["randr"], optional = true }
+x11rb = { version = "0.11.1", features = ["randr"], optional = true }
 
-regex = "1.6"
-bincode = "1.3"
-anyhow = "1.0"
+regex = "1.7.3"
+bincode = "1.3.3"
+anyhow = "1.0.70"
 derive_more = "0.99"
 maplit = "1"
-clap = {version = "4.0", features = ["derive"] }
+clap = {version = "4.1", features = ["derive"] }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-extend = "1"
-grass = {version = "0.11", default-features = false}
+extend = "1.2"
+grass = {version = "0.12.3", default-features = false}
 itertools = "0.10"
 log = "0.4"
 pretty_env_logger = "0.4"
 libc = "0.2"
 once_cell = "1.14"
-nix = "0.25"
+nix = "0.26.2"
 simple-signal = "1.1"
 unescape = "0.1"
 
-tokio = { version = "^1.18", features = ["full"] }
-futures-core = "0.3"
-futures-util = "0.3"
-tokio-util = "0.7"
+tokio = { version = "1.26.0", features = ["full"] }
+futures-core = "0.3.27"
+futures-util = "0.3.27"
+tokio-util = "0.7.7"
 
-sysinfo = "0.26"
+sysinfo = "0.28.4"
 
 wait-timeout = "0.2"
 
-notify = "5.0.0"
+notify = "5.1.0"
 
 codespan-reporting = "0.11"
 

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -1,98 +1,109 @@
-pub use platform::*;
+use yuck::config::window_definition::WindowDefinition;
 
-#[cfg(not(any(feature = "x11", feature = "wayland")))]
-mod platform {
-    use yuck::config::window_definition::{WindowDefinition, WindowStacking};
+#[cfg(feature = "wayland")]
+pub use platform_wayland::WaylandBackend;
 
-    pub fn initialize_window(_window_def: &WindowDefinition, _monitor: gdk::Rectangle) -> Option<gtk::Window> {
+#[cfg(feature = "x11")]
+pub use platform_x11::{set_xprops, X11Backend};
+
+pub trait DisplayBackend: Send + Sync + 'static {
+    fn initialize_window(window_def: &WindowDefinition, monitor: gdk::Rectangle) -> Option<gtk::Window>;
+}
+
+pub struct NoBackend;
+
+impl DisplayBackend for NoBackend {
+    fn initialize_window(_window_def: &WindowDefinition, _monitor: gdk::Rectangle) -> Option<gtk::Window> {
         Some(gtk::Window::new(gtk::WindowType::Toplevel))
     }
 }
 
 #[cfg(feature = "wayland")]
-mod platform {
-    use gdk;
+mod platform_wayland {
     use gtk::prelude::*;
     use yuck::config::{
         window_definition::{WindowDefinition, WindowStacking},
         window_geometry::AnchorAlignment,
     };
 
-    pub fn initialize_window(window_def: &WindowDefinition, monitor: gdk::Rectangle) -> Option<gtk::Window> {
-        let window = gtk::Window::new(gtk::WindowType::Toplevel);
-        // Initialising a layer shell surface
-        gtk_layer_shell::init_for_window(&window);
-        // Sets the monitor where the surface is shown
-        match window_def.monitor.clone() {
-            Some(ident) => {
+    use super::DisplayBackend;
+
+    pub struct WaylandBackend;
+
+    impl DisplayBackend for WaylandBackend {
+        fn initialize_window(window_def: &WindowDefinition, monitor: gdk::Rectangle) -> Option<gtk::Window> {
+            let window = gtk::Window::new(gtk::WindowType::Toplevel);
+            // Initialising a layer shell surface
+            gtk_layer_shell::init_for_window(&window);
+            // Sets the monitor where the surface is shown
+            if let Some(ident) = window_def.monitor.clone() {
                 let display = gdk::Display::default().expect("could not get default display");
                 if let Some(monitor) = crate::app::get_monitor_from_display(&display, &ident) {
                     gtk_layer_shell::set_monitor(&window, &monitor);
                 } else {
                     return None;
                 }
-            }
-            None => {}
-        };
-        window.set_resizable(window_def.resizable);
+            };
+            window.set_resizable(window_def.resizable);
 
-        // Sets the layer where the layer shell surface will spawn
-        match window_def.stacking {
-            WindowStacking::Foreground => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Top),
-            WindowStacking::Background => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Background),
-            WindowStacking::Bottom => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Bottom),
-            WindowStacking::Overlay => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Overlay),
+            // Sets the layer where the layer shell surface will spawn
+            match window_def.stacking {
+                WindowStacking::Foreground => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Top),
+                WindowStacking::Background => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Background),
+                WindowStacking::Bottom => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Bottom),
+                WindowStacking::Overlay => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Overlay),
+            }
+
+            // Sets the keyboard interactivity
+            gtk_layer_shell::set_keyboard_interactivity(&window, window_def.backend_options.wayland.focusable);
+
+            if let Some(geometry) = window_def.geometry {
+                // Positioning surface
+                let mut top = false;
+                let mut left = false;
+                let mut right = false;
+                let mut bottom = false;
+
+                match geometry.anchor_point.x {
+                    AnchorAlignment::START => left = true,
+                    AnchorAlignment::CENTER => {}
+                    AnchorAlignment::END => right = true,
+                }
+                match geometry.anchor_point.y {
+                    AnchorAlignment::START => top = true,
+                    AnchorAlignment::CENTER => {}
+                    AnchorAlignment::END => bottom = true,
+                }
+
+                gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Left, left);
+                gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Right, right);
+                gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Top, top);
+                gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Bottom, bottom);
+
+                let xoffset = geometry.offset.x.pixels_relative_to(monitor.width());
+                let yoffset = geometry.offset.y.pixels_relative_to(monitor.height());
+
+                if left {
+                    gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Left, xoffset);
+                } else {
+                    gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Right, xoffset);
+                }
+                if bottom {
+                    gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Bottom, yoffset);
+                } else {
+                    gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Top, yoffset);
+                }
+            }
+            if window_def.backend_options.wayland.exclusive {
+                gtk_layer_shell::auto_exclusive_zone_enable(&window);
+            }
+            Some(window)
         }
-
-        // Sets the keyboard interactivity
-        gtk_layer_shell::set_keyboard_interactivity(&window, window_def.backend_options.focusable);
-
-        if let Some(geometry) = window_def.geometry {
-            // Positioning surface
-            let mut top = false;
-            let mut left = false;
-            let mut right = false;
-            let mut bottom = false;
-
-            match geometry.anchor_point.x {
-                AnchorAlignment::START => left = true,
-                AnchorAlignment::CENTER => {}
-                AnchorAlignment::END => right = true,
-            }
-            match geometry.anchor_point.y {
-                AnchorAlignment::START => top = true,
-                AnchorAlignment::CENTER => {}
-                AnchorAlignment::END => bottom = true,
-            }
-
-            gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Left, left);
-            gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Right, right);
-            gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Top, top);
-            gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Bottom, bottom);
-
-            let xoffset = geometry.offset.x.pixels_relative_to(monitor.width());
-            let yoffset = geometry.offset.y.pixels_relative_to(monitor.height());
-
-            if left {
-                gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Left, xoffset);
-            } else {
-                gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Right, xoffset);
-            }
-            if bottom {
-                gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Bottom, yoffset);
-            } else {
-                gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Top, yoffset);
-            }
-        }
-        if window_def.backend_options.exclusive {
-            gtk_layer_shell::auto_exclusive_zone_enable(&window);
-        }
-        Some(window)
     }
 }
 
 #[cfg(feature = "x11")]
-mod platform {
+mod platform_x11 {
     use anyhow::{Context, Result};
     use gtk::{self, prelude::*};
     use x11rb::protocol::xproto::ConnectionExt;
@@ -104,45 +115,51 @@ mod platform {
         rust_connection::{DefaultStream, RustConnection},
     };
     use yuck::config::{
-        backend_window_options::{Side, WindowType},
+        backend_window_options::{Side, X11WindowType},
         window_definition::{WindowDefinition, WindowStacking},
     };
 
-    pub fn initialize_window(window_def: &WindowDefinition, _monitor: gdk::Rectangle) -> Option<gtk::Window> {
-        let window_type = if window_def.backend_options.wm_ignore { gtk::WindowType::Popup } else { gtk::WindowType::Toplevel };
-        let window = gtk::Window::new(window_type);
-        let wm_class_name = format!("eww-{}", window_def.name);
-        #[allow(deprecated)]
-        window.set_wmclass(&wm_class_name, &wm_class_name);
-        window.set_resizable(window_def.resizable);
-        window.set_keep_above(window_def.stacking == WindowStacking::Foreground);
-        window.set_keep_below(window_def.stacking == WindowStacking::Background);
-        if window_def.backend_options.sticky {
-            window.stick();
-        } else {
-            window.unstick();
+    use super::DisplayBackend;
+
+    pub struct X11Backend;
+    impl DisplayBackend for X11Backend {
+        fn initialize_window(window_def: &WindowDefinition, _monitor: gdk::Rectangle) -> Option<gtk::Window> {
+            let window_type =
+                if window_def.backend_options.x11.wm_ignore { gtk::WindowType::Popup } else { gtk::WindowType::Toplevel };
+            let window = gtk::Window::new(window_type);
+            let wm_class_name = format!("eww-{}", window_def.name);
+            #[allow(deprecated)]
+            window.set_wmclass(&wm_class_name, &wm_class_name);
+            window.set_resizable(window_def.resizable);
+            window.set_keep_above(window_def.stacking == WindowStacking::Foreground);
+            window.set_keep_below(window_def.stacking == WindowStacking::Background);
+            if window_def.backend_options.x11.sticky {
+                window.stick();
+            } else {
+                window.unstick();
+            }
+            Some(window)
         }
-        Some(window)
     }
 
     pub fn set_xprops(window: &gtk::Window, monitor: gdk::Rectangle, window_def: &WindowDefinition) -> Result<()> {
-        let backend = X11Backend::new()?;
+        let backend = X11BackendConnection::new()?;
         backend.set_xprops_for(window, monitor, window_def)?;
         Ok(())
     }
 
-    struct X11Backend {
+    struct X11BackendConnection {
         conn: RustConnection<DefaultStream>,
         root_window: u32,
         atoms: AtomCollection,
     }
 
-    impl X11Backend {
+    impl X11BackendConnection {
         fn new() -> Result<Self> {
             let (conn, screen_num) = RustConnection::connect(None)?;
             let screen = conn.setup().roots[screen_num].clone();
             let atoms = AtomCollection::new(&conn)?.reply()?;
-            Ok(X11Backend { conn, root_window: screen.root, atoms })
+            Ok(X11BackendConnection { conn, root_window: screen.root, atoms })
         }
 
         fn set_xprops_for(
@@ -154,7 +171,7 @@ mod platform {
             let gdk_window = window.window().context("Couldn't get gdk window from gtk window")?;
             let win_id =
                 gdk_window.downcast_ref::<gdkx11::X11Window>().context("Failed to get x11 window for gtk window")?.xid() as u32;
-            let strut_def = window_def.backend_options.struts;
+            let strut_def = window_def.backend_options.x11.struts;
             let root_window_geometry = self.conn.get_geometry(self.root_window)?.reply()?;
 
             let mon_end_x = (monitor_rect.x() + monitor_rect.width()) as u32 - 1u32;
@@ -208,14 +225,14 @@ mod platform {
                 win_id,
                 self.atoms._NET_WM_WINDOW_TYPE,
                 self.atoms.ATOM,
-                &[match window_def.backend_options.window_type {
-                    WindowType::Dock => self.atoms._NET_WM_WINDOW_TYPE_DOCK,
-                    WindowType::Normal => self.atoms._NET_WM_WINDOW_TYPE_NORMAL,
-                    WindowType::Dialog => self.atoms._NET_WM_WINDOW_TYPE_DIALOG,
-                    WindowType::Toolbar => self.atoms._NET_WM_WINDOW_TYPE_TOOLBAR,
-                    WindowType::Utility => self.atoms._NET_WM_WINDOW_TYPE_UTILITY,
-                    WindowType::Desktop => self.atoms._NET_WM_WINDOW_TYPE_DESKTOP,
-                    WindowType::Notification => self.atoms._NET_WM_WINDOW_TYPE_NOTIFICATION,
+                &[match window_def.backend_options.x11.window_type {
+                    X11WindowType::Dock => self.atoms._NET_WM_WINDOW_TYPE_DOCK,
+                    X11WindowType::Normal => self.atoms._NET_WM_WINDOW_TYPE_NORMAL,
+                    X11WindowType::Dialog => self.atoms._NET_WM_WINDOW_TYPE_DIALOG,
+                    X11WindowType::Toolbar => self.atoms._NET_WM_WINDOW_TYPE_TOOLBAR,
+                    X11WindowType::Utility => self.atoms._NET_WM_WINDOW_TYPE_UTILITY,
+                    X11WindowType::Desktop => self.atoms._NET_WM_WINDOW_TYPE_DESKTOP,
+                    X11WindowType::Notification => self.atoms._NET_WM_WINDOW_TYPE_NOTIFICATION,
                 }],
             )?
             .check()?;

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -16,6 +16,7 @@ use crate::{
 /// Struct that gets generated from `RawOpt`.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Opt {
+    pub force_wayland: bool,
     pub log_debug: bool,
     pub show_logs: bool,
     pub restart: bool,
@@ -31,6 +32,10 @@ struct RawOpt {
     /// Write out debug logs. (To read the logs, run `eww logs`).
     #[arg(long = "debug", global = true)]
     log_debug: bool,
+
+    /// Force eww to use wayland. This is a no-op if eww was compiled without wayland support.
+    #[arg(long = "force-wayland", global = true)]
+    force_wayland: bool,
 
     /// override path to configuration directory (directory that contains eww.yuck and eww.(s)css)
     #[arg(short, long, global = true)]
@@ -181,8 +186,8 @@ impl Opt {
 
 impl From<RawOpt> for Opt {
     fn from(other: RawOpt) -> Self {
-        let RawOpt { log_debug, config, show_logs, no_daemonize, restart, action } = other;
-        Opt { log_debug, show_logs, restart, config_path: config, action, no_daemonize }
+        let RawOpt { log_debug, force_wayland, config, show_logs, no_daemonize, restart, action } = other;
+        Opt { log_debug, force_wayland, show_logs, restart, config_path: config, action, no_daemonize }
     }
 }
 

--- a/crates/yuck/Cargo.toml
+++ b/crates/yuck/Cargo.toml
@@ -10,11 +10,6 @@ homepage = "https://github.com/elkowar/eww"
 
 build = "build.rs"
 
-[features]
-default = ["x11"]
-x11 = []
-wayland = []
-
 [dependencies]
 lalrpop-util = "0.19.5"
 regex = "1.5.5"

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -12,128 +12,109 @@ use eww_shared_util::Span;
 
 use super::{attributes::Attributes, window_definition::EnumParseError};
 
-pub use backend::*;
+use crate::error::{DiagError, DiagResultExt};
 
-#[cfg(feature = "x11")]
-mod backend {
-    use crate::error::{DiagError, DiagResultExt};
+/// Backend-specific options of a window that are backend
+#[derive(Debug, Clone, serde::Serialize, PartialEq)]
+pub struct BackendWindowOptions {
+    pub x11: X11BackendWindowOptions,
+    pub wayland: WlBackendWindowOptions,
+}
 
-    use super::*;
-
-    #[derive(Debug, Clone, PartialEq, serde::Serialize)]
-    pub struct BackendWindowOptions {
-        pub wm_ignore: bool,
-        pub sticky: bool,
-        pub window_type: WindowType,
-        pub struts: StrutDefinition,
+impl BackendWindowOptions {
+    pub fn from_attrs(attrs: &mut Attributes) -> DiagResult<Self> {
+        let struts = attrs.ast_optional("reserve")?;
+        let window_type = attrs.primitive_optional("windowtype")?;
+        let x11 = X11BackendWindowOptions {
+            wm_ignore: attrs.primitive_optional("wm-ignore")?.unwrap_or(window_type.is_none() && struts.is_none()),
+            window_type: window_type.unwrap_or_default(),
+            sticky: attrs.primitive_optional("sticky")?.unwrap_or(true),
+            struts: struts.unwrap_or_default(),
+        };
+        let wayland = WlBackendWindowOptions {
+            exclusive: attrs.primitive_optional("exclusive")?.unwrap_or(false),
+            focusable: attrs.primitive_optional("focusable")?.unwrap_or(false),
+        };
+        Ok(Self { x11, wayland })
     }
+}
 
-    impl BackendWindowOptions {
-        pub fn from_attrs(attrs: &mut Attributes) -> DiagResult<Self> {
-            let struts = attrs.ast_optional("reserve")?;
-            let window_type = attrs.primitive_optional("windowtype")?;
-            Ok(Self {
-                wm_ignore: attrs.primitive_optional("wm-ignore")?.unwrap_or(window_type.is_none() && struts.is_none()),
-                window_type: window_type.unwrap_or_default(),
-                sticky: attrs.primitive_optional("sticky")?.unwrap_or(true),
-                struts: struts.unwrap_or_default(),
-            })
-        }
-    }
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct X11BackendWindowOptions {
+    pub wm_ignore: bool,
+    pub sticky: bool,
+    pub window_type: X11WindowType,
+    pub struts: X11StrutDefinition,
+}
 
-    #[derive(Debug, Clone, PartialEq, Eq, smart_default::SmartDefault, serde::Serialize)]
-    pub enum WindowType {
-        #[default]
-        Dock,
-        Dialog,
-        Toolbar,
-        Normal,
-        Utility,
-        Desktop,
-        Notification,
-    }
-    impl FromStr for WindowType {
-        type Err = EnumParseError;
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct WlBackendWindowOptions {
+    pub exclusive: bool,
+    pub focusable: bool,
+}
 
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            enum_parse! { "window type", s,
-                "dock" => Self::Dock,
-                "toolbar" => Self::Toolbar,
-                "dialog" => Self::Dialog,
-                "normal" => Self::Normal,
-                "utility" => Self::Utility,
-                "desktop" => Self::Desktop,
-                "notification" => Self::Notification,
-            }
-        }
-    }
+/// Window type of an x11 window
+#[derive(Debug, Clone, PartialEq, Eq, smart_default::SmartDefault, serde::Serialize)]
+pub enum X11WindowType {
+    #[default]
+    Dock,
+    Dialog,
+    Toolbar,
+    Normal,
+    Utility,
+    Desktop,
+    Notification,
+}
+impl FromStr for X11WindowType {
+    type Err = EnumParseError;
 
-    #[derive(Debug, Clone, Copy, Eq, PartialEq, smart_default::SmartDefault, serde::Serialize)]
-    pub enum Side {
-        #[default]
-        Top,
-        Left,
-        Right,
-        Bottom,
-    }
-
-    impl std::str::FromStr for Side {
-        type Err = EnumParseError;
-
-        fn from_str(s: &str) -> Result<Side, Self::Err> {
-            enum_parse! { "side", s,
-                "l" | "left" => Side::Left,
-                "r" | "right" => Side::Right,
-                "t" | "top" => Side::Top,
-                "b" | "bottom" => Side::Bottom,
-            }
-        }
-    }
-
-    // Surface definition if the backend for X11 is enable
-    #[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize)]
-    pub struct StrutDefinition {
-        pub side: Side,
-        pub dist: NumWithUnit,
-    }
-
-    impl FromAstElementContent for StrutDefinition {
-        const ELEMENT_NAME: &'static str = "struts";
-
-        fn from_tail<I: Iterator<Item = Ast>>(_span: Span, mut iter: AstIterator<I>) -> DiagResult<Self> {
-            let mut attrs = iter.expect_key_values()?;
-            iter.expect_done().map_err(DiagError::from).note("Check if you are missing a colon in front of a key")?;
-            Ok(StrutDefinition { side: attrs.primitive_required("side")?, dist: attrs.primitive_required("distance")? })
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        enum_parse! { "window type", s,
+            "dock" => Self::Dock,
+            "toolbar" => Self::Toolbar,
+            "dialog" => Self::Dialog,
+            "normal" => Self::Normal,
+            "utility" => Self::Utility,
+            "desktop" => Self::Desktop,
+            "notification" => Self::Notification,
         }
     }
 }
 
-#[cfg(feature = "wayland")]
-mod backend {
-    use super::*;
-    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-    pub struct BackendWindowOptions {
-        pub exclusive: bool,
-        pub focusable: bool,
-    }
-    impl BackendWindowOptions {
-        pub fn from_attrs(attrs: &mut Attributes) -> DiagResult<Self> {
-            Ok(Self {
-                exclusive: attrs.primitive_optional("exclusive")?.unwrap_or(false),
-                focusable: attrs.primitive_optional("focusable")?.unwrap_or(false),
-            })
+#[derive(Debug, Clone, Copy, Eq, PartialEq, smart_default::SmartDefault, serde::Serialize)]
+pub enum Side {
+    #[default]
+    Top,
+    Left,
+    Right,
+    Bottom,
+}
+
+impl std::str::FromStr for Side {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Side, Self::Err> {
+        enum_parse! { "side", s,
+            "l" | "left" => Side::Left,
+            "r" | "right" => Side::Right,
+            "t" | "top" => Side::Top,
+            "b" | "bottom" => Side::Bottom,
         }
     }
 }
 
-#[cfg(not(any(feature = "x11", feature = "wayland")))]
-mod backend {
-    use super::*;
-    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-    pub struct BackendWindowOptions;
-    impl BackendWindowOptions {
-        pub fn from_attrs(attrs: &mut Attributes) -> DiagResult<Self> {
-            Ok(Self)
-        }
+#[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize)]
+pub struct X11StrutDefinition {
+    pub side: Side,
+    pub dist: NumWithUnit,
+}
+
+impl FromAstElementContent for X11StrutDefinition {
+    const ELEMENT_NAME: &'static str = "struts";
+
+    fn from_tail<I: Iterator<Item = Ast>>(_span: Span, mut iter: AstIterator<I>) -> DiagResult<Self> {
+        let mut attrs = iter.expect_key_values()?;
+        iter.expect_done().map_err(DiagError::from).note("Check if you are missing a colon in front of a key")?;
+        Ok(X11StrutDefinition { side: attrs.primitive_required("side")?, dist: attrs.primitive_required("distance")? })
     }
 }

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-10.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-10.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"(lol😄 1)\".to_string()))"
+---
+Ok(
+    (lol😄 "1"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-11.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-11.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, r#\"(test \"hi\")\"#.to_string()))"
+---
+Ok(
+    (test "hi"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-12.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-12.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, r#\"(test \"h\\\"i\")\"#.to_string()))"
+---
+Ok(
+    (test "h"i"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-13.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-13.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, r#\"(test \" hi \")\"#.to_string()))"
+---
+Ok(
+    (test " hi "),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-14.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-14.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"(+ (1 2 (* 2 5)))\".to_string()))"
+---
+Ok(
+    (+ ("1" "2" (* "2" "5"))),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-15.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-15.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, r#\"foo ; test\"#.to_string()))"
+---
+Ok(
+    foo,
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-16.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-16.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, r#\"(f arg ; test\n        arg2)\"#.to_string()))"
+---
+Ok(
+    (f arg arg2),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-17.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-17.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"\\\"h\\\\\\\"i\\\"\".to_string()))"
+---
+Ok(
+    "h"i",
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-2.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-2.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"(12)\".to_string()))"
+---
+Ok(
+    ("12"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-3.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-3.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"1.2\".to_string()))"
+---
+Ok(
+    "1.2",
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-4.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-4.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"-1.2\".to_string()))"
+---
+Ok(
+    "-1.2",
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-5.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-5.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"(1 2)\".to_string()))"
+---
+Ok(
+    ("1" "2"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-6.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-6.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"(1 :foo 1)\".to_string()))"
+---
+Ok(
+    ("1" :foo "1"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-7.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-7.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"(:foo 1)\".to_string()))"
+---
+Ok(
+    (:foo "1"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-8.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-8.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"(:foo->: 1)\".to_string()))"
+---
+Ok(
+    (:foo->: "1"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test-9.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test-9.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"(foo 1)\".to_string()))"
+---
+Ok(
+    (foo "1"),
+)

--- a/crates/yuck/src/parser/snapshots/yuck__parser__test__test.snap
+++ b/crates/yuck/src/parser/snapshots/yuck__parser__test__test.snap
@@ -1,0 +1,8 @@
+---
+source: crates/yuck/src/parser/mod.rs
+assertion_line: 68
+expression: "p.parse(0, Lexer::new(0, \"1\".to_string()))"
+---
+Ok(
+    "1",
+)


### PR DESCRIPTION
Defaults to building with x11 and wayland features both enabled, hopefully causing less confusion about versions compiled without wayland support. However, this will require some changes to existing packages, as we now need to either explicitly disable the wayland feature, or add a gtk-layer-shell dependency