### PR TITLE
Update ahash to fix `cargo install --locked`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -1477,7 +1477,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.8",
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Right now, eww fails to install when invoked with `cargo install --git $url` because of some API changes made to dbusmenu-glib that violate semver (at least, I think? I'm still not 100% certain what exactly those errors come from; they may be from the rust-glib or rust-gtk bindings?). So `cargo install --git $url --locked` should work (since it won't update the broken crate to the broken version), but `ahash` is currently specified as 0.7.6, which is yanked from crates.io since it doesn't build in the configuration that eww is using it with.

This simply updates the yanked version of `ahash` so that eww can continue to be installed via `cargo install --git $url --locked`.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing

I don't think anything on the checklist applies to this PR.
