### PR TITLE
Add custom tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `stack` widget (By: vladaviedov)
 - Add `unindent` property to the label widget, allowing to disable removal of leading spaces (By: nrv)
 - Switch to stable rust toolchain (1.76)
+- Add `tooltip` widget, which allows setting a custom tooltip (not only text), to a widget (By: Rayzeq)
 
 ## [0.4.0] (04.09.2022)
 


### PR DESCRIPTION
## Description

This PR add a widget named `tooltiped`, which is a widget that have eww widgets inside its tooltip instead of only text.

## Usage

For example you can put an image inside a tooltip like this:
```yuck
(tooltiped
    (image :path "/home/....")
    (label :text "example")
)
```

### Showcase

This allow doing thing like this for example:
![a](https://github.com/elkowar/eww/assets/26172375/e31ac694-11c1-4e3f-8fc4-0e09b5881fa2)

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
  This folder doesn't exist, I assume you mean `docs/src`, which I don't think I need to update.
- [x] I used `cargo fmt` to automatically format all code before committing
