### PR TITLE
Add namespace window option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ## [Unreleased]
 
 ### Features
+- Add `:namespace` window option
 - Default to building with x11 and wayland support simultaneously
 - Add `truncate-left` property on `label` widgets (By: kawaki-san)
 - Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -54,6 +54,10 @@ mod platform_wayland {
                 WindowStacking::Overlay => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Overlay),
             }
 
+            if let Some(namespace) = &window_def.backend_options.wayland.namespace {
+                gtk_layer_shell::set_namespace(&window, namespace);
+            }
+
             // Sets the keyboard interactivity
             gtk_layer_shell::set_keyboard_interactivity(&window, window_def.backend_options.wayland.focusable);
 

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -34,6 +34,7 @@ impl BackendWindowOptions {
         let wayland = WlBackendWindowOptions {
             exclusive: attrs.primitive_optional("exclusive")?.unwrap_or(false),
             focusable: attrs.primitive_optional("focusable")?.unwrap_or(false),
+            namespace: attrs.primitive_optional("namespace")?,
         };
         Ok(Self { x11, wayland })
     }
@@ -51,6 +52,7 @@ pub struct X11BackendWindowOptions {
 pub struct WlBackendWindowOptions {
     pub exclusive: bool,
     pub focusable: bool,
+    pub namespace: Option<String>,
 }
 
 /// Window type of an x11 window

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -81,6 +81,7 @@ Depending on if you are using X11 or Wayland, some additional properties exist:
 |  `stacking` | Where the window should appear in the stack. Possible values: `fg`, `bg`, `overlay`, `bottom`. |
 | `exclusive` | Whether the compositor should reserve space for the window automatically. |
 | `focusable` | Whether the window should be able to be focused. This is necessary for any widgets that use the keyboard to work. |
+| `namespace` | Set the wayland layersurface namespace eww uses |
 
 
 

--- a/docs/src/eww.md
+++ b/docs/src/eww.md
@@ -53,7 +53,7 @@ cd eww
 ```
 Then build:
 ```bash
-cargo build --release
+cargo build --release --no-default-features --features x11
 ```
 **NOTE:**
 When you're on Wayland, build with:


### PR DESCRIPTION
This PR adds a new window option `:namespace` for wayland, setting the wayland layershell namespace the window uses
