### PR TITLE
Make transform widgets rotate/scale around their centers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `jq` function, offering jq-style json processing
 - Add `justify` property to the label widget, allowing text justification (By: n3oney)
 - Add `EWW_TIME` magic variable (By: Erenoit)
+- Made `transform` widgets perform transforms around their center (By: Hyeve)
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/eww/src/widgets/transform.rs
+++ b/crates/eww/src/widgets/transform.rs
@@ -140,6 +140,10 @@ impl WidgetImpl for TransformPriv {
             let total_width = widget.allocated_width() as f64;
             let total_height = widget.allocated_height() as f64;
 
+            let total_width = widget.allocated_width() as f64;
+            let total_height = widget.allocated_height() as f64;
+            let center = (total_width / 2.0, total_height / 2.0);
+
             cr.save()?;
 
             let translate_x = match &*self.translate_x.borrow() {
@@ -162,9 +166,13 @@ impl WidgetImpl for TransformPriv {
                 None => 1.0,
             };
 
+            cr.translate(center.0, center.1);
+
             cr.scale(scale_x, scale_y);
             cr.rotate(perc_to_rad(rotate));
             cr.translate(translate_x, translate_y);
+
+            cr.translate(-center.0, -center.1);
 
             // Children widget
             if let Some(child) = &*self.content.borrow() {


### PR DESCRIPTION
## Description

I modified the transform widget to do rotation / scaling around the center of the widget, rather than around 0,0 (usually the top left of the screen).     

### Showcase

This means it now has an effect like this:
![image](https://github.com/elkowar/eww/assets/34379593/399df8ba-d738-4530-8799-4af29f2a6403)

Rather than this:
![image](https://github.com/elkowar/eww/assets/34379593/aac3a478-87d0-48a5-b47d-4332dbebcb0b)


## Additional Notes

Ideally, I think it'd be useful to base the transform origin off of some property, either new ones or using existing ones like v/h `align`, but I haven't attempted to figure out how to do that. Transforming around the center is fine for my use, and probably significantly more useful than transforming around 0,0 in general.

