### PR TITLE
add get_env function to yuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ## [Unreleased]
 
 ### Features
+- Add `get_env` function
 - Add `:namespace` window option
 - Default to building with x11 and wayland support simultaneously
 - Add `truncate-left` property on `label` widgets (By: kawaki-san)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ## [Unreleased]
 
 ### Features
-- Add `get_env` function
+- Add `get_env` function (By: RegenJacob)
 - Add `:namespace` window option
 - Default to building with x11 and wayland support simultaneously
 - Add `truncate-left` property on `label` widgets (By: kawaki-san)

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -308,9 +308,8 @@ impl SimplExpr {
 fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError> {
     match name {
         "get_env" => match args.as_slice() {
-            [string] => {
-                let string = string.as_string()?;
-                let var = std::env::var(string).unwrap_or("".to_string());
+            [var_name] => {
+                let var = std::env::var(var_name.as_string()?).unwrap_or_default();
                 Ok(DynVal::from(var))
             }
             _ => Err(EvalError::WrongArgCount(name.to_string())),

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -307,6 +307,14 @@ impl SimplExpr {
 
 fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError> {
     match name {
+        "get_env" => match args.as_slice() {
+            [string] => {
+                let string = string.as_string()?;
+                let var = std::env::var(string).unwrap_or("".to_string());
+                Ok(DynVal::from(var))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
         "round" => match args.as_slice() {
             [num, digits] => {
                 let num = num.as_f64()?;

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -47,3 +47,4 @@ Supported currently are the following features:
 	- `arraylength(value)`: Gets the length of the array
 	- `objectlength(value)`: Gets the amount of entries in the object
 	- `jq(value, jq_filter_string)`: run a [jq](https://stedolan.github.io/jq/manual/) style command on a json value. (Uses [jaq](https://crates.io/crates/jaq) internally).
+    - `get_env(key)`: Gets the specified Enviroment variable

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -47,4 +47,4 @@ Supported currently are the following features:
 	- `arraylength(value)`: Gets the length of the array
 	- `objectlength(value)`: Gets the amount of entries in the object
 	- `jq(value, jq_filter_string)`: run a [jq](https://stedolan.github.io/jq/manual/) style command on a json value. (Uses [jaq](https://crates.io/crates/jaq) internally).
-    - `get_env(string)`: Gets the specified Enviroment variable
+    - `get_env(string)`: Gets the specified enviroment variable

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -47,4 +47,4 @@ Supported currently are the following features:
 	- `arraylength(value)`: Gets the length of the array
 	- `objectlength(value)`: Gets the amount of entries in the object
 	- `jq(value, jq_filter_string)`: run a [jq](https://stedolan.github.io/jq/manual/) style command on a json value. (Uses [jaq](https://crates.io/crates/jaq) internally).
-    - `get_env(key)`: Gets the specified Enviroment variable
+    - `get_env(string)`: Gets the specified Enviroment variable


### PR DESCRIPTION
## Description

This PR adds the function `get_env("KEY")` to yuck.
SCSS already has the ability to read env vars so adding it directly to yuck seemed nice


When the specified env var is empty it returns an empty string 

## Usage

```fennel
(label :text "${get_env("USER")}")
```

## Additional Notes

This needs more testing.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
