### PR TITLE
fix #42: use gtk's text truncation system when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - The `shell-completions` subcommand is now run before anything is set up
 - Fix nix flake
 - Fix `jq` (By: w-lfchen)
+- Labels now use gtk's truncation system (By: Rayzeq).
 
 ### Features
 - Add `systray` widget (By: ralismark)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "notify",
  "once_cell",
  "ordered-stream",
+ "pango",
  "pretty_env_logger",
  "regex",
  "serde",

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -23,6 +23,7 @@ notifier_host.workspace = true
 
 gtk = "0.17.1"
 gdk = "0.17.1"
+pango = "0.17.1"
 glib = "0.17.8"
 glib-macros = "0.17.8"
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -877,7 +877,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         // @prop text - the text to display
         // @prop limit-width - maximum count of characters to display
         // @prop truncate-left - whether to truncate on the left side
-        // @prop show-truncated - show whether the text was truncated. Disabling it will completly disable truncation on pango markup.
+        // @prop show-truncated - show whether the text was truncated. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
         // @prop unindent - whether to remove leading spaces
         prop(text: as_string, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true) {
             let text = if show_truncated {
@@ -917,7 +917,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         // @prop markup - Pango markup to display
         // @prop limit-width - maximum count of characters to display
         // @prop truncate-left - whether to truncate on the left side
-        // @prop show-truncated - show whether the text was truncated. Disabling it will completly disable truncation on pango markup.
+        // @prop show-truncated - show whether the text was truncatedd. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
         prop(markup: as_string, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true) {
             if show_truncated {
                 // gtk does weird thing if we set max_width_chars to i32::MAX


### PR DESCRIPTION
## Description

This makes labels use gtk's truncation system.
One of the main advantages is that labels can be truncated as required, without having a fixed size.
It also allows pango markup to be truncated (except when `show-truncated` is `false`).

## Usage

As before

## Additional Notes

This PR contains duplicated code, but I didn't find any way to prevent it without removing `show-truncated`.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
