### PR TITLE
Remove sysinfo/linux-netdevs feature

### DIFF
--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -61,7 +61,7 @@ regex.workspace = true
 serde_json.workspace = true
 serde = {workspace = true, features = ["derive"]}
 simple-signal.workspace = true
-sysinfo = { workspace = true, features = ["linux-netdevs"] }
+sysinfo = { workspace = true }
 tokio-util.workspace = true
 tokio = { workspace = true, features = ["full"] }
 unescape.workspace = true


### PR DESCRIPTION
This PR removes the linux-netdevs feature from sysinfo dependency.

Rationale: I recently discovered the issue of non-responding eww resulting from a seemingly unrelated bad nfs mount. From what's stated in the API documentation, enabling linux-netdevs can result in hangs in [sysinfo::Disks](https://docs.rs/sysinfo/latest/sysinfo/struct.Disks.html) APIs when there are network mounts.

I found this feature was enabled in https://github.com/elkowar/eww/issues/958, in an attempt to fix [a `EWW_NET` display issue](https://github.com/elkowar/eww/issues/958). However, despite the naming suggests, `sysinfo/linux-netdevs` has nothing to do linux network interfaces. As can be seen from [this search](https://github.com/search?q=repo%3AGuillaumeGomez%2Fsysinfo%20linux-netdevs&type=code), the only place `linux-netdevs` takes effect is to determine whether or not network filesystems are included in the Disks API.

Therefore, I concluded that this feature may be added accidentally.