### PR TITLE
feat: Add option for graph drawing direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `:truncate` property to labels, disabled by default (except in cases where truncation would be enabled in version `0.5.0` and before) (By: Rayzeq).
 - Add support for `:hover` css selectors for tray items (By: zeapoz)
 - Add `min` and `max` function calls to simplexpr (By: ovalkonia)
+- Add `flip-x`, `flip-y`, `vertical` options to the graph widget to determine its direction
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1246,6 +1246,12 @@ fn build_graph(bargs: &mut BuilderArgs) -> Result<super::graph::Graph> {
         // @prop line-style - changes the look of the edges in the graph. Values: "miter" (default), "round",
         // "bevel"
         prop(line_style: as_string) { w.set_property("line-style", line_style); },
+        // @prop flip-x - whether the x axis should go from high to low
+        prop(flip_x: as_bool) { w.set_property("flip-x", flip_x); },
+        // @prop flip-y - whether the y axis should go from high to low
+        prop(flip_y: as_bool) { w.set_property("flip-y", flip_y); },
+        // @prop vertical - if set to true, the x and y axes will be exchanged
+        prop(vertical: as_bool) { w.set_property("vertical", vertical); },
     });
     Ok(w)
 }


### PR DESCRIPTION
## Description

This adds 3 boolean flags to the graph widget. `flip-x, flip-y, vertical`. By default, both x and y axes are flipped (the old behaviour), and the x, y axes follow the same directions as the screen. The `flip-x` and `flip-y` flags toggle the direction of `x` and `y` axes and `vertical` swaps the two axes, so you could have a graph that goes (time-axis) from left to right, bottom to top, etc.

## Usage

```lisp
(defwindow vbar
	:exclusive true
	:monitor 0
	:windowtype "dock"
	:geometry (geometry
		:x "0%"
		:y "0%"
		:width "25px"
		:height "99%"
		:anchor "center left"
	)
	:reserve (struts :side "left" :distance "20px")
	(widget-memory))

(defwidget widget-memory []
				(graph
					:width 20
					:height 100
					:vertical true
					:flip-y false
					:value {EWW_RAM.used_mem_perc}
					:time-range "30s"
					:dynamic false
					:max 100
					:min 0))
```
shows the memory graph on the left side of the screen going from bottom to top.

### Showcase

This is taken from my own configurations
![vertical-graph](https://github.com/elkowar/eww/assets/107011294/981313e6-28bf-4552-83e6-5de07b558dec)


## Additional Notes

There are other ways to arrange the flags, but in total there are 8 possible combinations

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [X] All widgets I've added are correctly documented.
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [X] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
