### PR TITLE
add `gravity` property to `label` widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `:namespace` window option
 - Default to building with x11 and wayland support simultaneously
 - Add `truncate-left` property on `label` widgets (By: kawaki-san)
+- Add `gravity` property on `label` widgets (By: Elekrisk)
 - Add support for safe access (`?.`) in simplexpr (By: oldwomanjosiah)
 - Allow floating-point numbers in percentages for window-geometry
 - Add support for safe access with index (`?.[n]`) (By: ModProg)

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -859,6 +859,10 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         prop(wrap: as_bool) { gtk_widget.set_line_wrap(wrap) },
         // @prop angle - the angle of rotation for the label (between 0 - 360)
         prop(angle: as_f64 = 0) { gtk_widget.set_angle(angle) },
+        // @prop gravity - the gravity of the string (south, east, west, north, auto). Text will want to face the direction of gravity.
+        prop(gravity: as_string = "south") {
+            gtk_widget.pango_context().set_base_gravity(parse_gravity(&gravity)?);
+        },
         // @prop xalign - the alignment of the label text on the x axis (between 0 - 1, 0 -> left, 0.5 -> center, 1 -> right)
         prop(xalign: as_f64 = 0.5) { gtk_widget.set_xalign(xalign as f32) },
         // @prop yalign - the alignment of the label text on the y axis (between 0 - 1, 0 -> bottom, 0.5 -> center, 1 -> top)
@@ -1093,6 +1097,17 @@ fn parse_justification(j: &str) -> Result<gtk::Justification> {
         "right" => gtk::Justification::Right,
         "center" => gtk::Justification::Center,
         "fill" => gtk::Justification::Fill,
+    }
+}
+
+/// @var gravity - "south", "east", "west", "north", "auto"
+fn parse_gravity(g: &str) -> Result<gtk::pango::Gravity> {
+    enum_parse! { "gravity", g,
+        "south" => gtk::pango::Gravity::South,
+        "east" => gtk::pango::Gravity::East,
+        "west" => gtk::pango::Gravity::West,
+        "north" => gtk::pango::Gravity::North,
+        "auto" => gtk::pango::Gravity::Auto,
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds the property `gravity` to the `label` widget, exposing functionality to specify the [Pango gravity](https://docs.gtk.org/Pango/pango_bidi.html#vertical-text). Text will want to face the direction of gravity. This is useful for vertical text, allowing scripts with vertical forms to display as such.

## Usage

Simply add the `:gravity` property to a `label` widget, with one of `"south"`, `"east"`, `"west"`, `"north"` or `"auto"`. `"auto"` will set the gravity to face downwards on the screen, taking account for rotation.

### Showcase

Without gravity, the Japanese text is still written horizontally:
```
(label :angle 270 :text "English text 日本語のテキスト More English text")
```
![20231014_01h25m15s_grim](https://github.com/elkowar/eww/assets/24945509/9eb7ce6b-134b-454f-82ed-5e36aed50095)


With gravity set to `"auto"`, the Japanese characters are rotated, so that they
are written vertically:
```
(label :angle 270 :gravity "auto" :text "English text 日本語のテキスト More English text")
```
![20231014_01h25m32s_grim](https://github.com/elkowar/eww/assets/24945509/add50570-6e62-40dd-939d-b5dfbfadc279)


## Additional Notes

Gravity defaults to `"south"`, since that is the existing behaviour, and probably the more intuitive result.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation generated by `gen-docs.ts` contains updated documentation.
- [x] I used `cargo fmt` to automatically format all code before committing
