### PR TITLE
docs: changed kB to bytes in `EWW_RAM` description

### DIFF
--- a/crates/eww/src/config/inbuilt.rs
+++ b/crates/eww/src/config/inbuilt.rs
@@ -34,7 +34,7 @@ define_builtin_vars! {
     // @prop { <name>: temperature }
     "EWW_TEMPS" [2] => || Ok(DynVal::from(get_temperatures())),
 
-    // @desc EWW_RAM - Information on ram and swap usage in kB.
+    // @desc EWW_RAM - Information on ram and swap usage in bytes.
     // @prop { total_mem, free_mem, total_swap, free_swap, available_mem, used_mem, used_mem_perc }
     "EWW_RAM" [2] => || Ok(DynVal::from(get_ram())),
 


### PR DESCRIPTION
Fixes #1074 
Please follow this template, if applicable.

## Description
The docs mention that `EWW_RAM` values are in kB but the returned values are in bytes. This PR changes the documentation to mention bytes instead of kB.

## Additional Notes
I think changing the documentation is better than returning kB values so that no existing widgets are broken.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
