### PR TITLE
Fix nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661353537,
-        "narHash": "sha256-1E2IGPajOsrkR49mM5h55OtYnU0dGyre6gl60NXKITE=",
+        "lastModified": 1680242334,
+        "narHash": "sha256-HlCbTg1oj6cWLtdQ9Gi8p27t4bde9cSWgtmWrBXdh8w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e304ff0d9db453a4b230e9386418fd974d5804a",
+        "rev": "f30990fc98b8468eba13d75f6c4c2190a61073ea",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661655464,
-        "narHash": "sha256-by9Hb0mNVdiCR7TBvUHIgDb0QIv3znp8VMGh7Bl35VQ=",
+        "lastModified": 1680229280,
+        "narHash": "sha256-9UoyQCeKUmHcsIdpsAgcz41LAIDkWhI2PhVDjckrpg0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0c4c1432353e12b325d1472bea99e364871d2cb3",
+        "rev": "aa480d799023141e1b9e5d6108700de63d9ad002",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description

As mentioned on #733 nix build of package `eww` was failing. An input `gtk-layer-shell` was added as suggested on #722 and also flake inputs were updated.

## Additional information
```
nix log 'github:adomixaszvers/eww/9ba67124b9fdfbbe5260f32d25d5879050685435#eww'

@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/qbsc3bi10rfh3ykiwfjzi78l6ycy8q37-eww
source root is eww
Executing cargoSetupPostUnpackHook
Finished cargoSetupPostUnpackHook
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
Executing cargoSetupPostPatchHook
Validating consistency between /build/eww/Cargo.lock and /build/cargo-vendor-dir/Cargo.lock
Finished cargoSetupPostPatchHook
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Executing cargoBuildHook
++ env CC_x86_64-unknown-linux-gnu=/nix/store/h5003wsy3qqimqvrkn3bc5mwq4hhidag-gcc-wrapper-12.2.0/bin/cc CXX_x86_64-unknown-linux-gnu=/nix/store/h5003wsy3qqimqvrkn3bc5mwq4hhidag-gcc-wrapper-12.2.0/bin/c++ CC_x86_64-unknown-linux-gnu=/nix/store/h5003wsy3qqimqvrkn3bc5mwq4hhidag-gcc-wrapper-12.2.0/bin/cc CXX_x86_64-unknown-linux-gnu=/nix/store/h5003wsy3qqimqvrkn3bc5mwq4hhidag-gcc-wrapper-12.2.0/bin/c++ cargo build -j 16 --target x86_64-unknown-linux-gnu --frozen --release --bin eww
[0m[0m[1m[32m   Compiling[0m proc-macro2 v1.0.53
[0m[0m[1m[32m   Compiling[0m quote v1.0.26
[0m[0m[1m[32m   Compiling[0m unicode-ident v1.0.5
[0m[0m[1m[32m   Compiling[0m syn v1.0.103
[0m[0m[1m[32m   Compiling[0m libc v0.2.140
[0m[0m[1m[32m   Compiling[0m autocfg v1.1.0
[0m[0m[1m[32m   Compiling[0m serde_derive v1.0.147
[0m[0m[1m[32m   Compiling[0m serde v1.0.147
[0m[0m[1m[32m   Compiling[0m smallvec v1.10.0
[0m[0m[1m[32m   Compiling[0m heck v0.4.0
[0m[0m[1m[32m   Compiling[0m pkg-config v0.3.25
[0m[0m[1m[32m   Compiling[0m version-compare v0.1.0
[0m[0m[1m[32m   Compiling[0m cfg-if v1.0.0
[0m[0m[1m[32m   Compiling[0m once_cell v1.17.1
[0m[0m[1m[32m   Compiling[0m thiserror v1.0.37
[0m[0m[1m[32m   Compiling[0m version_check v0.9.4
[0m[0m[1m[32m   Compiling[0m crunchy v0.2.2
[0m[0m[1m[32m   Compiling[0m tiny-keccak v2.0.2
[0m[0m[1m[32m   Compiling[0m memchr v2.5.0
[0m[0m[1m[32m   Compiling[0m proc-macro-hack v0.5.19
[0m[0m[1m[32m   Compiling[0m log v0.4.17
[0m[0m[1m[32m   Compiling[0m futures-core v0.3.27
[0m[0m[1m[32m   Compiling[0m bitflags v1.3.2
[0m[0m[1m[32m   Compiling[0m futures-task v0.3.27
[0m[0m[1m[32m   Compiling[0m pin-project-lite v0.2.9
[0m[0m[1m[32m   Compiling[0m futures-sink v0.3.27
[0m[0m[1m[32m   Compiling[0m futures-util v0.3.27
[0m[0m[1m[32m   Compiling[0m anyhow v1.0.70
[0m[0m[1m[32m   Compiling[0m parking_lot_core v0.9.4
[0m[0m[1m[32m   Compiling[0m pin-utils v0.1.0
[0m[0m[1m[32m   Compiling[0m futures-channel v0.3.25
[0m[0m[1m[32m   Compiling[0m siphasher v0.3.10
[0m[0m[1m[32m   Compiling[0m scopeguard v1.1.0
[0m[0m[1m[32m   Compiling[0m futures-io v0.3.25
[0m[0m[1m[32m   Compiling[0m ucd-trie v0.1.5
[0m[0m[1m[32m   Compiling[0m hashbrown v0.12.3
[0m[0m[1m[32m   Compiling[0m crossbeam-utils v0.8.12
[0m[0m[1m[32m   Compiling[0m regex-syntax v0.6.29
[0m[0m[1m[32m   Compiling[0m bit-vec v0.6.3
[0m[0m[1m[32m   Compiling[0m precomputed-hash v0.1.1
[0m[0m[1m[32m   Compiling[0m either v1.8.0
[0m[0m[1m[32m   Compiling[0m fixedbitset v0.4.2
[0m[0m[1m[32m   Compiling[0m new_debug_unreachable v1.0.4
[0m[0m[1m[32m   Compiling[0m pico-args v0.4.2
[0m[0m[1m[32m   Compiling[0m unicode-xid v0.2.4
[0m[0m[1m[32m   Compiling[0m gio v0.15.12
[0m[0m[1m[32m   Compiling[0m ident_case v1.0.1
[0m[0m[1m[32m   Compiling[0m ppv-lite86 v0.2.16
[0m[0m[1m[32m   Compiling[0m strsim v0.10.0
[0m[0m[1m[32m   Compiling[0m fnv v1.0.7
[0m[0m[1m[32m   Compiling[0m diff v0.1.13
[0m[0m[1m[32m   Compiling[0m rustversion v1.0.9
[0m[0m[1m[32m   Compiling[0m bytes v1.2.1
[0m[0m[1m[32m   Compiling[0m ref-cast v1.0.12
[0m[0m[1m[32m   Compiling[0m async-trait v0.1.64
[0m[0m[1m[32m   Compiling[0m serde_json v1.0.87
[0m[0m[1m[32m   Compiling[0m rayon-core v1.9.3
[0m[0m[1m[32m   Compiling[0m termcolor v1.1.3
[0m[0m[1m[32m   Compiling[0m io-lifetimes v1.0.2
[0m[0m[1m[32m   Compiling[0m itoa v1.0.4
[0m[0m[1m[32m   Compiling[0m ryu v1.0.11
[0m[0m[1m[32m   Compiling[0m rustix v0.36.11
[0m[0m[1m[32m   Compiling[0m lazy_static v1.4.0
[0m[0m[1m[32m   Compiling[0m cached_proc_macro_types v0.1.0
[0m[0m[1m[32m   Compiling[0m convert_case v0.4.0
[0m[0m[1m[32m   Compiling[0m static_assertions v1.1.0
[0m[0m[1m[32m   Compiling[0m dyn-clone v1.0.10
[0m[0m[1m[32m   Compiling[0m hashbrown v0.13.2
[0m[0m[1m[32m   Compiling[0m quick-error v1.2.3
[0m[0m[1m[32m   Compiling[0m async_once v0.2.6
[0m[0m[1m[32m   Compiling[0m linux-raw-sys v0.1.3
[0m[0m[1m[32m   Compiling[0m unicode-width v0.1.10
[0m[0m[1m[32m   Compiling[0m same-file v1.0.6
[0m[0m[1m[32m   Compiling[0m codemap v0.1.3
[0m[0m[1m[32m   Compiling[0m os_str_bytes v6.3.0
[0m[0m[1m[32m   Compiling[0m eww v0.4.0 (/build/eww/crates/eww)
[0m[0m[1m[32m   Compiling[0m maplit v1.0.2
[0m[0m[1m[32m   Compiling[0m unescape v0.1.0
[0m[0m[1m[32m   Compiling[0m instant v0.1.12
[0m[0m[1m[32m   Compiling[0m cfg-expr v0.11.0
[0m[0m[1m[32m   Compiling[0m proc-macro-error-attr v1.0.4
[0m[0m[1m[32m   Compiling[0m proc-macro-error v1.0.4
[0m[0m[1m[32m   Compiling[0m ahash v0.7.6
[0m[0m[1m[32m   Compiling[0m slab v0.4.7
[0m[0m[1m[32m   Compiling[0m lock_api v0.4.9
[0m[0m[1m[32m   Compiling[0m indexmap v1.9.1
[0m[0m[1m[32m   Compiling[0m memoffset v0.6.5
[0m[0m[1m[32m   Compiling[0m crossbeam-epoch v0.9.11
[0m[0m[1m[32m   Compiling[0m tokio v1.26.0
[0m[0m[1m[32m   Compiling[0m rayon v1.5.3
[0m[0m[1m[32m   Compiling[0m memoffset v0.7.1
[0m[0m[1m[32m   Compiling[0m x11 v2.20.0
[0m[0m[1m[32m   Compiling[0m gtk v0.15.5
[0m[0m[1m[32m   Compiling[0m phf_shared v0.10.0
[0m[0m[1m[32m   Compiling[0m bit-set v0.5.3
[0m[0m[1m[32m   Compiling[0m itertools v0.10.5
[0m[0m[1m[32m   Compiling[0m humantime v1.3.0
[0m[0m[1m[32m   Compiling[0m codespan-reporting v0.11.1
[0m[0m[1m[32m   Compiling[0m walkdir v2.3.2
[0m[0m[1m[32m   Compiling[0m clap_lex v0.3.0
[0m[0m[1m[32m   Compiling[0m ena v0.14.0
[0m[0m[1m[32m   Compiling[0m aho-corasick v0.7.19
[0m[0m[1m[32m   Compiling[0m crossbeam-channel v0.5.6
[0m[0m[1m[32m   Compiling[0m num_cpus v1.13.1
[0m[0m[1m[32m   Compiling[0m mio v0.8.5
[0m[0m[1m[32m   Compiling[0m getrandom v0.2.8
[0m[0m[1m[32m   Compiling[0m signal-hook-registry v1.4.0
[0m[0m[1m[32m   Compiling[0m socket2 v0.4.7
[0m[0m[1m[32m   Compiling[0m nix v0.25.0
[0m[0m[1m[32m   Compiling[0m inotify-sys v0.1.5
[0m[0m[1m[32m   Compiling[0m atty v0.2.14
[0m[0m[1m[32m   Compiling[0m gethostname v0.2.3
[0m[0m[1m[32m   Compiling[0m filetime v0.2.18
[0m[0m[1m[32m   Compiling[0m simple-signal v1.1.1
[0m[0m[1m[32m   Compiling[0m wait-timeout v0.2.0
[0m[0m[1m[32m   Compiling[0m nix v0.26.2
[0m[0m[1m[32m   Compiling[0m syn v2.0.10
[0m[0m[1m[32m   Compiling[0m dirs-sys-next v0.1.2
[0m[0m[1m[32m   Compiling[0m petgraph v0.6.2
[0m[0m[1m[32m   Compiling[0m crossbeam-deque v0.8.2
[0m[0m[1m[32m   Compiling[0m parking_lot v0.12.1
[0m[0m[1m[32m   Compiling[0m regex v1.7.3
[0m[0m[1m[32m   Compiling[0m inotify v0.9.6
[0m[0m[1m[32m   Compiling[0m rand_core v0.6.4
[0m[0m[1m[32m   Compiling[0m const-random-macro v0.1.15
[0m[0m[1m[32m   Compiling[0m dirs-next v2.0.0
[0m[0m[1m[32m   Compiling[0m hashbrown v0.11.2
[0m[0m[1m[32m   Compiling[0m notify v5.1.0
[0m[0m[1m[32m   Compiling[0m rand_chacha v0.3.1
[0m[0m[1m[32m   Compiling[0m x11rb-protocol v0.11.1
[0m[0m[1m[32m   Compiling[0m term v0.7.0
[0m[0m[1m[32m   Compiling[0m string_cache v0.8.4
[0m[0m[1m[32m   Compiling[0m const-random v0.1.15
[0m[0m[1m[32m   Compiling[0m lalrpop-util v0.19.8
[0m[0m[1m[32m   Compiling[0m env_logger v0.7.1
[0m[0m[1m[32m   Compiling[0m rand v0.8.5
[0m[0m[1m[32m   Compiling[0m is-terminal v0.4.5
[0m[0m[1m[32m   Compiling[0m lasso v0.6.0
[0m[0m[1m[32m   Compiling[0m ahash v0.3.8
[0m[0m[1m[32m   Compiling[0m ascii-canvas v3.0.0
[0m[0m[1m[32m   Compiling[0m pretty_env_logger v0.4.0
[0m[0m[1m[32m   Compiling[0m chumsky v0.8.0
[0m[0m[1m[32m   Compiling[0m lalrpop v0.19.8
[0m[0m[1m[32m   Compiling[0m phf_generator v0.10.0
[0m[0m[1m[32m   Compiling[0m darling_core v0.14.3
[0m[0m[1m[32m   Compiling[0m sysinfo v0.28.4
[0m[0m[1m[32m   Compiling[0m thiserror-impl v1.0.37
[0m[0m[1m[32m   Compiling[0m futures-macro v0.3.27
[0m[0m[1m[32m   Compiling[0m tokio-macros v1.8.0
[0m[0m[1m[32m   Compiling[0m ref-cast-impl v1.0.12
[0m[0m[1m[32m   Compiling[0m phf_macros v0.10.0
[0m[0m[1m[32m   Compiling[0m derive_more v0.99.17
[0m[0m[1m[32m   Compiling[0m strum_macros v0.24.3
[0m[0m[1m[32m   Compiling[0m smart-default v0.6.0
[0m[0m[1m[32m   Compiling[0m clap_derive v4.1.12
[0m[0m[1m[32m   Compiling[0m extend v1.2.0
[0m[0m[1m[32m   Compiling[0m darling_macro v0.14.3
[0m[0m[1m[32m   Compiling[0m pest v2.4.0
[0m[0m[1m[32m   Compiling[0m darling v0.14.3
[0m[0m[1m[32m   Compiling[0m cached_proc_macro v0.16.0
[0m[0m[1m[32m   Compiling[0m phf v0.10.1
[0m[0m[1m[32m   Compiling[0m grass_compiler v0.12.3
[0m[0m[1m[32m   Compiling[0m semver-parser v0.10.2
[0m[0m[1m[32m   Compiling[0m semver v0.11.0
[0m[0m[1m[32m   Compiling[0m strum v0.24.1
[0m[0m[1m[32m   Compiling[0m rustc_version v0.3.3
[0m[0m[1m[32m   Compiling[0m field-offset v0.3.4
[0m[0m[1m[32m   Compiling[0m clap v4.1.13
[0m[0m[1m[32m   Compiling[0m futures-executor v0.3.25
[0m[0m[1m[32m   Compiling[0m futures v0.3.25
[0m[0m[1m[32m   Compiling[0m x11rb v0.11.1
[0m[0m[1m[32m   Compiling[0m cached v0.42.0
[0m[0m[1m[32m   Compiling[0m tokio-util v0.7.7
[0m[0m[1m[32m   Compiling[0m simplexpr v0.1.0 (/build/eww/crates/simplexpr)
[0m[0m[1m[32m   Compiling[0m yuck v0.1.0 (/build/eww/crates/yuck)
[0m[0m[1m[32m   Compiling[0m grass v0.12.3
[0m[0m[1m[32m   Compiling[0m toml v0.5.9
[0m[0m[1m[32m   Compiling[0m jaq-parse v0.9.0
[0m[0m[1m[32m   Compiling[0m bincode v1.3.3
[0m[0m[1m[32m   Compiling[0m eww_shared_util v0.1.0 (/build/eww/crates/eww_shared_util)
[0m[0m[1m[32m   Compiling[0m system-deps v6.0.3
[0m[0m[1m[32m   Compiling[0m proc-macro-crate v1.2.1
[0m[0m[1m[32m   Compiling[0m jaq-core v0.9.0
[0m[0m[1m[32m   Compiling[0m glib-sys v0.15.10
[0m[0m[1m[32m   Compiling[0m gobject-sys v0.15.10
[0m[0m[1m[32m   Compiling[0m gio-sys v0.15.10
[0m[0m[1m[32m   Compiling[0m gdk-sys v0.15.1
[0m[0m[1m[32m   Compiling[0m gdk-pixbuf-sys v0.15.10
[0m[0m[1m[32m   Compiling[0m cairo-sys-rs v0.15.1
[0m[0m[1m[32m   Compiling[0m pango-sys v0.15.10
[0m[0m[1m[32m   Compiling[0m atk-sys v0.15.1
[0m[0m[1m[32m   Compiling[0m gtk-sys v0.15.3
[0m[0m[1m[32m   Compiling[0m gtk-layer-shell-sys v0.4.4
[0m[0m[1m[32m   Compiling[0m gdkx11-sys v0.15.1
[0m[0m[1m[32m   Compiling[0m glib-macros v0.15.11
[0m[0m[1m[32m   Compiling[0m gtk3-macros v0.15.4
[0m[0m[1m[32m   Compiling[0m jaq-std v0.9.0
[0m[0m[1m[32m   Compiling[0m glib v0.15.12
[0m[0m[1m[32m   Compiling[0m pango v0.15.10
[0m[0m[1m[32m   Compiling[0m cairo-rs v0.15.12
[0m[0m[1m[32m   Compiling[0m atk v0.15.1
[0m[0m[1m[32m   Compiling[0m gdk-pixbuf v0.15.11
[0m[0m[1m[32m   Compiling[0m gdk v0.15.4
[0m[0m[1m[32m   Compiling[0m gdkx11 v0.15.5
[0m[0m[1m[32m   Compiling[0m gtk-layer-shell v0.4.4
[0m[1m[33mwarning[0m[0m[1m: associated function `validate` is never used[0m
[0m  [0m[0m[1m[38;5;12m--> [0m[0mcrates/eww/src/state/one_to_n_elements_map.rs:72:12[0m
[0m   [0m[0m[1m[38;5;12m|[0m
[0m[1m[38;5;12m72[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    pub fn validate(&self) -> Result<()> {[0m
[0m   [0m[0m[1m[38;5;12m| [0m[0m           [0m[0m[1m[33m^^^^^^^^[0m
[0m   [0m[0m[1m[38;5;12m|[0m
[0m   [0m[0m[1m[38;5;12m= [0m[0m[1mnote[0m[0m: `#[warn(dead_code)]` on by default[0m

[0m[1m[33mwarning[0m[0m[1m: associated function `validate` is never used[0m
[0m   [0m[0m[1m[38;5;12m--> [0m[0mcrates/eww/src/state/scope_graph.rs:113:12[0m
[0m    [0m[0m[1m[38;5;12m|[0m
[0m[1m[38;5;12m113[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m    pub fn validate(&self) -> Result<()> {[0m
[0m    [0m[0m[1m[38;5;12m| [0m[0m           [0m[0m[1m[33m^^^^^^^^[0m

[0m[1m[33mwarning[0m[0m[1m: associated function `validate` is never used[0m
[0m   [0m[0m[1m[38;5;12m--> [0m[0mcrates/eww/src/state/scope_graph.rs:508:16[0m
[0m    [0m[0m[1m[38;5;12m|[0m
[0m[1m[38;5;12m508[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m        pub fn validate(&self) -> Result<()> {[0m
[0m    [0m[0m[1m[38;5;12m| [0m[0m               [0m[0m[1m[33m^^^^^^^^[0m

[0m[0m[1m[33mwarning[0m[1m:[0m `eww` (bin "eww") generated 3 warnings
[0m[0m[1m[32m    Finished[0m release [optimized] target(s) in 1m 59s
Executing cargoInstallPostBuildHook
Finished cargoInstallPostBuildHook
Finished cargoBuildHook
buildPhase completed in 2 minutes 0 seconds
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
Executing cargoCheckHook
++ cargo test -j 16 --release --target x86_64-unknown-linux-gnu --frozen --bin eww -- --test-threads=16
[0m[0m[1m[32m   Compiling[0m eww v0.4.0 (/build/eww/crates/eww)
[0m[0m[1m[32m    Finished[0m release [optimized] target(s) in 3.66s
[0m[0m[1m[32m     Running[0m unittests src/main.rs (target/x86_64-unknown-linux-gnu/release/deps/eww-7d7b74c5f8962be5)

running 10 tests
test state::one_to_n_elements_map::test::test_add_scope ... ok
test state::one_to_n_elements_map::test::test_remove_scope ... ok
test state::scope_graph::test::test_nested_inheritance ... ok
test state::scope_graph::test::test_variables_used_in_self_or_subscopes_of ... ok
test state::scope_graph::test::test_lookup_variable_in_scope ... ok
test util::test::test_unindent ... ok
test state::test::test_delete_scope ... ok
test widgets::test::test_replace_placeholders ... ok
test state::test::test_state_updates ... ok
test util::test::test_replace_env_var_references ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

Finished cargoCheckHook
@nix { "action": "setPhase", "phase": "glibPreInstallPhase" }
glibPreInstallPhase
@nix { "action": "setPhase", "phase": "installPhase" }
installing
Executing cargoInstallHook
Finished cargoInstallHook
@nix { "action": "setPhase", "phase": "dropIconThemeCache" }
dropIconThemeCache
@nix { "action": "setPhase", "phase": "glibPreFixupPhase" }
glibPreFixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/34m75n1dky1qfm64izy6xj9hfj4fqmdg-eww-9ba67124b9fdfbbe5260f32d25d5879050685435
shrinking /nix/store/34m75n1dky1qfm64izy6xj9hfj4fqmdg-eww-9ba67124b9fdfbbe5260f32d25d5879050685435/bin/eww
checking for references to /build/ in /nix/store/34m75n1dky1qfm64izy6xj9hfj4fqmdg-eww-9ba67124b9fdfbbe5260f32d25d5879050685435...
patching script interpreter paths in /nix/store/34m75n1dky1qfm64izy6xj9hfj4fqmdg-eww-9ba67124b9fdfbbe5260f32d25d5879050685435
stripping (with command strip and flags -S) in  /nix/store/34m75n1dky1qfm64izy6xj9hfj4fqmdg-eww-9ba67124b9fdfbbe5260f32d25d5879050685435/bin

```
