### PR TITLE
Make formattime follow system locale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "pure-rust-locales",
  "time",
  "wasm-bindgen",
  "winapi",
@@ -718,6 +719,7 @@ dependencies = [
 name = "eww_shared_util"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "derive_more",
  "ref-cast",
  "serde",
@@ -1895,6 +1897,12 @@ checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45c49fc4f91f35bae654f85ebb3a44d60ac64f11b3166ffa609def390c732d8"
 
 [[package]]
 name = "quote"

--- a/crates/eww_shared_util/Cargo.toml
+++ b/crates/eww_shared_util/Cargo.toml
@@ -12,3 +12,4 @@ homepage = "https://github.com/elkowar/eww"
 serde = {version = "1.0", features = ["derive"]}
 derive_more = "0.99"
 ref-cast = "1.0.6"
+chrono = { version = "0.4.26", features = ["unstable-locales"] }

--- a/crates/eww_shared_util/src/lib.rs
+++ b/crates/eww_shared_util/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod locale;
 pub mod span;
 pub mod wrappers;
 
+pub use locale::*;
 pub use span::*;
 pub use wrappers::*;
 

--- a/crates/eww_shared_util/src/locale.rs
+++ b/crates/eww_shared_util/src/locale.rs
@@ -1,0 +1,14 @@
+use chrono::Locale;
+use std::env::var;
+
+/// Returns the `Locale` enum based on the `LC_TIME` environment variable.
+/// If the environment variable is not defined or is malformed use the POSIX locale.
+pub fn get_locale() -> Locale {
+    let locale_string: String =
+        var("LC_TIME").map_or_else(|_| "C".to_string(), |v| v.split(".").next().unwrap_or("C").to_string());
+
+    match (&*locale_string).try_into() {
+        Ok(x) => x,
+        Err(_) => Locale::POSIX,
+    }
+}

--- a/crates/simplexpr/Cargo.toml
+++ b/crates/simplexpr/Cargo.toml
@@ -25,7 +25,7 @@ jaq-core = "0.9.0"
 jaq-std = {version = "0.9.0", features = ["bincode"]}
 static_assertions = "1.1.0"
 cached = "0.42.0"
-chrono = "0.4.26"
+chrono = { version = "0.4.26", features = ["unstable-locales"] }
 chrono-tz = "0.8.2"
 
 strum = { version = "0.24", features = ["derive"] }

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -6,7 +6,7 @@ use crate::{
     ast::{AccessType, BinOp, SimplExpr, UnaryOp},
     dynval::{ConversionError, DynVal},
 };
-use eww_shared_util::{Span, Spanned, VarName};
+use eww_shared_util::{get_locale, Span, Spanned, VarName};
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
@@ -443,12 +443,16 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
                 };
 
                 Ok(DynVal::from(match timezone.timestamp_opt(timestamp.as_i64()?, 0) {
-                    LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => t.format(&format.as_string()?).to_string(),
+                    LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => {
+                        t.format_localized(&format.as_string()?, get_locale()).to_string()
+                    }
                     LocalResult::None => return Err(EvalError::ChronoError("Invalid UNIX timestamp".to_string())),
                 }))
             }
             [timestamp, format] => Ok(DynVal::from(match Local.timestamp_opt(timestamp.as_i64()?, 0) {
-                LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => t.format(&format.as_string()?).to_string(),
+                LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => {
+                    t.format_localized(&format.as_string()?, get_locale()).to_string()
+                }
                 LocalResult::None => return Err(EvalError::ChronoError("Invalid UNIX timestamp".to_string())),
             })),
             _ => Err(EvalError::WrongArgCount(name.to_string())),


### PR DESCRIPTION
## Description
Fixes #869.

This draft:
1) Creates new function `get_locale` in `eww_shared_util` that returns the chrono `Locale` enum.
2) Enables the [chrono `unstable-locales` feature](https://docs.rs/chrono/latest/chrono/index.html#formatting-and-parsing) for the `simplexpr` crate
3) Changes the `t.format` function in simplexpr `formattime` expression to `t.format_localized` which then uses the aforementioned `get_locale` function to get the appropriate `Locale` enum.

Related issues:
- https://github.com/chronotope/chrono/issues/708
- https://github.com/greshake/i3status-rust/issues/73
- https://github.com/chronotope/chrono/issues/199
- https://github.com/chronotope/chrono/pull/453

## Questions
1) Is `eww_shared_util` a good place to put `get_locale` into?
2) Is it desirable to have the `get_locale` function called every time the `formattime` expression is evaluated?
3) We might also want to check for the `LANG` variable if `LC_TIME` fails.
4) Maybe we want to use some different way of getting the format like `libc-strftime`?

## Checklist

Please make sure you can check all the boxes that apply to this PR.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
