### PR TITLE
nix: refactor flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,35 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1687178632,
+        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
         "type": "github"
       }
     },
@@ -47,14 +65,52 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1688049487,
+        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "parts": "parts",
+        "rust": "rust"
       }
     },
-    "rust-overlay": {
+    "rust": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": [
@@ -62,16 +118,31 @@
         ]
       },
       "locked": {
-        "lastModified": 1661655464,
-        "narHash": "sha256-by9Hb0mNVdiCR7TBvUHIgDb0QIv3znp8VMGh7Bl35VQ=",
+        "lastModified": 1688610886,
+        "narHash": "sha256-Ir5FaBvhBtZ5OGZ3g9rgy4twUcEnyuGEz4QLmxAn9FE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0c4c1432353e12b325d1472bea99e364871d2cb3",
+        "rev": "358d7155300cd64357f9afd14aa3383c2323e5fc",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,62 +1,32 @@
 {
   inputs = {
+    # maybe consider __getFlake github:elkowar/eww instead
     flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    parts.url = "github:hercules-ci/flake-parts";
+    rust.url = "github:oxalica/rust-overlay";
+    nix-filter.url = "github:numtide/nix-filter";
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    rust.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, rust-overlay, flake-compat, ... }:
-    let
-      pkgsFor = system: import nixpkgs {
-        inherit system;
+  outputs = inputs@{ self, parts, nixpkgs, rust, ... }:
+    parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "aarch64-linux" "x86_64-linux" ];
 
-        overlays = [
-          self.overlays.default
-          rust-overlay.overlays.default
-        ];
-      };
+      flake.overlays.default = throw "The eww overlay was removed, please use packages.\${system}.* instead.";
 
-      targetSystems = [ "aarch64-linux" "x86_64-linux" ];
-      mkRustToolchain = pkgs: pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-    in
-    {
-      overlays.default = final: prev:
+      perSystem = ctx@{ self', pkgs, lib, system, ... }:
         let
-          rust = mkRustToolchain final;
+          pkgs = ctx.pkgs.extend rust.overlays.default;
+          toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
-          rustPlatform = prev.makeRustPlatform {
-            cargo = rust;
-            rustc = rust;
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = toolchain;
+            rustc = toolchain;
           };
         in
         {
-          eww = (prev.eww.override { inherit rustPlatform; }).overrideAttrs (old: {
-            version = self.rev or "dirty";
-            src = builtins.path { name = "eww"; path = prev.lib.cleanSource ./.; };
-            cargoDeps = rustPlatform.importCargoLock { lockFile = ./Cargo.lock; };
-            patches = [ ];
-          });
-
-          eww-wayland = final.eww.override { withWayland = true; };
-        };
-
-      packages = nixpkgs.lib.genAttrs targetSystems (system:
-        let
-          pkgs = pkgsFor system;
-        in
-        (self.overlays.default pkgs pkgs) // {
-          default = self.packages.${system}.eww;
-        }
-      );
-
-      devShells = nixpkgs.lib.genAttrs targetSystems (system:
-        let
-          pkgs = pkgsFor system;
-          rust = mkRustToolchain pkgs;
-        in
-        {
-          default = pkgs.mkShell {
+          devShells.default = pkgs.mkShell {
             packages = with pkgs; [
               rust
               rust-analyzer-unwrapped
@@ -68,9 +38,38 @@
               mdbook
             ];
 
-            RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
+            RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
           };
-        }
-      );
+
+          packages = {
+            default = self'.packages.eww;
+
+            eww = (pkgs.eww.override { inherit rustPlatform; }).overrideAttrs (old: {
+              version = self.rev or "dirty";
+
+              src = inputs.nix-filter.lib.filter {
+                root = ./.;
+
+                include = [
+                  ./crates
+                  ./Cargo.toml
+                  ./Cargo.lock
+                ];
+              };
+
+              patches = [ ];
+              cargoDeps = rustPlatform.importCargoLock { lockFile = ./Cargo.lock; };
+              buildFeatures = [ "wayland" "x11" ];
+              buildInputs = old.buildInputs ++ [ pkgs.gtk-layer-shell ];
+            });
+
+            eww-wayland = self'.packages.eww.overrideAttrs (_: { buildFeatures = [ "wayland" ]; });
+
+            eww-x11 = self'.packages.eww.overrideAttrs (old: {
+              buildFeatures = [ "x11" ];
+              buildInputs = lib.remove pkgs.gtk-layer-shell old.buildInputs;
+            });
+          };
+        };
     };
 }


### PR DESCRIPTION
Things done:
  - removed the overlay, since doing it properly is impossible and requires users to have rust-overlay locally
  - use flake-parts
  - have 3 packages, `eww` for a version with x11 and wayland support, `eww-wayland` for purely wayland, and `eww-x11` for purely x11