### PR TITLE
Allow named monitors on wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `substring` function to simplexpr
 - Add `--duration` flag to `eww open`
 - Add support for referring to monitor with `<primary>`
+- Add support for multiple matchers in `monitor` field
 
 ## [0.4.0] (04.09.2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add trigonometric functions (`sin`, `cos`, `tan`, `cot`) and degree/radian conversions (`degtorad`, `radtodeg`) (By: end-4)
 - Add `substring` function to simplexpr
 - Add `--duration` flag to `eww open`
+- Add support for referring to monitor with `<primary>`
 
 ## [0.4.0] (04.09.2022)
 

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -582,6 +582,14 @@ fn get_monitor_geometry(identifier: Option<MonitorIdentifier>) -> Result<gdk::Re
 /// Outside of x11, only [MonitorIdentifier::Numeric] is supported
 pub fn get_monitor_from_display(display: &gdk::Display, identifier: &MonitorIdentifier) -> Option<gdk::Monitor> {
     match identifier {
+        MonitorIdentifier::List(list) => {
+            for ident in list {
+                if let Some(monitor) = get_monitor_from_display(display, ident) {
+                    return Some(monitor);
+                }
+            }
+            None
+        }
         MonitorIdentifier::Primary => display.primary_monitor(),
         MonitorIdentifier::Numeric(num) => display.monitor(*num),
         MonitorIdentifier::Name(name) => {

--- a/crates/yuck/src/config/monitor.rs
+++ b/crates/yuck/src/config/monitor.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub enum MonitorIdentifier {
     Numeric(i32),
     Name(String),
+    Primary,
 }
 
 impl MonitorIdentifier {
@@ -20,6 +21,7 @@ impl fmt::Display for MonitorIdentifier {
         match self {
             Self::Numeric(n) => write!(f, "{}", n),
             Self::Name(n) => write!(f, "{}", n),
+            Self::Primary => write!(f, "<primary>"),
         }
     }
 }
@@ -30,7 +32,13 @@ impl str::FromStr for MonitorIdentifier {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.parse::<i32>() {
             Ok(n) => Ok(Self::Numeric(n)),
-            Err(_) => Ok(Self::Name(s.to_owned())),
+            Err(_) => {
+                if &s.to_lowercase() == "<primary>" {
+                    Ok(Self::Primary)
+                } else {
+                    Ok(Self::Name(s.to_owned()))
+                }
+            }
         }
     }
 }

--- a/crates/yuck/src/config/monitor.rs
+++ b/crates/yuck/src/config/monitor.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// The type of the identifier used to select a monitor
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MonitorIdentifier {
+    List(Vec<MonitorIdentifier>),
     Numeric(i32),
     Name(String),
     Primary,
@@ -19,6 +20,7 @@ impl MonitorIdentifier {
 impl fmt::Display for MonitorIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::List(l) => write!(f, "[{}]", l.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(" ")),
             Self::Numeric(n) => write!(f, "{}", n),
             Self::Name(n) => write!(f, "{}", n),
             Self::Primary => write!(f, "<primary>"),

--- a/crates/yuck/src/parser/ast.rs
+++ b/crates/yuck/src/parser/ast.rs
@@ -71,6 +71,8 @@ impl Ast {
 
     as_func!(AstType::List, as_list as_list_ref<Vec<Ast>> = Ast::List(_, x) => x);
 
+    as_func!(AstType::Array, as_array as_array_ref<Vec<Ast>> = Ast::Array(_, x) => x);
+
     pub fn expr_type(&self) -> AstType {
         match self {
             Ast::List(..) => AstType::List,

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -50,8 +50,18 @@ You can now open your first window by running `eww open example`! Glorious!
 
 |   Property | Description                                                  |
 | ---------: | ------------------------------------------------------------ |
-|  `monitor` | Which monitor this window should be displayed on. Can be either a number (X11 and Wayland) or an output name (X11 only). |
+|  `monitor` | Which monitor this window should be displayed on. See below for details.|
 | `geometry` | Geometry of the window.  |
+
+
+**`monitor`-property**
+
+This field can be:
+
+- the string `<primary>`, in which case eww tries to identify the primary display (which may fail, especially on wayland)
+- an integer, declaring the monitor index
+- the name of the monitor
+- an array of monitor matchers, such as: `["<primary>" "HDMI-A-1" "PHL 345B1C" 0]`. Eww will try to find a match in order, allowing you to specify fallbacks.
 
 
 **`geometry`-properties**


### PR DESCRIPTION
Please follow this template, if applicable.

## Description

Allows named monitors on wayland, adds <primary> monitor selection and the option to add multiple matchers for monitor names.

## Usage

```
(defwindow foo :monitor ["<primary>" 1 "DisplayPort-0"]
 ; ...
)
```



## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
