### PR TITLE
Fix: EWW_NET wrong values for TX/RX stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix and refactor nix flake (By: w-lfchen)
 - Fix remove items from systray (By: vnva)
 - Fix the gtk `stack` widget (By: ovalkonia)
+- Fix values in the `EWW_NET` variable (By: mario-kr)
 
 ### Features
 - Update rust toolchain to 1.80.1 (By: w-lfchen)

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -212,7 +212,6 @@ pub fn net() -> String {
     let (ref mut last_refresh, ref mut networks) = &mut *NETWORKS.lock().unwrap();
 
     networks.refresh_list();
-    networks.refresh();
     let elapsed = last_refresh.next_refresh();
 
     networks


### PR DESCRIPTION
## Description

The sysinfo crate, structure Networks, basically caches one value of total_received/total_transmitted each (as well as other metrics) and returns the difference between those two values when queried via the `received()` and `transmitted()` functions.

These values are updated by both the `refresh()` and `refresh_list()` functions; so by calling both of them right after each other like previously done here, sets both the cached total_received/... and the current total_received/... to nearly the same value.

`refresh_list()` also updates the list of interfaces on a host, with a marginally small performance impact for doing so (I measured slightly more than 100 microseconds on my machine (0.1 milliseconds), around 20-25% more than with `refresh()`), especially considering this is run only every 2 seconds.

Fixes #1070 

## Usage

N/A

### Showcase

N/A

## Additional Notes

I tested by running my panel config, which includes a network widget showing these two values. What was displayed was comparable to the network stats in bottom/btm.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
