### PR TITLE
Hacky workarround for log file growing too large

### DIFF
--- a/crates/eww/src/widgets/dup_log_count.rs
+++ b/crates/eww/src/widgets/dup_log_count.rs
@@ -1,0 +1,5 @@
+use std::sync::atomic::AtomicU64;
+
+pub static UPGRADE_FAIL_LOG_COUNT: AtomicU64 = AtomicU64::new(0);
+pub const UPGRADE_FAIL_LOG_MAX_COUNT: u64 = 10;
+

--- a/crates/eww/src/widgets/dup_log_count.rs
+++ b/crates/eww/src/widgets/dup_log_count.rs
@@ -2,4 +2,3 @@ use std::sync::atomic::AtomicU64;
 
 pub static UPGRADE_FAIL_LOG_COUNT: AtomicU64 = AtomicU64::new(0);
 pub const UPGRADE_FAIL_LOG_MAX_COUNT: u64 = 10;
-

--- a/crates/eww/src/widgets/mod.rs
+++ b/crates/eww/src/widgets/mod.rs
@@ -7,6 +7,8 @@ pub mod graph;
 pub mod transform;
 pub mod widget_definitions;
 
+mod dup_log_count;
+
 /// Run a command that was provided as an attribute.
 /// This command may use placeholders which will be replaced by the values of the arguments given.
 /// This can either be the placeholder `{}`, which will be replaced by the first argument,


### PR DESCRIPTION
Not meant to be merged but an attempt at a workaround for the people who need one. Not tested yet as I can't reproduce the widget deallocation problem anymore.