### PR TITLE
systray: add `:hover` attribute to tray items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ### Features
 - Add `:truncate` property to labels, disabled by default (except in cases where truncation would be enabled in version `0.5.0` and before) (By: Rayzeq).
+- Add support for `:hover` css selectors for tray items (By: zeapoz)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -1,5 +1,6 @@
 use crate::widgets::window::Window;
 use futures::StreamExt;
+use gdk::NotifyType;
 use gtk::{cairo::Surface, gdk::ffi::gdk_cairo_surface_create_from_pixbuf, prelude::*};
 use notifier_host;
 use std::{cell::RefCell, future::Future, rc::Rc};
@@ -130,11 +131,27 @@ impl Drop for Item {
 
 impl Item {
     fn new(id: String, item: notifier_host::Item, icon_size: tokio::sync::watch::Receiver<i32>) -> Self {
-        let widget = gtk::EventBox::new();
-        let out_widget = widget.clone(); // copy so we can return it
+        let gtk_widget = gtk::EventBox::new();
+
+        // Support :hover selector
+        gtk_widget.connect_enter_notify_event(|gtk_widget, evt| {
+            if evt.detail() != NotifyType::Inferior {
+                gtk_widget.clone().set_state_flags(gtk::StateFlags::PRELIGHT, false);
+            }
+            gtk::Inhibit(false)
+        });
+
+        gtk_widget.connect_leave_notify_event(|gtk_widget, evt| {
+            if evt.detail() != NotifyType::Inferior {
+                gtk_widget.clone().unset_state_flags(gtk::StateFlags::PRELIGHT);
+            }
+            gtk::Inhibit(false)
+        });
+
+        let out_widget = gtk_widget.clone(); // copy so we can return it
 
         let task = glib::MainContext::default().spawn_local(async move {
-            if let Err(e) = Item::maintain(widget.clone(), item, icon_size).await {
+            if let Err(e) = Item::maintain(gtk_widget.clone(), item, icon_size).await {
                 log::error!("error for systray item {}: {}", id, e);
             }
         });


### PR DESCRIPTION
## Description

Adds support for the `:hover` selector for system tray items (similarly to #323). 

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
