### PR TITLE
add `:unindent` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add support for referring to monitor with `<primary>`
 - Add support for multiple matchers in `monitor` field
 - Add `stack` widget (By: vladaviedov)
+- Add `unindent` property to the label widget, allowing to disable removal of leading spaces (By: nrv)
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -2,7 +2,7 @@
 use super::{build_widget::BuilderArgs, circular_progressbar::*, run_command, transform::*};
 use crate::{
     def_widget, enum_parse, error_handling_ctx,
-    util::{list_difference, unindent},
+    util::{self, list_difference},
     widgets::build_widget::build_gtk_widget,
 };
 use anyhow::{anyhow, Context, Result};
@@ -830,7 +830,8 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         // @prop limit-width - maximum count of characters to display
         // @prop truncate-left - whether to truncate on the left side
         // @prop show-truncated - show whether the text was truncated
-        prop(text: as_string, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true) {
+        // @prop unindent - whether to remove leading spaces
+        prop(text: as_string, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true) {
             let limit_width = limit_width as usize;
             let char_count = text.chars().count();
             let text = if char_count > limit_width {
@@ -852,7 +853,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
             };
 
             let text = unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))?;
-            let text = unindent(&text);
+            let text = if unindent { util::unindent(&text) } else { text };
             gtk_widget.set_text(&text);
         },
         // @prop markup - Pango markup to display


### PR DESCRIPTION
Please follow this template, if applicable.

## Description

Adds a property to control `label` unindenting/stripping leading spaces (default is `true`). This partly addresses #647 (although it is about using raw strings as widgets, but with this you can use `label` to work around it).

## Usage

Example of a custom `raw-label` widget that does not strip leading spaces:
```clojure
(defwidget raw-label [text ?class ?truncate-left ?show-truncated]
  (label
    :unindent false
    :text "${text}"
    :class {class}
    :truncate-left {truncate-left ?: false}
    :show-truncated {show-truncated ?: true}
  )
)
```
## Showcase

Screenshot of my bar:

![image](https://github.com/elkowar/eww/assets/70909425/e27fdc8c-5f8e-492b-bea9-5616c54370a9)

The rightmost elements use the above `raw-label` widget to display left-padded strings that i get from my scripts correctly, so the bar does not flick around on updates.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
