### PR TITLE
systray: add  property

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1200,6 +1200,7 @@ fn build_systray(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
     let props = Rc::new(systray::Props::new());
     let props_clone = props.clone(); // copies for def_widget
     let props_clone2 = props.clone(); // copies for def_widget
+    let props_clone3 = props.clone(); // copies for def_widget
 
     def_widget!(bargs, _g, gtk_widget, {
         // @prop spacing - spacing between elements
@@ -1218,7 +1219,11 @@ fn build_systray(bargs: &mut BuilderArgs) -> Result<gtk::Box> {
         },
         // @prop prepend-new - prepend new icons.
         prop(prepend_new: as_bool = true) {
-            *props_clone2.prepend_new.borrow_mut() = prepend_new;
+            *props_clone2.clone().prepend_new.borrow_mut() = prepend_new;
+        },
+        // @prop visible-empty - visibility of the widget when the systray is empty
+        prop(visible_empty: as_bool = true) {
+            *props_clone3.clone().visible_empty.borrow_mut() = visible_empty;
         },
     });
 


### PR DESCRIPTION
## Description

Added the `:visible-empty` property for the `systray` widget. By default, an empty tray is displayed.

I also noticed a problem that tray elements are not removed from `systray.items`.

## Usage

```yuck
(systray :visible-empty false)
```

### Showcase

https://github.com/elkowar/eww/assets/57404657/d4faf8e2-9bac-4432-978f-c49365a4425a

## Additional Notes

This is my first time writing in rust, so I might have made mistakes, please check carefully to see if I correct any mistakes.

I don’t understand in what format I need to describe the changes in `CHANGELOG.md`, and as far as I understand, the documentation for widgets is generated automatically.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ x] I used `cargo fmt` to automatically format all code before committing
