### PR TITLE
Use gdk_screen_get_monitor_plug_name to provide more consistent monitor names on wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix the gtk `stack` widget (By: ovalkonia)
 - Fix values in the `EWW_NET` variable (By: mario-kr)
 - Fix the gtk `expander` widget (By: ovalkonia)
+- Fix wayland monitor names support (By: dragonnn)
 
 ### Features
 - Update rust toolchain to 1.80.1 (By: w-lfchen)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "eww_shared_util",
  "extend",
  "futures",
+ "gdk-sys",
  "gdkx11",
  "grass",
  "gtk",

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -23,9 +23,12 @@ notifier_host.workspace = true
 gtk-layer-shell = { version = "0.8.1", optional = true }
 gdkx11 = { version = "0.18", optional = true }
 x11rb = { version = "0.13.1", features = ["randr"], optional = true }
+gdk-sys = "0.18.0"
 
 ordered-stream = "0.2.0"
 
+
+grass.workspace = true
 anyhow.workspace = true
 bincode.workspace = true
 chrono.workspace = true
@@ -35,7 +38,6 @@ codespan-reporting.workspace = true
 derive_more.workspace = true
 extend.workspace = true
 futures.workspace = true
-grass.workspace = true
 gtk.workspace = true
 itertools.workspace = true
 libc.workspace = true

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -642,7 +642,15 @@ pub fn get_monitor_from_display(display: &gdk::Display, identifier: &MonitorIden
         MonitorIdentifier::Name(name) => {
             for m in 0..display.n_monitors() {
                 if let Some(model) = display.monitor(m).and_then(|x| x.model()) {
-                    if model == *name {
+                    let plug_name;
+                    unsafe {
+                        use glib::translate::ToGlibPtr;
+                        let plug_name_pointer =
+                            gdk_sys::gdk_screen_get_monitor_plug_name(display.default_screen().to_glib_none().0, m);
+                        use std::ffi::CStr;
+                        plug_name = CStr::from_ptr(plug_name_pointer).to_str().unwrap();
+                    }
+                    if model == *name || name == plug_name {
                         return display.monitor(m);
                     }
                 }

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -625,6 +625,18 @@ fn get_gdk_monitor(identifier: Option<MonitorIdentifier>) -> Result<Monitor> {
     Ok(monitor)
 }
 
+/// Get the name of monitor plug for given monitor number
+/// workaround gdk not providing this information on wayland in regular calls
+/// gdk_screen_get_monitor_plug_name is deprecated but works fine for that case
+fn get_monitor_plug_name(display: &gdk::Display, monitor_num: i32) -> Option<&str> {
+    unsafe {
+        use glib::translate::ToGlibPtr;
+        let plug_name_pointer = gdk_sys::gdk_screen_get_monitor_plug_name(display.default_screen().to_glib_none().0, monitor_num);
+        use std::ffi::CStr;
+        CStr::from_ptr(plug_name_pointer).to_str().ok()
+    }
+}
+
 /// Returns the [Monitor][gdk::Monitor] structure corresponding to the identifer.
 /// Outside of x11, only [MonitorIdentifier::Numeric] is supported
 pub fn get_monitor_from_display(display: &gdk::Display, identifier: &MonitorIdentifier) -> Option<gdk::Monitor> {
@@ -642,15 +654,7 @@ pub fn get_monitor_from_display(display: &gdk::Display, identifier: &MonitorIden
         MonitorIdentifier::Name(name) => {
             for m in 0..display.n_monitors() {
                 if let Some(model) = display.monitor(m).and_then(|x| x.model()) {
-                    let plug_name;
-                    unsafe {
-                        use glib::translate::ToGlibPtr;
-                        let plug_name_pointer =
-                            gdk_sys::gdk_screen_get_monitor_plug_name(display.default_screen().to_glib_none().0, m);
-                        use std::ffi::CStr;
-                        plug_name = CStr::from_ptr(plug_name_pointer).to_str().unwrap();
-                    }
-                    if model == *name || name == plug_name {
+                    if model == *name || Some(name.as_str()) == get_monitor_plug_name(display, m) {
                         return display.monitor(m);
                     }
                 }


### PR DESCRIPTION
## Description

This fixes issue https://github.com/elkowar/eww/issues/1086 and https://github.com/elkowar/eww/issues/875 (at least partly).
It is based on the linked ags issue in 1086. Yes it is a bad workaround with does require unsafe, pulling in gdk-sys and using a deprecated function from it but really without it eww is basically not usable on wayland with any kind of dynamic monitor setup (common when using laptops).

## Usage

Allows using monitor plug names under wayland like that:
```
(defwindow bar-DP-2
  :monitor "DP-2"
  :geometry (geometry :width "100%"
    :anchor "bottom center"
  )
  :exclusive true
  :namespace "eww"
  (bar)
)
```

## Additional Notes

Even that it uses unsafe, deprecated functions and gdk-sys I really think this is worth adding since as far I have researched this topic they is no other way of improving wayland monitor support other then rewriting to gtk4 with I suspect doesn't happen soon. 
Tested it on niri windows manager and works fine.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
