### PR TITLE
Fix: the gtk `expander` widget bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix nix flake
 - Fix `jq` (By: w-lfchen)
 - Labels now use gtk's truncation system (By: Rayzeq).
+- Fix the gtk `expander` widget (By: ovalkonia)
 
 ### Features
 - Add `systray` widget (By: ralismark)


### PR DESCRIPTION
## Description

As it was mentioned in this issue -> https://github.com/elkowar/eww/issues/1085, if the `name` property was set for the `expander` widget, then child elements didn't show up. Essentially it was a choice between a labeled but child-free `expander` or labeless but with children `expander`.

This behavior came from the `build_builtin_gtk_widget()` function. To be more precise, this function adds child elements only if there aren't any children that have been already added with the `widget_use_to_gtk_widget()` function. The problem with that in this case is that `expander`'s label is actually considered to be a child element itself:
![1720052331](https://github.com/elkowar/eww/assets/60359793/06b4b245-a5ff-43a3-b23b-28a12a6ab233)

So now the `build_gtk_expander()` function handles the child element explicitly (see diff).

Fixes https://github.com/elkowar/eww/issues/1085

## Usage

N/A

### Showcase

Here's the minimal configuration used below:
```
(defwindow example
    :monitor "0"
    :geometry (geometry
        :x "0"
        :y "0"
        :width "100%"
        :height "35px"
        :anchor "top center"
    )
    :exclusive "true"
    (expander
        :name "foo"
        :halign "start"
        (label :text "expanded child")
    )
)
```

The result:
![1720105295](https://github.com/elkowar/eww/assets/60359793/23aa2df8-1d33-46f6-b847-6776ad4ea1ed)
Works as expected

## Additional Notes

Now the `expander` widget is also required to have exactly one child. If no children were provided, there would be an error. I just thought it would be nice, but it can be removed without any problems if necessary.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
