### PR TITLE
fix: bump cargo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eww"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eww"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["elkowar <5300871+elkowar@users.noreply.github.com>"]
 description = "Widgets for everyone!"
 license = "MIT"


### PR DESCRIPTION
## Description
Bump the cargo version of the eww crate.
This has been done in https://github.com/elkowar/eww/commit/387d344690903949121040f8a892f946e323c472 but not https://github.com/elkowar/eww/commit/d87c2fdbfdc012e76d229e4e9ea3325bc0f23e89, therefore I feel like this has been forgotten.

## Checklist

- [x] I used `cargo fmt` to automatically format all code before committing
