### PR TITLE
Potential fix for `for`-loop memory leak

### DIFF
--- a/crates/eww/src/widgets/build_widget.rs
+++ b/crates/eww/src/widgets/build_widget.rs
@@ -313,11 +313,7 @@ fn build_children_special_widget(
                             nth_child_widget_use.clone(),
                             None,
                         )?;
-                        for old_child in child_container.children() {
-                            unsafe {
-                                old_child.destroy();
-                            }
-                        }
+                        child_container.children().iter().for_each(|f| child_container.remove(f));
                         child_container.set_child(Some(&new_child_widget));
                         new_child_widget.show();
                         Ok(())

--- a/crates/eww/src/widgets/build_widget.rs
+++ b/crates/eww/src/widgets/build_widget.rs
@@ -246,7 +246,7 @@ fn build_loop_special_widget(
                         .collect_vec();
                     let mut created_children = created_children.borrow_mut();
                     for old_child in created_children.drain(..) {
-                        unsafe { old_child.destroy() };
+                        gtk_container.remove(&old_child);
                     }
                     let mut created_child_scopes = created_child_scopes.borrow_mut();
                     for child_scope in created_child_scopes.drain(..) {


### PR DESCRIPTION
## Description

Some users, including me have been noticing a memory leak with included slowdowns when using the `for` implementation, in my case for the Hyprland workspace widget [provided here](https://wiki.hyprland.org/Useful-Utilities/Status-Bars/#eww). There is also a related issue #794.

Looking at the related PR for this feature #350, I noticed the `unsafe` calls for destroying the old widget, which seemed a bit odd. After trying to get a feel for the code and some negotiating with ChatGPT, I tried using the `remove()` method that the GTK `Container` class provides, which gets rid of the `unsafe` code block.

After some usage of a custom build with this one-liner fix, the widget still works correctly, and I noticed that the memory leakage was gone.

EDIT:

Went ahead and removed an additional `unsafe` call in the same file, which seems more appropriate now for removing each child widget using `iter().for_each()`. Builds and works fine on my side.

I could be tapping in the dark here and missing something, if that is the case, please let me know!

### Showcase

*(Notice the `MemB`)*

This is the result after switching workspaces a couple of times after ten minutes of usage with the latest master branch.

![ouwgSKN](https://github.com/elkowar/eww/assets/43351274/9d7f0ef2-5505-48f1-a0b8-0399012e0025)

This is with my added fix after 10 minutes and fast workspace switching.

![Rzkpmmi](https://github.com/elkowar/eww/assets/43351274/91253b3d-8633-4531-bac8-f846b696f288)

## Additional Notes

It would be cool if someone could double-check if this is really the fix. Other than that, this is just a single-line change.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
