### PR TITLE
Added gtk stack widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `jq` function, offering jq-style json processing
 - Add `justify` property to the label widget, allowing text justification (By: n3oney)
 - Add `EWW_TIME` magic variable (By: Erenoit)
+- Add `stack` widget (By: vladaviedov)
 
 ## [0.4.0] (04.09.2022)
 


### PR DESCRIPTION
## Description

This PR adds the stack widget from GTK.
This widget shows one of its children at a time.

## Usage

```
(stack
    :selected int_var

    (child 0)
    (child 1)
    (...)
)
```

Setting `int_var` will show child with respective index.

### Showcase

![stack](https://github.com/elkowar/eww/assets/87404908/b6488503-d964-460f-92b9-8bfaccf39126)

## Additional Notes

I made this as a workaround to the problem I was having in #835, however I don't think it resolves that issue.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
