### PR TITLE
Add roundsize function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add trigonometric functions (`sin`, `cos`, `tan`, `cot`) and degree/radian conversions (`degtorad`, `radtodeg`) (By: end-4)
 - Add `substring` function to simplexpr
 - Add `--duration` flag to `eww open`
+- Add `roundsize` function to simplexpr
 
 ## [0.4.0] (04.09.2022)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2187,7 @@ dependencies = [
  "jaq-std",
  "lalrpop",
  "lalrpop-util",
+ "number_prefix",
  "once_cell",
  "regex",
  "serde",

--- a/crates/simplexpr/Cargo.toml
+++ b/crates/simplexpr/Cargo.toml
@@ -31,6 +31,7 @@ chrono-tz = "0.8.2"
 strum = { version = "0.24", features = ["derive"] }
 
 eww_shared_util = { version = "0.1.0", path = "../eww_shared_util" }
+number_prefix = "0.4.0"
 
 
 [build-dependencies]

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -1,6 +1,7 @@
 use cached::proc_macro::cached;
 use chrono::{Local, LocalResult, TimeZone};
 use itertools::Itertools;
+use number_prefix::{NumberPrefix};
 
 use crate::{
     ast::{AccessType, BinOp, SimplExpr, UnaryOp},
@@ -13,6 +14,7 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
+use serde_json::json;
 
 #[derive(Debug, thiserror::Error)]
 pub struct JaqParseError(pub Option<jaq_core::parse::Error>);
@@ -317,6 +319,29 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
                 let num = num.as_f64()?;
                 let digits = digits.as_i32()?;
                 Ok(DynVal::from(format!("{:.1$}", num, digits as usize)))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
+        "roundsize" => match args.as_slice() {
+            [size] => {
+                let size = size.as_f64()?;
+                Ok(match NumberPrefix::binary(size) {
+                    NumberPrefix::Standalone(bytes) => DynVal::from(json!({"size": bytes, "units": "B"}).to_string()),
+                    NumberPrefix::Prefixed(prefix, n) => DynVal::from(json!({"size": n, "units": format!("{}B", prefix)}).to_string())
+                })
+            }
+            [size, format_type] => {
+                let format_type = format_type.as_string()?;
+                let func = match format_type.as_str() {
+                    "decimal" => NumberPrefix::decimal,
+                    "binary" => NumberPrefix::binary,
+                    _ => return Err(EvalError::NoVariablesAllowed(format_type.parse().unwrap()))
+                };
+                let size = size.as_f64()?;
+                Ok(match func(size) {
+                    NumberPrefix::Standalone(bytes) => DynVal::from(json!({"size": bytes, "units": "B"}).to_string()),
+                    NumberPrefix::Prefixed(prefix, n) => DynVal::from(json!({"size": n, "units": format!("{}B", prefix)}).to_string())
+                })
             }
             _ => Err(EvalError::WrongArgCount(name.to_string())),
         },

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -59,3 +59,5 @@ Supported currently are the following features:
       Same as other `formattime`, but does not accept timezone. Instead, it uses system's local timezone.
       Check [chrono's documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) for more
       information about format string.
+    - `roundsize(bytes)`: Round a number of bytes to human-readable on binary base (KiB, MiB, GiB). Returned value format `{ size, units }` 
+    - `roundsize(bytes, format_type)`: Round a number of bytes to human-readable with specific format type it's can be `binary (KiB, MiB, GiB...)` or `decimal (KB, MB, GB...)`. Returned value format `{ size, units }`


### PR DESCRIPTION
## Description

I added a function for easily pars size value into human-readable value. 

## Usage

```yuck
;; RAM Stats Widgets ;;
(defwidget ram_stats [used_mem total_mem]
      (label
        :text `${round(used_mem.size,2)}${used_mem.units}/${round(total_mem.size,0)}${total_mem.units}`)
    )
  )

;; Stats Widgets ;;
(defwidget stats []
    (ram_stats 
    :total_mem {roundsize(EWW_RAM.total_mem)}
    :used_mem {roundsize(EWW_RAM.used_mem)})
  )
)
```

### Showcase

It's help to parse magic variable that provide size in bytes without external script

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
