### PR TITLE
Update GTK and related dependencies to 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,7 +1000,6 @@ dependencies = [
  "extend",
  "futures",
  "gdkx11",
- "glib-macros",
  "grass",
  "gtk",
  "gtk-layer-shell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -151,7 +151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -161,18 +161,37 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
- "async-lock",
+ "async-lock 2.8.0",
  "autocfg",
  "cfg-if",
  "concurrent-queue",
- "futures-lite",
+ "futures-lite 1.13.0",
  "log",
  "parking",
- "polling",
- "rustix 0.37.23",
+ "polling 2.8.0",
+ "rustix 0.37.27",
  "slab",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
+dependencies = [
+ "async-lock 3.4.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.0.0",
+ "parking",
+ "polling 3.7.2",
+ "rustix 0.38.34",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -181,77 +200,104 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.3.1",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-process"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
 dependencies = [
- "async-io",
- "async-lock",
- "autocfg",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
  "blocking",
  "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 0.37.23",
- "signal-hook",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-recursion"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794f185324c2f00e771cd9f1ae8b5ac68be2ca7abb129a87afd6e86d228bc54d"
+dependencies = [
+ "async-io 2.3.3",
+ "async-lock 3.4.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.34",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.4.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "atk"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba16453d10c712284061a05f6510f75abeb92b56ba88dfeb48c74775020cc22"
+checksum = "b4af014b17dd80e8af9fa689b2d4a211ddba6eb583c1622f35d0cb543f6b17e4"
 dependencies = [
  "atk-sys",
- "bitflags 1.3.2",
  "glib",
  "libc",
 ]
 
 [[package]]
 name = "atk-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf0a7ca572fbd5762fd8f8cd65a581e06767bc1234913fe1f43e370cff6e90"
+checksum = "251e0b7d90e33e0ba930891a505a9a35ece37b2dd37a14f3ffc306c13b980009"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
@@ -339,11 +385,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
 dependencies = [
  "async-channel",
- "async-lock",
+ "async-lock 2.8.0",
  "async-task",
  "atomic-waker",
  "fastrand 1.9.0",
- "futures-lite",
+ "futures-lite 1.13.0",
  "log",
 ]
 
@@ -355,9 +401,9 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -400,11 +446,11 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cairo-rs"
-version = "0.17.10"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3603c4028a5e368d09b51c8b624b9a46edcd7c3778284077a6125af73c9f0a"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -414,13 +460,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.17.10"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691d0c66b1fb4881be80a760cb8fe76ea97218312f9dfe2c9cc0f496ca279cb1"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
@@ -434,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.4"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40ccee03b5175c18cde8f37e7d2a33bcef6f8ec8f7cc0d81090d1bb380949c9"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -531,10 +577,10 @@ version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -567,9 +613,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -721,7 +767,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
@@ -751,7 +797,7 @@ dependencies = [
  "gobject-sys",
  "gtk-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
@@ -853,9 +899,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.7"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2"
+checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -863,13 +909,13 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.7"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
+checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -893,23 +939,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -917,6 +952,38 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener 5.3.1",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "eww"
@@ -985,7 +1052,7 @@ checksum = "311a6d2f1f9d60bff73d2c78a0af97ed27f79672f15c238192a5bbb64db56d00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1063,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1073,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
@@ -1090,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -1110,33 +1177,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.28"
+name = "futures-lite"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "9c1155db57329dca6d018b61e76b1488ce9a2e5e44028cac420a5898f4fcef63"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1152,11 +1229,10 @@ dependencies = [
 
 [[package]]
 name = "gdk"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1df5ea52cccd7e3a0897338b5564968274b52f5fd12601e0afa44f454c74d3"
+checksum = "f5ba081bdef3b75ebcdbfc953699ed2d7417d6bd853347a42a37d76406a33646"
 dependencies = [
- "bitflags 1.3.2",
  "cairo-rs",
  "gdk-pixbuf",
  "gdk-sys",
@@ -1168,11 +1244,10 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.17.10"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695d6bc846438c5708b07007537b9274d883373dd30858ca881d7d71b5540717"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
 dependencies = [
- "bitflags 1.3.2",
  "gdk-pixbuf-sys",
  "gio",
  "glib",
@@ -1182,22 +1257,22 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9285ec3c113c66d7d0ab5676599176f1f42f4944ca1b581852215bf5694870cb"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
 dependencies = [
  "gio-sys",
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
 name = "gdk-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2152de9d38bc67a17b3fe49dc0823af5bf874df59ea088c5f28f31cf103de703"
+checksum = "31ff856cb3386dae1703a920f803abafcc580e9b5f711ca62ed1620c25b51ff2"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -1207,14 +1282,14 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
 name = "gdkx11"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9efc60ffeede8e3816d1e4ca54b62107c31b6560f967cd84583c8b23acccf"
+checksum = "db2ea8a4909d530f79921290389cbd7c34cb9d623bfe970eaae65ca5f9cd9cce"
 dependencies = [
  "gdk",
  "gdkx11-sys",
@@ -1226,14 +1301,14 @@ dependencies = [
 
 [[package]]
 name = "gdkx11-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaa174c09165bb416717bf5cf3132a3dc617a069b09000ac0eae1b921a00740"
+checksum = "fee8f00f4ee46cad2939b8990f5c70c94ff882c3028f3cc5abf950fa4ab53043"
 dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
  "x11",
 ]
 
@@ -1276,11 +1351,10 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gio"
-version = "0.17.10"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6973e92937cf98689b6a054a9e56c657ed4ff76de925e36fc331a15f0c5d30a"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
 dependencies = [
- "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1296,24 +1370,24 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccf87c30a12c469b6d958950f6a9c09f2be20b7773f7e70d20b867fdf2628c3"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
  "winapi",
 ]
 
 [[package]]
 name = "glib"
-version = "0.17.10"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fad45ba8d4d2cea612b432717e834f48031cd8853c8aaf43b2c79fec8d144b"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1332,38 +1406,37 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.17.10"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca5c79337338391f1ab8058d6698125034ce8ef31b72a442437fa6c8580de26"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
- "anyhow",
- "heck",
- "proc-macro-crate",
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80aa6ea7bba0baac79222204aa786a6293078c210abe69ef1336911d4bdc4f0"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34c3317740a6358ec04572c1bcfd3ac0b5b6529275fae255b237b314bb8062"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
@@ -1390,12 +1463,11 @@ dependencies = [
 
 [[package]]
 name = "gtk"
-version = "0.17.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c4222ab92b08d4d0bab90ddb6185b4e575ceeea8b8cdf00b938d7b6661d966"
+checksum = "93c4f5e0e20b60e10631a5f06da7fe3dda744b05ad0ea71fee2f47adf865890c"
 dependencies = [
  "atk",
- "bitflags 1.3.2",
  "cairo-rs",
  "field-offset",
  "futures-channel",
@@ -1406,16 +1478,15 @@ dependencies = [
  "gtk-sys",
  "gtk3-macros",
  "libc",
- "once_cell",
  "pango",
  "pkg-config",
 ]
 
 [[package]]
 name = "gtk-layer-shell"
-version = "0.6.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992f5fedb31835424a5280acd162bf348995f617d26969fde8d3dfd389b3ff5f"
+checksum = "adb41643070b55cdda5a4a10a338520cff4345395e342b754c02f341e4107383"
 dependencies = [
  "bitflags 2.4.0",
  "gdk",
@@ -1428,22 +1499,22 @@ dependencies = [
 
 [[package]]
 name = "gtk-layer-shell-sys"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5754bcfaadfc3529116af6ae93559b267d88647f965382153a4b8ea9372be75a"
+checksum = "b9aa75cbb5bf5195d8be239b189f2a36cbea223777188c50f0bce124e291fe34"
 dependencies = [
  "gdk-sys",
  "glib-sys",
  "gtk-sys",
  "libc",
- "system-deps",
+ "system-deps 7.0.1",
 ]
 
 [[package]]
 name = "gtk-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8eb6a4b93e5a7e6980f7348d08c1cd93d31fae07cf97f20678c5ec41de3d7e"
+checksum = "771437bf1de2c1c0b496c11505bdf748e26066bbe942dfc8f614c9460f6d7722"
 dependencies = [
  "atk-sys",
  "cairo-sys-rs",
@@ -1454,21 +1525,20 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
 name = "gtk3-macros"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3efb84d682c9a39c10bd9f24f5a4b9c15cc8c7edc45c19cb2ca2c4fc38b2d95e"
+checksum = "c6063efb63db582968fb7df72e1ae68aa6360dcfb0a75143f34fc7d616bad75e"
 dependencies = [
- "anyhow",
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1503,10 +1573,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1623,7 +1705,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1634,8 +1716,8 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
- "rustix 0.38.8",
+ "hermit-abi 0.3.2",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -1803,9 +1885,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -1827,9 +1909,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1928,15 +2010,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
- "static_assertions",
 ]
 
 [[package]]
@@ -2012,7 +2093,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -2043,11 +2124,10 @@ dependencies = [
 
 [[package]]
 name = "pango"
-version = "0.17.10"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35be456fc620e61f62dff7ff70fbd54dcbaf0a4b920c0f16de1107c47d921d48"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
 dependencies = [
- "bitflags 1.3.2",
  "gio",
  "glib",
  "libc",
@@ -2057,14 +2137,14 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.17.10"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da69f9f3850b0d8990d462f8c709561975e95f689c1cdf0fecdebde78b35195"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.1.1",
 ]
 
 [[package]]
@@ -2205,9 +2285,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2235,6 +2315,21 @@ dependencies = [
  "log",
  "pin-project-lite",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix 0.38.34",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2282,7 +2377,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.14",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -2317,18 +2421,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2429,7 +2533,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2484,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2498,15 +2602,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.5",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2544,22 +2648,22 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2575,13 +2679,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2595,23 +2699,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
 ]
 
 [[package]]
@@ -2695,14 +2789,14 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -2764,11 +2858,11 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2784,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2815,10 +2909,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30c2de8a4d8f4b823d634affc9cd2a74ec98c53a756f317e529a48046cbf71f3"
 dependencies = [
  "cfg-expr",
- "heck",
+ "heck 0.4.1",
  "pkg-config",
- "toml",
- "version-compare",
+ "toml 0.7.6",
+ "version-compare 0.1.1",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c81f13d9a334a6c242465140bd262fae382b752ff2011c4f7419919a9c97922"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.8.2",
+ "version-compare 0.2.0",
 ]
 
 [[package]]
@@ -2836,7 +2943,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.8",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -2877,7 +2984,7 @@ checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2933,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2953,13 +3060,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2984,14 +3091,26 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.14",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -3010,12 +3129,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.37"
+name = "toml_edit"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "cfg-if",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3023,20 +3154,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -3049,10 +3180,11 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uds_windows"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
 dependencies = [
+ "memoffset 0.9.0",
  "tempfile",
  "winapi",
 ]
@@ -3098,6 +3230,12 @@ name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -3163,7 +3301,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -3185,7 +3323,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3505,12 +3643,12 @@ dependencies = [
 
 [[package]]
 name = "xdg-home"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
+checksum = "ca91dcf8f93db085f3a0a29358cd0b9d670915468f4290e8b85d118a34211ab8"
 dependencies = [
- "nix 0.26.2",
- "winapi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3554,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "3.14.1"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948"
+checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
 dependencies = [
  "async-broadcast",
  "async-process",
@@ -3565,12 +3703,12 @@ dependencies = [
  "byteorder",
  "derivative",
  "enumflags2",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
  "futures-sink",
  "futures-util",
  "hex",
- "nix 0.26.2",
+ "nix 0.26.4",
  "once_cell",
  "ordered-stream",
  "rand",
@@ -3590,11 +3728,11 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.14.1"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
+checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -3604,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
+checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
 dependencies = [
  "serde",
  "static_assertions",
@@ -3630,14 +3768,14 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "zvariant"
-version = "3.15.0"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
+checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
 dependencies = [
  "byteorder",
  "enumflags2",
@@ -3649,11 +3787,11 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "3.15.0"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
+checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,6 @@ dependencies = [
  "eww_shared_util",
  "extend",
  "futures",
- "gdk-pixbuf",
  "gdkx11",
  "glib-macros",
  "grass",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,6 @@ dependencies = [
  "notify",
  "once_cell",
  "ordered-stream",
- "pango",
  "pretty_env_logger",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,6 @@ dependencies = [
  "futures",
  "gdk-pixbuf",
  "gdkx11",
- "glib",
  "glib-macros",
  "grass",
  "gtk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,12 +1324,12 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.2.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
- "winapi",
+ "windows-targets 0.48.2",
 ]
 
 [[package]]
@@ -1943,15 +1943,6 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -1994,19 +1985,6 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
-name = "nix"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
 
 [[package]]
 name = "nix"
@@ -3360,15 +3338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-wsapoll"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,25 +3590,20 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf3c79412dd91bae7a7366b8ad1565a85e35dd049affc3a6a2c549e97419617"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "gethostname",
- "nix 0.25.1",
- "winapi",
- "winapi-wsapoll",
+ "rustix 0.38.34",
  "x11rb-protocol",
 ]
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1513b141123073ce54d5bb1d33f801f17508fbd61e02060b1214e96d39c56"
-dependencies = [
- "nix 0.25.1",
-]
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xdg-home"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,8 +991,6 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "bincode",
- "cairo-rs",
- "cairo-sys-rs",
  "chrono",
  "clap",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,6 @@ dependencies = [
  "eww_shared_util",
  "extend",
  "futures",
- "gdk",
  "gdk-pixbuf",
  "gdkx11",
  "glib",
@@ -2014,7 +2013,6 @@ name = "notifier_host"
 version = "0.1.0"
 dependencies = [
  "dbusmenu-gtk3",
- "gdk",
  "gtk",
  "log",
  "thiserror",

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -24,8 +24,6 @@ notifier_host.workspace = true
 gtk = "0.18.1"
 glib-macros = "0.18.5"
 
-gdk-pixbuf = "0.18.5"
-
 gtk-layer-shell = { version = "0.8.1", optional = true }
 gdkx11 = { version = "0.18", optional = true }
 x11rb = { version = "0.13.1", features = ["randr"], optional = true }

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -21,19 +21,19 @@ eww_shared_util.workspace = true
 yuck.workspace = true
 notifier_host.workspace = true
 
-gtk = "0.17.1"
-gdk = "0.17.1"
-pango = "0.17.1"
-glib = "0.17.8"
-glib-macros = "0.17.8"
+gtk = "0.18.1"
+gdk = "0.18.0"
+pango = "0.18.3"
+glib = "0.18.5"
+glib-macros = "0.18.5"
 
-cairo-rs = "0.17"
-cairo-sys-rs = "0.17"
+cairo-rs = "0.18.5"
+cairo-sys-rs = "0.18.2"
 
-gdk-pixbuf = "0.17"
+gdk-pixbuf = "0.18.5"
 
-gtk-layer-shell = { version = "0.6.1", optional = true }
-gdkx11 = { version = "0.17", optional = true }
+gtk-layer-shell = { version = "0.8.1", optional = true }
+gdkx11 = { version = "0.18", optional = true }
 x11rb = { version = "0.11.1", features = ["randr"], optional = true }
 
 zbus = { version = "3.7.0", default-features = false, features = ["tokio"] }

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -34,7 +34,7 @@ gdk-pixbuf = "0.18.5"
 
 gtk-layer-shell = { version = "0.8.1", optional = true }
 gdkx11 = { version = "0.18", optional = true }
-x11rb = { version = "0.11.1", features = ["randr"], optional = true }
+x11rb = { version = "0.13.1", features = ["randr"], optional = true }
 
 zbus = { version = "3.7.0", default-features = false, features = ["tokio"] }
 ordered-stream = "0.2.0"

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -25,9 +25,6 @@ gtk = "0.18.1"
 glib = "0.18.5"
 glib-macros = "0.18.5"
 
-cairo-rs = "0.18.5"
-cairo-sys-rs = "0.18.2"
-
 gdk-pixbuf = "0.18.5"
 
 gtk-layer-shell = { version = "0.8.1", optional = true }

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -22,7 +22,6 @@ yuck.workspace = true
 notifier_host.workspace = true
 
 gtk = "0.18.1"
-glib = "0.18.5"
 glib-macros = "0.18.5"
 
 gdk-pixbuf = "0.18.5"

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -22,7 +22,6 @@ yuck.workspace = true
 notifier_host.workspace = true
 
 gtk = "0.18.1"
-glib-macros = "0.18.5"
 
 gtk-layer-shell = { version = "0.8.1", optional = true }
 gdkx11 = { version = "0.18", optional = true }

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -22,7 +22,6 @@ yuck.workspace = true
 notifier_host.workspace = true
 
 gtk = "0.18.1"
-gdk = "0.18.0"
 pango = "0.18.3"
 glib = "0.18.5"
 glib-macros = "0.18.5"

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -22,7 +22,6 @@ yuck.workspace = true
 notifier_host.workspace = true
 
 gtk = "0.18.1"
-pango = "0.18.3"
 glib = "0.18.5"
 glib-macros = "0.18.5"
 

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -17,6 +17,7 @@ use codespan_reporting::files::Files;
 use eww_shared_util::{Span, VarName};
 use gdk::Monitor;
 use glib::ObjectExt;
+use gtk::gdk;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use simplexpr::{dynval::DynVal, SimplExpr};

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -17,7 +17,7 @@ use codespan_reporting::files::Files;
 use eww_shared_util::{Span, VarName};
 use gdk::Monitor;
 use glib::ObjectExt;
-use gtk::gdk;
+use gtk::{gdk, glib};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use simplexpr::{dynval::DynVal, SimplExpr};

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -26,6 +26,7 @@ impl DisplayBackend for NoBackend {
 mod platform_wayland {
     use crate::{widgets::window::Window, window_initiator::WindowInitiator};
     use gtk::prelude::*;
+    use gtk_layer_shell::LayerShell;
     use yuck::config::{window_definition::WindowStacking, window_geometry::AnchorAlignment};
 
     use super::DisplayBackend;
@@ -38,12 +39,12 @@ mod platform_wayland {
         fn initialize_window(window_init: &WindowInitiator, monitor: gdk::Rectangle, x: i32, y: i32) -> Option<Window> {
             let window = Window::new(gtk::WindowType::Toplevel, x, y);
             // Initialising a layer shell surface
-            gtk_layer_shell::init_for_window(&window);
+            window.init_layer_shell();
             // Sets the monitor where the surface is shown
             if let Some(ident) = window_init.monitor.clone() {
                 let display = gdk::Display::default().expect("could not get default display");
                 if let Some(monitor) = crate::app::get_monitor_from_display(&display, &ident) {
-                    gtk_layer_shell::set_monitor(&window, &monitor);
+                    window.set_monitor(&monitor);
                 } else {
                     return None;
                 }
@@ -52,18 +53,18 @@ mod platform_wayland {
 
             // Sets the layer where the layer shell surface will spawn
             match window_init.stacking {
-                WindowStacking::Foreground => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Top),
-                WindowStacking::Background => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Background),
-                WindowStacking::Bottom => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Bottom),
-                WindowStacking::Overlay => gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Overlay),
+                WindowStacking::Foreground => window.set_layer(gtk_layer_shell::Layer::Top),
+                WindowStacking::Background => window.set_layer(gtk_layer_shell::Layer::Background),
+                WindowStacking::Bottom => window.set_layer(gtk_layer_shell::Layer::Bottom),
+                WindowStacking::Overlay => window.set_layer(gtk_layer_shell::Layer::Overlay),
             }
 
             if let Some(namespace) = &window_init.backend_options.wayland.namespace {
-                gtk_layer_shell::set_namespace(&window, namespace);
+                window.set_namespace(namespace);
             }
 
             // Sets the keyboard interactivity
-            gtk_layer_shell::set_keyboard_interactivity(&window, window_init.backend_options.wayland.focusable);
+            window.set_keyboard_interactivity(window_init.backend_options.wayland.focusable);
 
             if let Some(geometry) = window_init.geometry {
                 // Positioning surface
@@ -83,27 +84,27 @@ mod platform_wayland {
                     AnchorAlignment::END => bottom = true,
                 }
 
-                gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Left, left);
-                gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Right, right);
-                gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Top, top);
-                gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Bottom, bottom);
+                window.set_anchor(gtk_layer_shell::Edge::Left, left);
+                window.set_anchor(gtk_layer_shell::Edge::Right, right);
+                window.set_anchor(gtk_layer_shell::Edge::Top, top);
+                window.set_anchor(gtk_layer_shell::Edge::Bottom, bottom);
 
                 let xoffset = geometry.offset.x.pixels_relative_to(monitor.width());
                 let yoffset = geometry.offset.y.pixels_relative_to(monitor.height());
 
                 if left {
-                    gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Left, xoffset);
+                    window.set_layer_shell_margin(gtk_layer_shell::Edge::Left, xoffset);
                 } else {
-                    gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Right, xoffset);
+                    window.set_layer_shell_margin(gtk_layer_shell::Edge::Right, xoffset);
                 }
                 if bottom {
-                    gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Bottom, yoffset);
+                    window.set_layer_shell_margin(gtk_layer_shell::Edge::Bottom, yoffset);
                 } else {
-                    gtk_layer_shell::set_margin(&window, gtk_layer_shell::Edge::Top, yoffset);
+                    window.set_layer_shell_margin(gtk_layer_shell::Edge::Top, yoffset);
                 }
             }
             if window_init.backend_options.wayland.exclusive {
-                gtk_layer_shell::auto_exclusive_zone_enable(&window);
+                window.auto_exclusive_zone_enable();
             }
             Some(window)
         }

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -1,5 +1,7 @@
 use crate::{widgets::window::Window, window_initiator::WindowInitiator};
 
+use gtk::gdk;
+
 #[cfg(feature = "wayland")]
 pub use platform_wayland::WaylandBackend;
 
@@ -25,6 +27,7 @@ impl DisplayBackend for NoBackend {
 #[cfg(feature = "wayland")]
 mod platform_wayland {
     use crate::{widgets::window::Window, window_initiator::WindowInitiator};
+    use gtk::gdk;
     use gtk::prelude::*;
     use gtk_layer_shell::LayerShell;
     use yuck::config::{window_definition::WindowStacking, window_geometry::AnchorAlignment};
@@ -116,6 +119,7 @@ mod platform_x11 {
     use crate::{widgets::window::Window, window_initiator::WindowInitiator};
     use anyhow::{Context, Result};
     use gdk::Monitor;
+    use gtk::gdk;
     use gtk::{self, prelude::*};
     use x11rb::protocol::xproto::ConnectionExt;
 

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -105,7 +105,7 @@ pub fn initialize_server<B: DisplayBackend>(
     // initialize all the handlers and tasks running asyncronously
     let tokio_handle = init_async_part(app.paths.clone(), ui_send);
 
-    glib::MainContext::default().spawn_local(async move {
+    gtk::glib::MainContext::default().spawn_local(async move {
         // if an action was given to the daemon initially, execute it first.
         if let Some(action) = action {
             app.handle_command(action);

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -92,7 +92,7 @@ pub fn initialize_server<B: DisplayBackend>(
         paths,
     };
 
-    if let Some(screen) = gdk::Screen::default() {
+    if let Some(screen) = gtk::gdk::Screen::default() {
         gtk::StyleContext::add_provider_for_screen(&screen, &app.css_provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 

--- a/crates/eww/src/widgets/build_widget.rs
+++ b/crates/eww/src/widgets/build_widget.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use codespan_reporting::diagnostic::Severity;
 use eww_shared_util::{AttrName, Spanned};
-use gdk::prelude::Cast;
 use gtk::{
+    gdk::prelude::Cast,
     prelude::{BoxExt, ContainerExt, WidgetExt},
     Orientation,
 };

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use glib::{object_subclass, prelude::*, wrapper};
 use glib_macros::Properties;
+use gtk::glib::{self, object_subclass, prelude::*, wrapper};
 use gtk::{cairo, gdk, prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
 

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -154,7 +154,7 @@ impl WidgetImpl for CircProgPriv {
         self.preferred_height()
     }
 
-    fn draw(&self, cr: &cairo::Context) -> Inhibit {
+    fn draw(&self, cr: &cairo::Context) -> glib::Propagation {
         let res: Result<()> = (|| {
             let value = *self.value.borrow();
             let start_at = *self.start_at.borrow();
@@ -226,7 +226,7 @@ impl WidgetImpl for CircProgPriv {
             error_handling_ctx::print_error(error)
         };
 
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     }
 }
 

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use glib::{object_subclass, prelude::*, wrapper};
 use glib_macros::Properties;
-use gtk::{prelude::*, subclass::prelude::*};
+use gtk::{gdk, prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
 
 use crate::error_handling_ctx;

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
-use glib_macros::Properties;
-use gtk::glib::{self, object_subclass, prelude::*, wrapper};
+use gtk::glib::{self, object_subclass, prelude::*, wrapper, Properties};
 use gtk::{cairo, gdk, prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
 

--- a/crates/eww/src/widgets/circular_progressbar.rs
+++ b/crates/eww/src/widgets/circular_progressbar.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use glib::{object_subclass, prelude::*, wrapper};
 use glib_macros::Properties;
-use gtk::{gdk, prelude::*, subclass::prelude::*};
+use gtk::{cairo, gdk, prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
 
 use crate::error_handling_ctx;

--- a/crates/eww/src/widgets/graph.rs
+++ b/crates/eww/src/widgets/graph.rs
@@ -2,8 +2,7 @@ use std::{cell::RefCell, collections::VecDeque};
 // https://www.figuiere.net/technotes/notes/tn002/
 // https://github.com/gtk-rs/examples/blob/master/src/bin/listbox_model.rs
 use anyhow::{anyhow, Result};
-use glib_macros::Properties;
-use gtk::glib::{self, object_subclass, wrapper};
+use gtk::glib::{self, object_subclass, wrapper, Properties};
 use gtk::{cairo, gdk, prelude::*, subclass::prelude::*};
 
 use crate::error_handling_ctx;

--- a/crates/eww/src/widgets/graph.rs
+++ b/crates/eww/src/widgets/graph.rs
@@ -170,7 +170,7 @@ impl WidgetImpl for GraphPriv {
         (width, width)
     }
 
-    fn draw(&self, cr: &cairo::Context) -> Inhibit {
+    fn draw(&self, cr: &cairo::Context) -> glib::Propagation {
         let res: Result<()> = (|| {
             let history = &*self.history.borrow();
             let extra_point = *self.extra_point.borrow();
@@ -276,7 +276,7 @@ impl WidgetImpl for GraphPriv {
             error_handling_ctx::print_error(error)
         };
 
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     }
 }
 

--- a/crates/eww/src/widgets/graph.rs
+++ b/crates/eww/src/widgets/graph.rs
@@ -4,7 +4,7 @@ use std::{cell::RefCell, collections::VecDeque};
 use anyhow::{anyhow, Result};
 use glib::{object_subclass, wrapper};
 use glib_macros::Properties;
-use gtk::{prelude::*, subclass::prelude::*};
+use gtk::{gdk, prelude::*, subclass::prelude::*};
 
 use crate::error_handling_ctx;
 

--- a/crates/eww/src/widgets/graph.rs
+++ b/crates/eww/src/widgets/graph.rs
@@ -2,8 +2,8 @@ use std::{cell::RefCell, collections::VecDeque};
 // https://www.figuiere.net/technotes/notes/tn002/
 // https://github.com/gtk-rs/examples/blob/master/src/bin/listbox_model.rs
 use anyhow::{anyhow, Result};
-use glib::{object_subclass, wrapper};
 use glib_macros::Properties;
+use gtk::glib::{self, object_subclass, wrapper};
 use gtk::{cairo, gdk, prelude::*, subclass::prelude::*};
 
 use crate::error_handling_ctx;

--- a/crates/eww/src/widgets/graph.rs
+++ b/crates/eww/src/widgets/graph.rs
@@ -4,7 +4,7 @@ use std::{cell::RefCell, collections::VecDeque};
 use anyhow::{anyhow, Result};
 use glib::{object_subclass, wrapper};
 use glib_macros::Properties;
-use gtk::{gdk, prelude::*, subclass::prelude::*};
+use gtk::{cairo, gdk, prelude::*, subclass::prelude::*};
 
 use crate::error_handling_ctx;
 

--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -1,6 +1,6 @@
 use crate::widgets::window::Window;
 use futures::StreamExt;
-use gtk::{cairo::Surface, gdk, gdk::ffi::gdk_cairo_surface_create_from_pixbuf, gdk::NotifyType, prelude::*};
+use gtk::{cairo::Surface, gdk, gdk::ffi::gdk_cairo_surface_create_from_pixbuf, gdk::NotifyType, glib, prelude::*};
 use std::{cell::RefCell, future::Future, rc::Rc};
 
 // DBus state shared between systray instances, to avoid creating too many connections etc.

--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -139,14 +139,14 @@ impl Item {
             if evt.detail() != NotifyType::Inferior {
                 gtk_widget.clone().set_state_flags(gtk::StateFlags::PRELIGHT, false);
             }
-            gtk::Inhibit(false)
+            glib::Propagation::Proceed
         });
 
         gtk_widget.connect_leave_notify_event(|gtk_widget, evt| {
             if evt.detail() != NotifyType::Inferior {
                 gtk_widget.clone().unset_state_flags(gtk::StateFlags::PRELIGHT);
             }
-            gtk::Inhibit(false)
+            glib::Propagation::Proceed
         });
 
         let out_widget = gtk_widget.clone(); // copy so we can return it
@@ -231,7 +231,7 @@ impl Item {
             if let Err(result) = result {
                 log::error!("failed to handle mouse click {}: {}", evt.button(), result);
             }
-            gtk::Inhibit(true)
+            glib::Propagation::Stop
         }));
 
         // updates

--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -2,7 +2,6 @@ use crate::widgets::window::Window;
 use futures::StreamExt;
 use gdk::NotifyType;
 use gtk::{cairo::Surface, gdk::ffi::gdk_cairo_surface_create_from_pixbuf, prelude::*};
-use notifier_host;
 use std::{cell::RefCell, future::Future, rc::Rc};
 
 // DBus state shared between systray instances, to avoid creating too many connections etc.

--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -1,7 +1,6 @@
 use crate::widgets::window::Window;
 use futures::StreamExt;
-use gdk::NotifyType;
-use gtk::{cairo::Surface, gdk::ffi::gdk_cairo_surface_create_from_pixbuf, prelude::*};
+use gtk::{cairo::Surface, gdk, gdk::ffi::gdk_cairo_surface_create_from_pixbuf, gdk::NotifyType, prelude::*};
 use std::{cell::RefCell, future::Future, rc::Rc};
 
 // DBus state shared between systray instances, to avoid creating too many connections etc.

--- a/crates/eww/src/widgets/transform.rs
+++ b/crates/eww/src/widgets/transform.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
-use glib::{object_subclass, wrapper};
 use glib_macros::Properties;
+use gtk::glib::{self, object_subclass, wrapper};
 use gtk::{prelude::*, subclass::prelude::*};
 use std::{cell::RefCell, str::FromStr};
 use yuck::value::NumWithUnit;

--- a/crates/eww/src/widgets/transform.rs
+++ b/crates/eww/src/widgets/transform.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
-use glib_macros::Properties;
-use gtk::glib::{self, object_subclass, wrapper};
+use gtk::glib::{self, object_subclass, wrapper, Properties};
 use gtk::{prelude::*, subclass::prelude::*};
 use std::{cell::RefCell, str::FromStr};
 use yuck::value::NumWithUnit;

--- a/crates/eww/src/widgets/transform.rs
+++ b/crates/eww/src/widgets/transform.rs
@@ -121,7 +121,7 @@ impl ContainerImpl for TransformPriv {
 
 impl BinImpl for TransformPriv {}
 impl WidgetImpl for TransformPriv {
-    fn draw(&self, cr: &cairo::Context) -> glib::Propagation {
+    fn draw(&self, cr: &gtk::cairo::Context) -> glib::Propagation {
         let res: Result<()> = (|| {
             let rotate = *self.rotate.borrow();
             let total_width = self.obj().allocated_width() as f64;

--- a/crates/eww/src/widgets/transform.rs
+++ b/crates/eww/src/widgets/transform.rs
@@ -121,7 +121,7 @@ impl ContainerImpl for TransformPriv {
 
 impl BinImpl for TransformPriv {}
 impl WidgetImpl for TransformPriv {
-    fn draw(&self, cr: &cairo::Context) -> Inhibit {
+    fn draw(&self, cr: &cairo::Context) -> glib::Propagation {
         let res: Result<()> = (|| {
             let rotate = *self.rotate.borrow();
             let total_width = self.obj().allocated_width() as f64;
@@ -166,7 +166,7 @@ impl WidgetImpl for TransformPriv {
             error_handling_ctx::print_error(error)
         };
 
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     }
 }
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -232,11 +232,11 @@ pub(super) fn resolve_range_attrs(bargs: &mut BuilderArgs, gtk_widget: &gtk::Ran
     let is_being_dragged = Rc::new(RefCell::new(false));
     gtk_widget.connect_button_press_event(glib::clone!(@strong is_being_dragged => move |_, _| {
         *is_being_dragged.borrow_mut() = true;
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     }));
     gtk_widget.connect_button_release_event(glib::clone!(@strong is_being_dragged => move |_, _| {
         *is_being_dragged.borrow_mut() = false;
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     }));
 
     // We keep track of the last value that has been set via gtk_widget.set_value (by a change in the value property).
@@ -507,7 +507,7 @@ fn build_gtk_button(bargs: &mut BuilderArgs) -> Result<gtk::Button> {
                     3 => run_command(timeout, &onrightclick, &[] as &[&str]),
                     _ => {},
                 }
-                gtk::Inhibit(false)
+                glib::Propagation::Proceed
             }));
         }
 
@@ -729,25 +729,25 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
         if evt.detail() != NotifyType::Inferior {
             gtk_widget.clone().set_state_flags(gtk::StateFlags::PRELIGHT, false);
         }
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     });
 
     gtk_widget.connect_leave_notify_event(|gtk_widget, evt| {
         if evt.detail() != NotifyType::Inferior {
             gtk_widget.clone().unset_state_flags(gtk::StateFlags::PRELIGHT);
         }
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     });
 
     // Support :active selector
     gtk_widget.connect_button_press_event(|gtk_widget, _| {
         gtk_widget.clone().set_state_flags(gtk::StateFlags::ACTIVE, false);
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     });
 
     gtk_widget.connect_button_release_event(|gtk_widget, _| {
         gtk_widget.clone().unset_state_flags(gtk::StateFlags::ACTIVE);
-        gtk::Inhibit(false)
+        glib::Propagation::Proceed
     });
 
     def_widget!(bargs, _g, gtk_widget, {
@@ -761,7 +761,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
                 if delta != 0f64 { // Ignore the first event https://bugzilla.gnome.org/show_bug.cgi?id=675959
                     run_command(timeout, &onscroll, &[if delta < 0f64 { "up" } else { "down" }]);
                 }
-                gtk::Inhibit(false)
+                glib::Propagation::Proceed
             }));
         },
         // @prop timeout - timeout of the command. Default: "200ms"
@@ -772,7 +772,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
                 if evt.detail() != NotifyType::Inferior {
                     run_command(timeout, &onhover, &[evt.position().0, evt.position().1]);
                 }
-                gtk::Inhibit(false)
+                glib::Propagation::Proceed
             }));
         },
         // @prop timeout - timeout of the command. Default: "200ms"
@@ -783,7 +783,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
                 if evt.detail() != NotifyType::Inferior {
                     run_command(timeout, &onhoverlost, &[evt.position().0, evt.position().1]);
                 }
-                gtk::Inhibit(false)
+                glib::Propagation::Proceed
             }));
         },
         // @prop cursor - Cursor to show while hovering (see [gtk3-cursors](https://docs.gtk.org/gdk3/ctor.Cursor.new_from_name.html) for possible names)
@@ -799,7 +799,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
                         gdk_window.set_cursor(gdk::Cursor::from_name(&display, &cursor).as_ref());
                     }
                 }
-                gtk::Inhibit(false)
+                glib::Propagation::Proceed
             }));
             connect_signal_handler!(gtk_widget, gtk_widget.connect_leave_notify_event(move |widget, _evt| {
                 if _evt.detail() != NotifyType::Inferior {
@@ -808,7 +808,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
                         gdk_window.set_cursor(None);
                     }
                 }
-                gtk::Inhibit(false)
+                glib::Propagation::Proceed
             }));
         },
         // @prop timeout - timeout of the command. Default: "200ms"
@@ -878,7 +878,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
                     3 => run_command(timeout, &onrightclick, &[] as &[&str]),
                     _ => {},
                 }
-                gtk::Inhibit(false)
+                glib::Propagation::Proceed
             }));
         }
     });

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -11,8 +11,8 @@ use eww_shared_util::Spanned;
 
 use gdk::{ModifierType, NotifyType};
 use glib::translate::FromGlib;
-use gtk::gdk;
 use gtk::{self, glib, prelude::*, DestDefaults, TargetEntry, TargetList};
+use gtk::{gdk, pango};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -8,9 +8,10 @@ use crate::{
 use anyhow::{anyhow, Context, Result};
 use codespan_reporting::diagnostic::Severity;
 use eww_shared_util::Spanned;
-use gdk::{ModifierType, NotifyType};
 
+use gdk::{ModifierType, NotifyType};
 use glib::translate::FromGlib;
+use gtk::gdk;
 use gtk::{self, glib, prelude::*, DestDefaults, TargetEntry, TargetList};
 use itertools::Itertools;
 use once_cell::sync::Lazy;

--- a/crates/eww/src/widgets/window.rs
+++ b/crates/eww/src/widgets/window.rs
@@ -1,5 +1,5 @@
-use glib::{object_subclass, wrapper};
 use glib_macros::Properties;
+use gtk::glib::{self, object_subclass, wrapper};
 use gtk::{prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
 

--- a/crates/eww/src/widgets/window.rs
+++ b/crates/eww/src/widgets/window.rs
@@ -1,5 +1,4 @@
-use glib_macros::Properties;
-use gtk::glib::{self, object_subclass, wrapper};
+use gtk::glib::{self, object_subclass, wrapper, Properties};
 use gtk::{prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
 

--- a/crates/notifier_host/Cargo.toml
+++ b/crates/notifier_host/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/elkowar/eww"
 homepage = "https://github.com/elkowar/eww"
 
 [dependencies]
-gtk = "0.17.1"
-gdk = "0.17.1"
+gtk = "0.18.1"
+gdk = "0.18.0"
 zbus = { version = "3.7.0", default-features = false, features = ["tokio"] }
 dbusmenu-gtk3 = "0.1.0"
 

--- a/crates/notifier_host/Cargo.toml
+++ b/crates/notifier_host/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/elkowar/eww"
 
 [dependencies]
 gtk = "0.18.1"
-gdk = "0.18.0"
 zbus = { version = "3.7.0", default-features = false, features = ["tokio"] }
 dbusmenu-gtk3 = "0.1.0"
 

--- a/crates/notifier_host/src/icon.rs
+++ b/crates/notifier_host/src/icon.rs
@@ -105,7 +105,7 @@ fn icon_from_name(
 ) -> std::result::Result<gtk::gdk_pixbuf::Pixbuf, IconError> {
     let theme = if let Some(path) = theme_path {
         let theme = gtk::IconTheme::new();
-        theme.prepend_search_path(&path);
+        theme.prepend_search_path(path);
         theme
     } else {
         gtk::IconTheme::default().expect("Could not get default gtk theme")

--- a/crates/notifier_host/src/item.rs
+++ b/crates/notifier_host/src/item.rs
@@ -88,9 +88,9 @@ impl Item {
         Ok(())
     }
 
-    pub async fn popup_menu(&self, event: &gdk::EventButton, x: i32, y: i32) -> zbus::Result<()> {
+    pub async fn popup_menu(&self, event: &gtk::gdk::EventButton, x: i32, y: i32) -> zbus::Result<()> {
         if let Some(menu) = &self.gtk_menu {
-            menu.popup_at_pointer(event.downcast_ref::<gdk::Event>());
+            menu.popup_at_pointer(event.downcast_ref::<gtk::gdk::Event>());
             Ok(())
         } else {
             self.sni.context_menu(x, y).await


### PR DESCRIPTION
## Description

This PR updates GTK, GDK, and all related dependencies to 0.18.

Additionally, since `gtk` re-exports `gdk`, `gdk-pixbuf`, `glib`, `pango`, and `cairo`, it is possible (and I'd argue preferable) to depend directly on the re-exported versions. This way, we don't have to worry about keeping the versions aligned anymore - Cargo will take care of that. Notably, the re-exported version of `gdk-pixbuf` was already used everywhere, so it could just be removed without any import changes.

## Motivation

I'd love to see `eww` updated to GTK 4, but I understand that this is complex and time consuming, and while I wouldn't mind assisting, I don't have enough experience with GTK to be of much use.

That said, what I can at least do is get the 0.17->0.18 breaking changes out of the way, and simplify the dependencies a bit to make the eventual migration ever so slightly easier.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] I used `cargo fmt` to automatically format all code before committing
