### PR TITLE
feat: Add fill attribute to image widget for custom/dynamic svg color

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -541,7 +541,7 @@ fn svg_to_pixbuf(
         reg.replace(&svg_data, &format!("fill=\"{}\"", fill))
     } else {
         let reg = regex::Regex::new(r"<svg")?;
-        reg.replace(&svg_data, &format!(" fill=\"{}\"", fill))
+        reg.replace(&svg_data, &format!("<svg fill=\"{}\"", fill))
     };
 
     let pixbuf_svg = gtk::gdk_pixbuf::PixbufLoader::with_type("svg")?;

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -546,15 +546,11 @@ fn svg_to_pixbuf(
 
     let pixbuf_svg = gtk::gdk_pixbuf::PixbufLoader::with_type("svg")?;
 
-    if image_width >= 0 && image_height == -1 {
-        pixbuf_svg.set_size(image_width, image_width);
-    }
-    if image_width == -1 && image_height >= 0 {
-        pixbuf_svg.set_size(image_height, image_height);
-    }
-    if image_width >= 0 && image_height >= 0 {
-        pixbuf_svg.set_size(image_width, image_height);
-    }
+    match (image_width, image_height) {
+        (w, h) if w > 0 || h > 0 => pixbuf_svg.set_size(w, h),
+        // Add default size to prevent widget overflowing, if image is too big
+        _ => pixbuf_svg.set_size(24, 24),
+    };
 
     let svg_buf: Vec<u8> = svg_data.as_bytes().to_vec();
     pixbuf_svg.write(&svg_buf)?;

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -574,7 +574,7 @@ fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
         // @prop image-height - height of the image
         prop(path: as_string, image_width: as_i32 = -1, image_height: as_i32 = -1, fill: as_string = "currentColor") {
             if fill != "currentColor" && !path.ends_with(".svg") {
-                log::warn!("The fill sttribute is only for SVG images");
+                log::warn!("The fill attribute is only for SVG images");
             }
 
             if path.ends_with(".gif") {


### PR DESCRIPTION
## Description
Added fill attribute to image widget for custom/dynamic svg color.

> [!NOTE]
> This option is only for svg images


## Usage

```lisp
(image
  :fill "green"
  :path "./my-svg-icon.svg"
)
```

```lisp
(image
  :fill "#0389ff"
  :path "./my-svg-icon.svg"
)
```

### Showcase
<table>
<tr>
<img src="https://github.com/user-attachments/assets/78104549-06b3-4f7d-b9e6-b5c8da616328">
</tr>
<tr>
<img src="https://github.com/user-attachments/assets/a6a5476a-d9d7-4db8-89e7-abad27fb5656">
</tr>
</table>


## Additional Notes

Anything else you want to add, such as remaining questions or explanations.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
