### PR TITLE
Add jq_raw function to simplexpr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add trigonometric functions (`sin`, `cos`, `tan`, `cot`) and degree/radian conversions (`degtorad`, `radtodeg`) (By: end-4)
 - Add `substring` function to simplexpr
 - Add `--duration` flag to `eww open`
+- Add `jq_raw` function
 
 ## [0.4.0] (04.09.2022)
 

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -51,6 +51,7 @@ Supported currently are the following features:
 	- `arraylength(value)`: Gets the length of the array
 	- `objectlength(value)`: Gets the amount of entries in the object
 	- `jq(value, jq_filter_string)`: run a [jq](https://stedolan.github.io/jq/manual/) style command on a json value. (Uses [jaq](https://crates.io/crates/jaq) internally).
+    - `jq_raw(value, jq_filter_string)`: as above, but top-level strings will not be quoted, as with `jq --raw-output`.
     - `formattime(unix_timestamp, format_str, timezone)`: Gets the time in a given format from UNIX timestamp.
       Check [chrono's documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) for more
       information about format string and [chrono-tz's documentation](https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)


### PR DESCRIPTION
## Description
This is a fairly simple change which adds a `jq_raw` function - `jq_raw()` shares `jq()`'s implementation, with the difference being that _top level_ strings are not quoted (nested strings _are_ quoted). This behavior is consistent with `jq`'s documented and observed behavior for --raw-output.

This PR resolves #745.

For instance, we see the following behavior with orthodox `jq`

```
$ echo '{"a": ["b"]}' | jq -r '.a'
[
  "b"
]
$ echo '{"a": ["b"]}' | jq -r '.a[]'
b
```

Similarly, the expressions
```
{jq_raw("{\"a\": [\"b\"]}", ".a")}
{jq_raw("{\"a\": [\"b\"]}", ".a[]")}
```
Produce the following output,

![image](https://github.com/elkowar/eww/assets/6024227/e373b37e-ec47-470c-8856-275b28155da7)

## Usage

Use `jq_raw` as you would `jq` when unquoted strings are needed (typically for display)

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [X] The documentation in the `docs/src` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
