### PR TITLE
Handle mouse clicks for systray items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,6 +1954,7 @@ name = "notifier_host"
 version = "0.1.0"
 dependencies = [
  "dbusmenu-gtk3",
+ "gdk",
  "gtk",
  "log",
  "thiserror",

--- a/crates/eww/src/widgets/mod.rs
+++ b/crates/eww/src/widgets/mod.rs
@@ -7,6 +7,7 @@ pub mod graph;
 mod systray;
 pub mod transform;
 pub mod widget_definitions;
+pub mod window;
 
 /// Run a command that was provided as an attribute.
 /// This command may use placeholders which will be replaced by the values of the arguments given.

--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -158,7 +158,7 @@ impl Item {
 
         // updates
         let mut status_updates = item.sni.receive_new_status().await?;
-        let mut title_updates = item.sni.receive_new_status().await?;
+        let mut title_updates = item.sni.receive_new_title().await?;
         let mut icon_updates = item.sni.receive_new_icon().await?;
 
         loop {

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1142,6 +1142,7 @@ fn build_systray(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
     let gtk_widget = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     let props = Rc::new(systray::Props::new());
     let props_clone = props.clone(); // copies for def_widget
+    let props_clone2 = props.clone(); // copies for def_widget
 
     def_widget!(bargs, _g, gtk_widget, {
         // @prop spacing - spacing between elements
@@ -1157,6 +1158,10 @@ fn build_systray(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
             } else {
                 props.icon_size(icon_size);
             }
+        },
+        // @prop prepend-new - prepend new icons.
+        prop(prepend_new: as_bool = true) {
+            *props_clone2.prepend_new.borrow_mut() = prepend_new;
         },
     });
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1138,13 +1138,18 @@ fn build_graph(bargs: &mut BuilderArgs) -> Result<super::graph::Graph> {
 const WIDGET_NAME_SYSTRAY: &str = "systray";
 /// @widget systray
 /// @desc Tray for system notifier icons
-fn build_systray(bargs: &mut BuilderArgs) -> Result<gtk::MenuBar> {
-    let gtk_widget = gtk::MenuBar::new();
+fn build_systray(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
+    let gtk_widget = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     let props = Rc::new(systray::Props::new());
-    let props_clone = props.clone();
+    let props_clone = props.clone(); // copies for def_widget
 
-    // copies for def_widget
     def_widget!(bargs, _g, gtk_widget, {
+        // @prop spacing - spacing between elements
+        prop(spacing: as_i32 = 0) { gtk_widget.set_spacing(spacing) },
+        // @prop orientation - orientation of the box. possible values: $orientation
+        prop(orientation: as_string) { gtk_widget.set_orientation(parse_orientation(&orientation)?) },
+        // @prop space-evenly - space the widgets evenly.
+        prop(space_evenly: as_bool = true) { gtk_widget.set_homogeneous(space_evenly) },
         // @prop icon-size - size of icons in the tray
         prop(icon_size: as_i32) {
             if icon_size <= 0 {
@@ -1153,8 +1158,6 @@ fn build_systray(bargs: &mut BuilderArgs) -> Result<gtk::MenuBar> {
                 props.icon_size(icon_size);
             }
         },
-        // @prop pack-direction - how to arrange tray items
-        prop(pack_direction: as_string) { gtk_widget.set_pack_direction(parse_packdirection(&pack_direction)?); },
     });
 
     systray::spawn_systray(&gtk_widget, &props_clone);
@@ -1236,16 +1239,6 @@ fn parse_gravity(g: &str) -> Result<gtk::pango::Gravity> {
         "west" => gtk::pango::Gravity::West,
         "north" => gtk::pango::Gravity::North,
         "auto" => gtk::pango::Gravity::Auto,
-    }
-}
-
-/// @var pack-direction - "right", "ltr", "left", "rtl", "down", "ttb", "up", "btt"
-fn parse_packdirection(o: &str) -> Result<gtk::PackDirection> {
-    enum_parse! { "packdirection", o,
-        "right" | "ltr" => gtk::PackDirection::Ltr,
-        "left" | "rtl" => gtk::PackDirection::Rtl,
-        "down" | "ttb" => gtk::PackDirection::Ttb,
-        "up" | "btt" => gtk::PackDirection::Btt,
     }
 }
 

--- a/crates/eww/src/widgets/window.rs
+++ b/crates/eww/src/widgets/window.rs
@@ -1,0 +1,64 @@
+use glib::{object_subclass, wrapper};
+use glib_macros::Properties;
+use gtk::{prelude::*, subclass::prelude::*};
+use std::cell::RefCell;
+
+wrapper! {
+    pub struct Window(ObjectSubclass<WindowPriv>)
+    @extends gtk::Window, gtk::Bin, gtk::Container, gtk::Widget, @implements gtk::Buildable;
+}
+
+#[derive(Properties)]
+#[properties(wrapper_type = Window)]
+pub struct WindowPriv {
+    #[property(get, name = "x", nick = "X", blurb = "Global x coordinate", default = 0)]
+    x: RefCell<i32>,
+
+    #[property(get, name = "y", nick = "Y", blurb = "Global y coordinate", default = 0)]
+    y: RefCell<i32>,
+}
+
+// This should match the default values from the ParamSpecs
+impl Default for WindowPriv {
+    fn default() -> Self {
+        WindowPriv { x: RefCell::new(0), y: RefCell::new(0) }
+    }
+}
+
+#[object_subclass]
+impl ObjectSubclass for WindowPriv {
+    type ParentType = gtk::Window;
+    type Type = Window;
+
+    const NAME: &'static str = "WindowEww";
+}
+
+impl Default for Window {
+    fn default() -> Self {
+        glib::Object::new::<Self>()
+    }
+}
+
+impl Window {
+    pub fn new(type_: gtk::WindowType, x_: i32, y_: i32) -> Self {
+        let w: Self = glib::Object::builder().property("type", type_).build();
+        let priv_ = w.imp();
+        priv_.x.replace(x_);
+        priv_.y.replace(y_);
+        w
+    }
+}
+
+impl ObjectImpl for WindowPriv {
+    fn properties() -> &'static [glib::ParamSpec] {
+        Self::derived_properties()
+    }
+
+    fn property(&self, id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        self.derived_property(id, pspec)
+    }
+}
+impl WindowImpl for WindowPriv {}
+impl BinImpl for WindowPriv {}
+impl ContainerImpl for WindowPriv {}
+impl WidgetImpl for WindowPriv {}

--- a/crates/notifier_host/Cargo.toml
+++ b/crates/notifier_host/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/elkowar/eww"
 
 [dependencies]
 gtk = "0.17.1"
+gdk = "0.17.1"
 zbus = { version = "3.7.0", default-features = false, features = ["tokio"] }
 dbusmenu-gtk3 = "0.1.0"
 


### PR DESCRIPTION
## Description

Relocated from https://github.com/ralismark/eww/pull/6

This implements mouse button click handling for systray icons. Meanwhile, the building widgets MenuBar/MenuItem are replaced with Box/EventBox to fulfill the event hooking.

## Additional Notes

`gtk::Window` is subclassed just to store its global coordinates, which appears to be a bit overkill, but I didn't come up with better ideas. This could be further polished.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [X] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
