### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -2,7 +2,7 @@
 
 Yuck includes a small expression language that can be used to run several operations on your data.
 This can be used to show different values depending on certain conditions,
-do mathematic operations, and even access values withing JSON-structures.
+do mathematic operations, and even access values within JSON-structures.
 
 These expressions can be placed anywhere within your configuration inside `{ ... }`,
 as well as within strings, inside string-interpolation blocks (`"foo ${ ... } bar"`).


### PR DESCRIPTION
Fixed a typo: withing --> within

There's a tiny typo in the docs :)


