### PR TITLE
Completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ## Unreleased
 
+### Fixes
+- The `shell-completions` subcommand is now run before anything is set up
+
 ## [0.5.0] (17.02.2024)
 
 ### BREAKING CHANGES

--- a/crates/eww/src/client.rs
+++ b/crates/eww/src/client.rs
@@ -6,7 +6,6 @@ use crate::{
     paths::EwwPaths,
 };
 use anyhow::{Context, Result};
-use clap::CommandFactory as _;
 use std::{
     io::{Read, Write},
     os::unix::net::UnixStream,
@@ -20,9 +19,6 @@ pub fn handle_client_only_action(paths: &EwwPaths, action: ActionClientOnly) -> 
                 .stdin(Stdio::null())
                 .spawn()?
                 .wait()?;
-        }
-        ActionClientOnly::ShellCompletions { shell } => {
-            clap_complete::generate(shell, &mut opts::RawOpt::command(), "eww", &mut std::io::stdout());
         }
     }
     Ok(())

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -59,6 +59,13 @@ pub(super) struct RawOpt {
 
 #[derive(Subcommand, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Action {
+    /// Generate a shell completion script
+    ShellCompletions {
+        #[arg(short, long)]
+        #[serde(with = "serde_shell")]
+        shell: clap_complete::shells::Shell,
+    },
+
     /// Start the Eww daemon.
     #[command(name = "daemon", alias = "d")]
     Daemon,
@@ -75,13 +82,6 @@ pub enum ActionClientOnly {
     /// Print and watch the eww logs
     #[command(name = "logs")]
     Logs,
-
-    /// Generate a shell completion script
-    ShellCompletions {
-        #[arg(short, long)]
-        #[serde(with = "serde_shell")]
-        shell: clap_complete::shells::Shell,
-    },
 }
 
 #[derive(Subcommand, Debug, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
This PR makes it so that the `shell-completions` subcommand is handled before anything else.
This is useful in NixOS when generating shell completions in the build of a derivation. Without this PR, it fails with this error:
```
 2024-02-19T19:37:36.923Z ERROR eww::error_handling_ctx > Failed to initialize eww paths

Caused by:
    Configuration directory /homeless-shelter/.config/eww does not exist
```

## Checklist

- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] I used `cargo fmt` to automatically format all code before committing
