### PR TITLE
add EWW_IPV4/6 magic variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `jq` function, offering jq-style json processing
 - Add `justify` property to the label widget, allowing text justification (By: n3oney)
 - Add `EWW_TIME` magic variable (By: Erenoit)
+- Add `EWW_IPV4`, `EWW_IPV6` magic variable (By: Lanpingner)
 - Add trigonometric functions (`sin`, `cos`, `tan`, `cot`) and degree/radian conversions (`degtorad`, `radtodeg`) (By: end-4)
 - Add `substring` function to simplexpr
 - Add `--duration` flag to `eww open`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +700,7 @@ dependencies = [
  "gtk-layer-shell",
  "itertools 0.11.0",
  "libc",
+ "local-ip-address",
  "log",
  "maplit",
  "nix 0.26.2",
@@ -1478,6 +1485,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
+name = "local-ip-address"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fefe707432eb6bd4704b3dacfc87aab269d56667ad05dcd6869534e8890e767"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1570,31 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -55,6 +55,7 @@ tokio-util = "0.7.8"
 
 sysinfo = "0.29.8"
 chrono = "0.4.26"
+local-ip-address = "0.5.3"
 
 wait-timeout = "0.2"
 

--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -64,6 +64,12 @@ define_builtin_vars! {
 
     // @desc EWW_TIME - the current UNIX timestamp
     "EWW_TIME" [1] => || Ok(DynVal::from(get_time())) ,
+
+    // @desc EWW_IPV4 - Information about the IPv4 address on all interfaces except "lo"
+    "EWW_IPV4" [1] => || Ok(DynVal::from(get_ipv4())),
+
+    // @desc EWW_IPV6 - Information about the IPv6 address on all interfaces except "lo"
+    "EWW_IPV6" [1] => || Ok(DynVal::from(get_ipv6())),
 }
 
 macro_rules! define_magic_constants {

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -4,6 +4,8 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use std::{fs::read_to_string, sync::Mutex};
 use sysinfo::{ComponentExt, CpuExt, DiskExt, NetworkExt, NetworksExt, System, SystemExt};
+use local_ip_address::list_afinet_netifas;
+
 
 static SYSTEM: Lazy<Mutex<System>> = Lazy::new(|| Mutex::new(System::new()));
 
@@ -206,4 +208,26 @@ pub fn net() -> String {
 
 pub fn get_time() -> String {
     chrono::offset::Utc::now().timestamp().to_string()
+}
+
+pub fn get_ipv4() -> String {
+    let ifas = list_afinet_netifas().unwrap();
+    let joined = ifas
+    .iter()
+    .filter(|ipv| ipv.1.is_ipv4() && ipv.0 != "lo")
+    .map(|ip| format!("{}", ip.1))
+    .collect::<Vec<_>>()
+    .join(", ");
+    joined
+}
+
+pub fn get_ipv6() -> String {
+    let ifas = list_afinet_netifas().unwrap();
+    let joined = ifas
+    .iter()
+    .filter(|ipv| ipv.1.is_ipv6() && ipv.0 != "lo")
+    .map(|ip| format!("{}", ip.1))
+    .collect::<Vec<_>>()
+    .join(", ");
+    joined
 }

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -1,11 +1,10 @@
 use crate::util::IterAverage;
 use anyhow::{Context, Result};
 use itertools::Itertools;
+use local_ip_address::list_afinet_netifas;
 use once_cell::sync::Lazy;
 use std::{fs::read_to_string, sync::Mutex};
 use sysinfo::{ComponentExt, CpuExt, DiskExt, NetworkExt, NetworksExt, System, SystemExt};
-use local_ip_address::list_afinet_netifas;
-
 
 static SYSTEM: Lazy<Mutex<System>> = Lazy::new(|| Mutex::new(System::new()));
 
@@ -212,22 +211,14 @@ pub fn get_time() -> String {
 
 pub fn get_ipv4() -> String {
     let ifas = list_afinet_netifas().unwrap();
-    let joined = ifas
-    .iter()
-    .filter(|ipv| ipv.1.is_ipv4() && ipv.0 != "lo")
-    .map(|ip| format!("{}", ip.1))
-    .collect::<Vec<_>>()
-    .join(", ");
+    let joined =
+        ifas.iter().filter(|ipv| ipv.1.is_ipv4() && ipv.0 != "lo").map(|ip| format!("{}", ip.1)).collect::<Vec<_>>().join(", ");
     joined
 }
 
 pub fn get_ipv6() -> String {
     let ifas = list_afinet_netifas().unwrap();
-    let joined = ifas
-    .iter()
-    .filter(|ipv| ipv.1.is_ipv6() && ipv.0 != "lo")
-    .map(|ip| format!("{}", ip.1))
-    .collect::<Vec<_>>()
-    .join(", ");
+    let joined =
+        ifas.iter().filter(|ipv| ipv.1.is_ipv6() && ipv.0 != "lo").map(|ip| format!("{}", ip.1)).collect::<Vec<_>>().join(", ");
     joined
 }


### PR DESCRIPTION
## Description

This PR creates 2 magic variables that can retrieve all IPV4/6 addresses on all interfaces  

## Usage
To retrieve all IPV4 address
`(label :text EWW_IPV4)`

To retrieve all IPV6 address
`(label :text EWW_IPV6)`

## Checklist

Please make sure you can check all the boxes that apply to this PR.
 
- [✓] All widgets I've added are correctly documented.
- [✓] I added my changes to CHANGELOG.md, if appropriate.
- [✓] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [✓] I used `cargo fmt` to automatically format all code before committing
