### PR TITLE
Remove window flicker and extend duration with open command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ## Unreleased
 
 ### Fixes
+- Fix window flicker when opening an already existing window (By: benesim)
 - Fix and refactor nix flake (By: w-lfchen)
 - Fix remove items from systray (By: vnva)
 


### PR DESCRIPTION
## Description

This solves a problem that had been already solved in 0d1b5e0f9e532ade4b7c9fd77b46b6a29b1d8529 but was reintroduced in a9a35c1804d72ef92e04ee71555bd9e5a08fa17e. Basically before this, the window has been closed and reopened if it existed, which results in flickering due to the animations.

In addition to removing the window flicker the timer (if started with --duration) will also be renewed. This fixes #892.

## Additional Notes

- This is a breaking change, people who relied on using `open` to apply new settings to a window will be surprised. However, in 0d1b5e0f9e532ade4b7c9fd77b46b6a29b1d8529 it was mentioned that this could and should be solved by `reload`.
- With this implementation the window close timer won't be aborted if no `--duration` has been supplied, e.g.: I open a window with `--duration 4s` after 3s i open the window again but without `--duration` -> The window will still close after 1s. This might be counter-intuitive and could be fixed quite easily, I just wasn't sure what behavior to implement.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
