### PR TITLE
feat: add fill-svg and preserve-aspect-ratio attributes to image widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ### Features
 - Update rust toolchain to 1.80.1 (By: w-lfchen)
+- Add `:fill-svg` and `:preserve-aspect-ratio` properties to images (By: hypernova7, w-lfchen)
 - Add `:truncate` property to labels, disabled by default (except in cases where truncation would be enabled in version `0.5.0` and before) (By: Rayzeq).
 - Add support for `:hover` css selectors for tray items (By: zeapoz)
 - Add `min` and `max` function calls to simplexpr (By: ovalkonia)

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -571,7 +571,7 @@ fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
         // @prop path - path to the image file
         // @prop image-width - width of the image
         // @prop image-height - height of the image
-        prop(path: as_string, image_width: as_i32 = -1, image_height: as_i32 = -1, fill_svg: as_string = "") {
+        prop(path: as_string, image_width: as_i32 = -1, image_height: as_i32 = -1, preserve_aspect_ratio: as_bool = true, fill_svg: as_string = "") {
             if !path.ends_with(".svg") && !fill_svg.is_empty() {
                 log::warn!("Fill attribute ignored, file is not an svg image");
             }
@@ -593,10 +593,10 @@ fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
                         reg.replace(&svg_data, &format!("<svg fill=\"{}\"", fill_svg))
                     };
                     let stream = gtk::gio::MemoryInputStream::from_bytes(&gtk::glib::Bytes::from(svg_data.as_bytes()));
-                    pixbuf = gtk::gdk_pixbuf::Pixbuf::from_stream_at_scale(&stream, image_width, image_height, true, None::<&gtk::gio::Cancellable>)?;
+                    pixbuf = gtk::gdk_pixbuf::Pixbuf::from_stream_at_scale(&stream, image_width, image_height, preserve_aspect_ratio, None::<&gtk::gio::Cancellable>)?;
                     stream.close(None::<&gtk::gio::Cancellable>)?;
                 } else {
-                    pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file_at_size(std::path::PathBuf::from(path), image_width, image_height)?;
+                    pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(std::path::PathBuf::from(path), image_width, image_height, preserve_aspect_ratio)?;
                 }
                 gtk_widget.set_from_pixbuf(Some(&pixbuf));
             }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -571,6 +571,8 @@ fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
         // @prop path - path to the image file
         // @prop image-width - width of the image
         // @prop image-height - height of the image
+        // @prop preserve-aspect-ratio - whether to keep the aspect ratio when resizing an image. Default: true, false doesn't work for all image types
+        // @prop fill-svg - sets the color of svg images
         prop(path: as_string, image_width: as_i32 = -1, image_height: as_i32 = -1, preserve_aspect_ratio: as_bool = true, fill_svg: as_string = "") {
             if !path.ends_with(".svg") && !fill_svg.is_empty() {
                 log::warn!("Fill attribute ignored, file is not an svg image");


### PR DESCRIPTION
## Description
- supersedes #1146, as discussed there
- adds the `fill-svg` attribute that attempts to replace the color of an svg
- adds the `preserve-aspect-ratio` attribute to decide whether to keep an images aspect ratio when it is resized

## Usage
```
(image
  :fill-svg "#cba6f7"
  :image-height 200
  :image-width 400
  :preserve-aspect-ratio true
  :path "../github-icon.svg"
)
```

### Showcase
see #1146, @hypernova7 has provided screenshots.

## Additional Notes
`preserve-aspect-ratio` only sets a flag when loading the image and is therefore bound by what gtk allows.
for example, it doesn't work with svg images, but there are no issues with pngs

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
*this shouldn't be necessary, since everything is generated automatically, right?*
- [x] I used `cargo fmt` to automatically format all code before committing
