### PR TITLE
Add force-poll command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add trigonometric functions (`sin`, `cos`, `tan`, `cot`) and degree/radian conversions (`degtorad`, `radtodeg`) (By: end-4)
 - Add `substring` function to simplexpr
 - Add `--duration` flag to `eww open`
+- Add `force-poll` command (By: ZaheenJ)
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -91,6 +91,10 @@ pub enum ActionWithServer {
         mappings: Vec<(VarName, DynVal)>,
     },
 
+    /// Manually tells  polling variables to update
+    #[clap(name = "force-poll", alias = "fp")]
+    ForcePoll { vars: Vec<VarName> },
+
     /// Open the GTK debugger
     #[command(name = "inspector", alias = "debugger")]
     OpenInspector,
@@ -210,6 +214,7 @@ impl ActionWithServer {
     pub fn into_daemon_command(self) -> (app::DaemonCommand, Option<daemon_response::DaemonResponseReceiver>) {
         let command = match self {
             ActionWithServer::Update { mappings } => app::DaemonCommand::UpdateVars(mappings),
+            ActionWithServer::ForcePoll { vars } => app::DaemonCommand::ForcePoll(vars),
             ActionWithServer::OpenInspector => app::DaemonCommand::OpenInspector,
 
             ActionWithServer::KillServer => app::DaemonCommand::KillServer,

--- a/crates/eww/src/script_var_handler.rs
+++ b/crates/eww/src/script_var_handler.rs
@@ -192,7 +192,7 @@ impl PollVarHandler {
     }
 }
 
-fn run_poll_once(var: &PollScriptVar) -> Result<DynVal> {
+pub fn run_poll_once(var: &PollScriptVar) -> Result<DynVal> {
     match &var.command {
         VarSource::Shell(span, command) => {
             script_var::run_command(command).map_err(|e| anyhow!(create_script_var_failed_warn(*span, &var.name, &e.to_string())))


### PR DESCRIPTION
## Description

Adds a new eww command `force-poll`. Addresses https://github.com/elkowar/eww/issues/673

## Usage

Run `eww force-poll <pollvar>` or `eww fp <pollvar>`. If the variable is a poll variable then it will manually run the associated command to update it or returns with `No poll var named <var> exists` or `No script var named <var> exists` if a regular variable named var doesn't exist either.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented (None added).
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes (not applicable?).
- [X] I used `cargo fmt` to automatically format all code before committing
