### PR TITLE
Add :icon and :icon-size properties to the image widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Remove `eww windows` command, replace with `eww active-windows` and `eww list-windows`
 
 ### Features
+- Add `:icon` and `:icon-size` to the image widget (By: Adrian Perez de Castro)
 - Add `get_env` function (By: RegenJacob)
 - Add `:namespace` window option
 - Default to building with x11 and wayland support simultaneously

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -513,6 +513,18 @@ fn build_gtk_button(bargs: &mut BuilderArgs) -> Result<gtk::Button> {
     Ok(gtk_widget)
 }
 
+/// @var icon-size - "menu", "small-toolbar", "toolbar", "large-toolbar", "button", "dnd", "dialog"
+fn parse_icon_size(o: &str) -> Result<gtk::IconSize> {
+    enum_parse! { "icon-size", o,
+        "menu" => gtk::IconSize::Menu,
+        "small-toolbar" | "toolbar" => gtk::IconSize::SmallToolbar,
+        "large-toolbar" => gtk::IconSize::LargeToolbar,
+        "button" => gtk::IconSize::Button,
+        "dnd" => gtk::IconSize::Dnd,
+        "dialog" => gtk::IconSize::Dialog,
+    }
+}
+
 const WIDGET_NAME_IMAGE: &str = "image";
 /// @widget image
 /// @desc A widget displaying an image
@@ -530,7 +542,12 @@ fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
                 let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file_at_size(std::path::PathBuf::from(path), image_width, image_height)?;
                 gtk_widget.set_from_pixbuf(Some(&pixbuf));
             }
-        }
+        },
+        // @prop icon - name of a theme icon
+        // @prop icon-size - size of the theme icon
+        prop(icon: as_string, icon_size: as_string = "button") {
+            gtk_widget.set_from_icon_name(Some(&icon), parse_icon_size(&icon_size)?);
+        },
     });
     Ok(gtk_widget)
 }


### PR DESCRIPTION
## Description

Add a new `:icon` property which allows using icons from the currently selected theme. For completeness, add `:icon-size` as well. As a nice extra, GTK automatically makes such images follow the selected icon theme.

## Usage

The following shows how to use an image from the icon theme using the new properties:

```janet
(defwindow icon-example
  :monitor 0
  :geometry (geometry :width "64px" :height "64px")
  (image :icon "dialog-information"
         :icon-size "dialog"))
```

### Showcase

Bar with launchers, each one is a `(button :onclick "..." :tooltip "..." (image :icon "..."))` element:

![Launcher bar screenshot](https://github.com/elkowar/eww/assets/723451/284bc35e-59e9-4fe1-b9f9-fafedcf26258)

Short screen capture showing how the icons follow the current GTK icon theme:

https://github.com/elkowar/eww/assets/723451/d89b1627-af3c-461a-aff9-1092c4f2d1de


## Additional Notes

First contribution, after discovering Eww yesterday. I hope the changes are done well.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
