### PR TITLE
Fix: the gtk `stack` widget bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ### Fixes
 - Fix and refactor nix flake (By: w-lfchen)
 - Fix remove items from systray (By: vnva)
+- Fix the gtk `stack` widget (By: ovalkonia)
 
 ### Features
 - Add `:truncate` property to labels, disabled by default (except in cases where truncation would be enabled in version `0.5.0` and before) (By: Rayzeq).

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1089,7 +1089,7 @@ const WIDGET_NAME_STACK: &str = "stack";
 fn build_gtk_stack(bargs: &mut BuilderArgs) -> Result<gtk::Stack> {
     let gtk_widget = gtk::Stack::new();
 
-    if let Ordering::Less = bargs.widget_use.children.len().cmp(&1) {
+    if bargs.widget_use.children.len() < 1 {
         return Err(DiagError(gen_diagnostic!("stack must contain at least one element", bargs.widget_use.span)).into());
     }
 


### PR DESCRIPTION
## Description

The `:selected` property had initially no effect and resulted in a warning stating that a child with the given name wasn't found. This exact issue has already been described here ->  https://github.com/elkowar/eww/issues/1116.

Take a look at the following screenshot showing minimal configuration:
![1722946531](https://github.com/user-attachments/assets/69c6c581-2191-42a1-a717-8304a2a247fc)
As you can see, there's a warning and instead of the expected "1st", it shows "0th".
Although, if you update the variable, it will work, since all the children are already there:
![1722946548](https://github.com/user-attachments/assets/fe7cbc14-3957-49e7-abfc-2abc7397569f)

The problem is here:
https://github.com/elkowar/eww/blob/e95d3af963327f85de86e110fe1514be0c6473bc/crates/eww/src/widgets/widget_definitions.rs#L980-L1011
`gtk_widget.set_visible_child_name(&selected.to_string())` gets called before any children are actually added.

Fixes https://github.com/elkowar/eww/issues/1116

## Usage

N/A

### Showcase

Here is that same minimal configuration from before, but this time using the fixed version:
![1718667805](https://github.com/elkowar/eww/assets/60359793/b2d459f4-752c-4e34-a851-33b3086040e9)
No warnings and it shows "1st", just as expected!

## Additional Notes

N/A

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing