### PR TITLE
Fix string truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to eww will be listed here, starting at changes since versio
 ### Fixes
 - Fix and refactor nix flake (By: w-lfchen)
 
+### Features
+- Add `:truncate` property to labels, disabled by default (except in cases where truncation would be enabled in version `0.5.0` and before) (By: Rayzeq).
+
 ## [0.6.0] (21.04.2024)
 
 ### Fixes

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -918,7 +918,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
 
                 let limit_width = limit_width as usize;
                 let char_count = text.chars().count();
-                if char_count > limit_width && !show_truncated {
+                if char_count > limit_width {
                     if truncate_left {
                         text.chars().skip(char_count - limit_width).collect()
                     } else {

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -894,11 +894,12 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
 
     def_widget!(bargs, _g, gtk_widget, {
         // @prop text - the text to display
+        // @prop truncate - whether to truncate text (or pango markup). If `show-truncated` is `false`, or if `limit-width` has a value, this property has no effect and truncation is enabled.
         // @prop limit-width - maximum count of characters to display
         // @prop truncate-left - whether to truncate on the left side
         // @prop show-truncated - show whether the text was truncated. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
         // @prop unindent - whether to remove leading spaces
-        prop(text: as_string, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true) {
+        prop(text: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true) {
             let text = if show_truncated {
                 // gtk does weird thing if we set max_width_chars to i32::MAX
                 if limit_width == i32::MAX {
@@ -906,10 +907,14 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
                 } else {
                     gtk_widget.set_max_width_chars(limit_width);
                 }
-                if truncate_left {
-                    gtk_widget.set_ellipsize(pango::EllipsizeMode::Start);
+                if truncate || limit_width != i32::MAX {
+                    if truncate_left {
+                        gtk_widget.set_ellipsize(pango::EllipsizeMode::Start);
+                    } else {
+                        gtk_widget.set_ellipsize(pango::EllipsizeMode::End);
+                    }
                 } else {
-                    gtk_widget.set_ellipsize(pango::EllipsizeMode::End);
+                    gtk_widget.set_ellipsize(pango::EllipsizeMode::None);
                 }
 
                 text
@@ -934,11 +939,12 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
             gtk_widget.set_text(&text);
         },
         // @prop markup - Pango markup to display
+        // @prop truncate - whether to truncate text (or pango markup). If `show-truncated` is `false`, or if `limit-width` has a value, this property has no effect and truncation is enabled.
         // @prop limit-width - maximum count of characters to display
         // @prop truncate-left - whether to truncate on the left side
         // @prop show-truncated - show whether the text was truncatedd. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
-        prop(markup: as_string, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true) {
-            if show_truncated {
+        prop(markup: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true) {
+            if (truncate || limit_width != i32::MAX) && show_truncated {
                 // gtk does weird thing if we set max_width_chars to i32::MAX
                 if limit_width == i32::MAX {
                     gtk_widget.set_max_width_chars(-1);


### PR DESCRIPTION
## Description

Some users have issues because gtk truncate text when it shouldn't, so I've added a `:truncate` property on labels, disabled by default.
As specified in the property documentation, it has no effect is `show-truncated` is `false`, or if `limit-width` has a value.
This behavior allows configurations using the old system (where `limit-width` was mandatory to have truncation) to continue working without the need to add `:truncate true`.

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
