### PR TITLE
Remove duplicate CSS and use .bar class in the example

### DIFF
--- a/examples/eww-bar/eww.scss
+++ b/examples/eww-bar/eww.scss
@@ -22,6 +22,7 @@
   color: #000000;
   border-radius: 10px;
 }
+
 .metric scale trough {
   all: unset;
   background-color: #4e4e4e;
@@ -31,25 +32,11 @@
   margin-left: 10px;
   margin-right: 20px;
 }
-.metric scale trough highlight {
-  all: unset;
-  background-color: #D35D6E;
-  color: #000000;
-  border-radius: 10px;
-}
-.metric scale trough {
-  all: unset;
-  background-color: #4e4e4e;
-  border-radius: 50px;
-  min-height: 3px;
-  min-width: 50px;
-  margin-left: 10px;
-  margin-right: 20px;
-}
+
 .label-ram {
   font-size: large;
 }
+
 .workspaces button:hover {
   color: #D35D6E;
 }
-

--- a/examples/eww-bar/eww.yuck
+++ b/examples/eww-bar/eww.yuck
@@ -1,5 +1,5 @@
 (defwidget bar []
-  (centerbox :orientation "h"
+  (centerbox :class "bar" :orientation "h"
     (workspaces)
     (music)
     (sidestuff)))


### PR DESCRIPTION
I just started using Eww and tried the example. There I noticed small issues and fixed them.

## Description

In the example files I removed two CSS class definitions that where duplicated and used the `.bar` class, which was unused before, on the bar widget.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
