### PR TITLE
add `EWW_TIME` magic variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add Vanilla CSS support (By: Ezequiel Ramis)
 - Add `jq` function, offering jq-style json processing
 - Add `justify` property to the label widget, allowing text justification (By: n3oney)
+- Add `EWW_TIME` magic variable (By: Erenoit)
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -29,7 +29,7 @@ macro_rules! define_builtin_vars {
     }
 }
 
-define_builtin_vars! { Duration::new(2, 0),
+define_builtin_vars! { Duration::new(1, 0),
     // @desc EWW_TEMPS - Heat of the components in Celcius
     // @prop { <name>: temperature }
     "EWW_TEMPS" => || Ok(DynVal::from(get_temperatures())),
@@ -61,6 +61,18 @@ define_builtin_vars! { Duration::new(2, 0),
     // @desc EWW_NET - Bytes up/down on all interfaces
     // @prop { <name>: { up, down } }
     "EWW_NET" => || Ok(DynVal::from(net())),
+
+    // @desc EWW_TIME - Information on current time
+    // @prop { year, month_name, month_num, day, weekday, am_pm, hour_24, hour_12, minute, second }
+    "EWW_TIME" => || Ok(DynVal::from(
+        match get_time() {
+            Err(e) => {
+                log::error!("Couldn't get the time: {:?}", e);
+                "Error: Check `eww log` for more details".to_string()
+            }
+            Ok(o) => o,
+        }
+    )),
 }
 
 macro_rules! define_magic_constants {

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -177,3 +177,27 @@ pub fn net() -> String {
     );
     interfaces
 }
+
+#[cfg(target_family = "unix")]
+pub fn get_time() -> Result<String> {
+    let time = String::from_utf8(
+        std::process::Command::new("date")
+            .arg(r#"+"%Y %B %m %d %A %p %H %I %M %S""#)
+            .output()
+            .context("\nError while getting the time on unix, with `date`: ")?
+            .stdout,
+    )?;
+
+    // Remove the " at the beginning and the end
+    let time_v = time[1..time.len() - 2].split_whitespace().collect::<Vec<&str>>();
+
+    Ok(format!(
+        r#"{{ "year": "{}", "month_name": "{}", "month_num": "{}", "day": "{}", "weekday": "{}", "am_pm": "{}", "hour_24": "{}", "hour_12": "{}", "minute": "{}", "second": "{}" }}"#,
+        time_v[0], time_v[1], time_v[2], time_v[3], time_v[4], time_v[5], time_v[6], time_v[7], time_v[8], time_v[9]
+    ))
+}
+
+#[cfg(not(target_family = "unix"))]
+pub fn get_time() -> Result<String> {
+    Err(anyhow::anyhow!("Eww doesn't support your OS for getting the time"))
+}

--- a/docs/src/magic-vars.md
+++ b/docs/src/magic-vars.md
@@ -2,5 +2,5 @@
 
 These are variables that are always there, without you having to import them.
 
-The delay between the updating variables is always 2s.
+The delay between the updating variables is always 1s.
 


### PR DESCRIPTION
## Description

Adds new magic variable `EWW_TIME` to get time information. A lot of people use some
type of time information in their widgets in all sorts of ways. I added fields for most
usage cases but I can add more if needed. I think field names are self explanatory but I can
explain one by one if needed.

I used `date` from `coreutils` to get the time information from the system. Therefore, it should
work on most of the `unix` machines. It should also respect `LC_TIME`.

Additionally reduced update delay to 1 second to be able to measure seconds correctly.

This is my first pull request; so, any help is appreciated.

## Usage

It can be used the same as other magic variables. For example:

```
(label :text "${EWW_TIME.day}/${EWW_TIME.month_num}/${EWW_TIME.year}")
```
should output `06/06/2023`.

## Additional Notes

- Not exactly requested feature bu may close #791.
- It is only tested on linux. More test may be needed.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
