### PR TITLE
allow use of global_variables in defwindow

### DIFF
--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -380,8 +380,8 @@ impl<B: DisplayBackend> App<B> {
 
             let window_def = self.eww_config.get_window(window_name)?.clone();
             assert_eq!(window_def.name, window_name, "window definition name did not equal the called window");
-
-            let initiator = WindowInitiator::new(&window_def, window_args)?;
+            let global_vars = self.scope_graph.borrow().global_scope().data.clone();
+            let initiator = WindowInitiator::new(&window_def, window_args, global_vars)?;
 
             let root_index = self.scope_graph.borrow().root_index;
 

--- a/crates/eww/src/window_initiator.rs
+++ b/crates/eww/src/window_initiator.rs
@@ -26,22 +26,23 @@ pub struct WindowInitiator {
 }
 
 impl WindowInitiator {
-    pub fn new(window_def: &WindowDefinition, args: &WindowArguments) -> Result<Self> {
+    pub fn new(window_def: &WindowDefinition, args: &WindowArguments, mut global_vars: HashMap<VarName, DynVal>) -> Result<Self> {
         let vars = args.get_local_window_variables(window_def)?;
+        global_vars.extend(vars.clone());
 
         let geometry = match &window_def.geometry {
             Some(geo) => Some(geo.eval(&vars)?.override_if_given(args.anchor, args.pos, args.size)),
             None => None,
         };
-        let monitor = if args.monitor.is_none() { window_def.eval_monitor(&vars)? } else { args.monitor.clone() };
+        let monitor = if args.monitor.is_none() { window_def.eval_monitor(&global_vars)? } else { args.monitor.clone() };
         Ok(WindowInitiator {
-            backend_options: window_def.backend_options.eval(&vars)?,
+            backend_options: window_def.backend_options.eval(&global_vars)?,
             geometry,
             id: args.instance_id.clone(),
             monitor,
             name: window_def.name.clone(),
-            resizable: window_def.eval_resizable(&vars)?,
-            stacking: window_def.eval_stacking(&vars)?,
+            resizable: window_def.eval_resizable(&global_vars)?,
+            stacking: window_def.eval_stacking(&global_vars)?,
             local_variables: vars,
         })
     }


### PR DESCRIPTION
## Description

Allow the usage of global variables from defwindow like in :monitor

## Usage

Main use case is workaround current Wayland/Gdk limitation of picking up monitor the point is currently under (I tried to make it worked but failed). With this PR user can define in eww stuff like that:

```
(defwindow control_center
  :monitor {active_monitor}
  :stacking "overlay"
  :geometry (geometry
    :anchor "bottom right"
    :width "2px"
    :height "2px"
  )
  :namespace "eww"
  (control_center)
)

(deflisten active_monitor :initial 0 "scripts/get_active_monitor.sh")
```
with two scripts that are need for hyprland to make it work. 
```
#!/usr/bin/env bash
script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

hyprctl monitors -j | jq '.[] | select(.focused) | .id'

socat -u UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock - |
  stdbuf -o0 awk -F '>>|,'-e '/^focusedmon>>/ {print $2}' |
  stdbuf -o0 awk -F',' '{print $1}' |
  stdbuf -o0 $script_dir/filter_active_monitor.sh

```
```
#!/usr/bin/env bash

monitors=($(echo $(hyprctl monitors -j | jq '.[] | "\(.id):\(.name)"') | tr ' ' '\n'))

while read -r line; do
  for monitor in "${monitors[@]}"; do
      monitor=${monitor%\"}
      monitor=${monitor#\"}
      monitor_number="${monitor%%:*}"
      monitor_name="${monitor#*:}"

      if [ "$line" = "$monitor_name" ]; then
        echo "$monitor_number"
        break
      fi
    done
done
```
Could be done in one script but I didn't find a way to do it yet.
With this way user can have a window that opens on the current active monitor instead of a fixed one.
Even that it is a workaround adding something like "<active>" monitor definition it still can be useful for other stuff in defwindow like for example making the geometry dynamic (for example to always open a menu under the mouse). 

## Additional Notes

Currently with this PR eww doesn't pick up that the variables is used in defwindow. Hope someone could give me some guidance where to put that. I already found out how the variables scopes are picked up in eww, but no idea yet how to bring that into `WindowInitiator::new` to register variables used by a window open. 
Maybe this should be done not at open but at eww startup so the variable used in defwindow is always updated?

## Checklist

- [ ] Add variables used in defwindow to be pick up in scopes to run the right scripts always when a defwindows uses a deflisten/defpool variable
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
