### PR TITLE
Add `min` and `max` simplexpr functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ### Features
 - Add `:truncate` property to labels, disabled by default (except in cases where truncation would be enabled in version `0.5.0` and before) (By: Rayzeq).
 - Add support for `:hover` css selectors for tray items (By: zeapoz)
+- Add `min` and `max` function calls to simplexpr (By: ovalkonia)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -328,6 +328,22 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
             }
             _ => Err(EvalError::WrongArgCount(name.to_string())),
         },
+        "min" => match args.as_slice() {
+            [a, b] => {
+                let a = a.as_f64()?;
+                let b = b.as_f64()?;
+                Ok(DynVal::from(f64::min(a, b)))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
+        "max" => match args.as_slice() {
+            [a, b] => {
+                let a = a.as_f64()?;
+                let b = b.as_f64()?;
+                Ok(DynVal::from(f64::max(a, b)))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
         "sin" => match args.as_slice() {
             [num] => {
                 let num = num.as_f64()?;


### PR DESCRIPTION
## Description

Pretty self-explanatory, adds `min` and `max` simplexpr functions. It might be useful sometimes, so why not!

Resolves https://github.com/elkowar/eww/issues/1122

## Usage

The usage is the same as with other simplexpr function calls. The syntax would be `min(a, b)` and `max(a, b)`, where `a` and `b` must both be convertible into `f64`. Here is a configuration used in the showcase below:
```
(defwidget ftest []
    (box
        :halign "center"
        :spacing "50"
        :space-evenly "false"
        "min(-9.591, 15.3) = ${min(-9.591, 15.3)}"
        "max(5, 4.7) = ${max(5, 4.7)}"))

(defwindow example
    :monitor "0"
    :geometry (geometry
        :x "0"
        :y "0"
        :width "100%"
        :height "35px"
        :anchor "top center")
    :exclusive "true"
    (ftest))
``` 

### Showcase

![1719010939](https://github.com/elkowar/eww/assets/60359793/1729ce93-ac2f-4787-a913-53fa1c6831cc)

## Additional Notes

N/A

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
