### PR TITLE
Updated nix overlay to support wayland and X11 at the same time (and remove eww-wayland overlay)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -33,16 +36,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661353537,
-        "narHash": "sha256-1E2IGPajOsrkR49mM5h55OtYnU0dGyre6gl60NXKITE=",
+        "lastModified": 1687770398,
+        "narHash": "sha256-xnQt3X0EWuBO5tI4ln2vzMpuuKRvQJvVZMBDVcJaSu8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e304ff0d9db453a4b230e9386418fd974d5804a",
+        "rev": "2e7efc14f29d4f67eb479349ba2d8e4f6ec4f11f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -62,16 +64,31 @@
         ]
       },
       "locked": {
-        "lastModified": 1661655464,
-        "narHash": "sha256-by9Hb0mNVdiCR7TBvUHIgDb0QIv3znp8VMGh7Bl35VQ=",
+        "lastModified": 1687746941,
+        "narHash": "sha256-wsSRCmPQ1+uXsDNnEH2mN4ZVtHHpfavA4FrQnCb5A44=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0c4c1432353e12b325d1472bea99e364871d2cb3",
+        "rev": "b91d162355e88de89b379f3d6a459ade92704474",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -29,19 +29,22 @@
             cargo = rust;
             rustc = rust;
           };
-        in
-        rec {
           # TODO update this to reflect the changes in upstream (nixpkgs), when upstream is updated
-          eww = (prev.eww.override { inherit rustPlatform; withWayland = true; }).overrideAttrs (old: {
+          eww = withWayland: (prev.eww.override { inherit rustPlatform; withWayland = true; }).overrideAttrs (old: {
             version = self.rev or "dirty";
             src = builtins.path { name = "eww"; path = prev.lib.cleanSource ./.; };
             cargoDeps = rustPlatform.importCargoLock { lockFile = ./Cargo.lock; };
-            cargoBuildNoDefaultFeatures = false;
-            cargoCheckNoDefaultFeatures = false;
+            # this currently just disables the x11 feature and enables the cargo feature "wayland" via the upstream derivation
+            cargoBuildNoDefaultFeatures = withWayland;
+            cargoCheckNoDefaultFeatures = withWayland;
             patches = [ ];
           });
-
-          eww-wayland = eww;
+        in
+        {
+          # this doesn't support wayland currently (although it should, see https://github.com/elkowar/eww/issues/739)
+          eww = eww false;
+          eww-x11 = eww false;
+          eww-wayland = eww true;
         };
 
       packages = nixpkgs.lib.genAttrs targetSystems (system:

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, rust-overlay, flake-compat, ... }:
+  outputs = { self, nixpkgs, rust-overlay, ... }:
     let
       pkgsFor = system: import nixpkgs {
         inherit system;
@@ -30,15 +30,18 @@
             rustc = rust;
           };
         in
-        {
-          eww = (prev.eww.override { inherit rustPlatform; }).overrideAttrs (old: {
+        rec {
+          # TODO update this to reflect the changes in upstream (nixpkgs), when upstream is updated
+          eww = (prev.eww.override { inherit rustPlatform; withWayland = true; }).overrideAttrs (old: {
             version = self.rev or "dirty";
             src = builtins.path { name = "eww"; path = prev.lib.cleanSource ./.; };
             cargoDeps = rustPlatform.importCargoLock { lockFile = ./Cargo.lock; };
+            cargoBuildNoDefaultFeatures = false;
+            cargoCheckNoDefaultFeatures = false;
             patches = [ ];
           });
 
-          eww-wayland = final.eww.override { withWayland = true; };
+          eww-wayland = eww;
         };
 
       packages = nixpkgs.lib.genAttrs targetSystems (system:


### PR DESCRIPTION
## Description

Fixes #733

Since X11 and wayland is now supported at the same time, eww could be reduced to the same package `eww`.
Right now this builds with support for X11 and wayland (default features). It may make sense to add more fine-grained support for different features in upstream via parameters, when it is updated there (i.e. `withWayland`, `withX11`, for either X11 or wayland support or both at the same time (should probably be the default then)) .
