### PR TITLE
fix: fix changelog, warnings and lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix remove items from systray (By: vnva)
 - Fix the gtk `stack` widget (By: ovalkonia)
 - Fix values in the `EWW_NET` variable (By: mario-kr)
+- Fix the gtk `expander` widget (By: ovalkonia)
 
 ### Features
 - Update rust toolchain to 1.80.1 (By: w-lfchen)
@@ -25,7 +26,6 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix nix flake
 - Fix `jq` (By: w-lfchen)
 - Labels now use gtk's truncation system (By: Rayzeq).
-- Fix the gtk `expander` widget (By: ovalkonia)
 
 ### Features
 - Add `systray` widget (By: ralismark)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
 dependencies = [
  "shlex",
 ]
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9340e41703683548f486fdfdce615b0520dd220d18b1d4ce5abbc87d461c221b"
+checksum = "531d7959c5bbb6e266cecdd0f20213639c3a5c3e4d615f97db87661745f781ff"
 dependencies = [
  "clap",
 ]
@@ -560,7 +560,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -698,7 +698,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -709,7 +709,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -782,7 +782,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "unicode-xid",
 ]
 
@@ -874,7 +874,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -987,14 +987,14 @@ checksum = "311a6d2f1f9d60bff73d2c78a0af97ed27f79672f15c238192a5bbb64db56d00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "field-offset"
@@ -1108,7 +1108,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1331,7 +1331,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1457,7 +1457,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2070,7 +2070,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2239,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2333,7 +2333,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2428,29 +2428,29 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -2466,7 +2466,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2576,7 +2576,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2633,7 +2633,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2648,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2659,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4115055da5f572fff541dd0c4e61b0262977f453cc9fe04be83aba25a89bdab"
+checksum = "2b92e0bdf838cbc1c4c9ba14f9c97a7ec6cdcd1ae66b10e1e42775a25553f45d"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2753,7 +2753,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2792,7 +2792,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2894,7 +2894,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3018,7 +3018,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
@@ -3040,7 +3040,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3131,7 +3131,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3142,7 +3142,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3429,7 +3429,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "zvariant_utils",
 ]
 
@@ -3462,7 +3462,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3487,7 +3487,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "zvariant_utils",
 ]
 
@@ -3499,5 +3499,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]

--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -53,7 +53,6 @@ fn main() {
         return;
     }
 
-    #[allow(unused)]
     let detected_wayland = detect_wayland();
     #[allow(unused)]
     let use_wayland = opts.force_wayland || detected_wayland;
@@ -69,7 +68,7 @@ fn main() {
     #[cfg(all(not(feature = "wayland"), feature = "x11"))]
     let result = {
         if use_wayland {
-            log::warn!("Eww compiled without wayland support. falling back to X11, eventhough wayland was requested.");
+            log::warn!("Eww compiled without wayland support. Falling back to X11, eventhough wayland was requested.");
         }
         run::<display_backend::X11Backend>(opts, eww_binary_name)
     };

--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -60,10 +60,10 @@ fn main() {
     #[cfg(all(feature = "wayland", feature = "x11"))]
     let result = if use_wayland {
         log::info!("Running on wayland. force_wayland={}, detected_wayland={}", opts.force_wayland, detected_wayland);
-        run(opts, eww_binary_name, display_backend::WaylandBackend)
+        run::<display_backend::WaylandBackend>(opts, eww_binary_name)
     } else {
         log::info!("Running on X11. force_wayland={}, detected_wayland={}", opts.force_wayland, detected_wayland);
-        run(opts, eww_binary_name, display_backend::X11Backend)
+        run::<display_backend::X11Backend>(opts, eww_binary_name)
     };
 
     #[cfg(all(not(feature = "wayland"), feature = "x11"))]
@@ -71,14 +71,14 @@ fn main() {
         if use_wayland {
             log::warn!("Eww compiled without wayland support. falling back to X11, eventhough wayland was requested.");
         }
-        run(opts, eww_binary_name, display_backend::X11Backend)
+        run::<display_backend::X11Backend>(opts, eww_binary_name)
     };
 
     #[cfg(all(feature = "wayland", not(feature = "x11")))]
-    let result = run(opts, eww_binary_name, display_backend::WaylandBackend);
+    let result = run::<display_backend::WaylandBackend>(opts, eww_binary_name);
 
     #[cfg(not(any(feature = "wayland", feature = "x11")))]
-    let result = run(opts, eww_binary_name, display_backend::NoBackend);
+    let result = run::<display_backend::NoBackend>(opts, eww_binary_name);
 
     if let Err(err) = result {
         error_handling_ctx::print_error(err);
@@ -92,7 +92,7 @@ fn detect_wayland() -> bool {
     session_type.contains("wayland") || (!wayland_display.is_empty() && !session_type.contains("x11"))
 }
 
-fn run<B: DisplayBackend>(opts: opts::Opt, eww_binary_name: String, display_backend: B) -> Result<()> {
+fn run<B: DisplayBackend>(opts: opts::Opt, eww_binary_name: String) -> Result<()> {
     let paths = opts
         .config_path
         .map(EwwPaths::from_config_dir)
@@ -132,7 +132,7 @@ fn run<B: DisplayBackend>(opts: opts::Opt, eww_binary_name: String, display_back
             if !opts.show_logs {
                 println!("Run `{} logs` to see any errors while editing your configuration.", eww_binary_name);
             }
-            let fork_result = server::initialize_server(paths.clone(), None, display_backend, !opts.no_daemonize)?;
+            let fork_result = server::initialize_server::<B>(paths.clone(), None, !opts.no_daemonize)?;
             opts.no_daemonize || fork_result == ForkResult::Parent
         }
 
@@ -164,7 +164,7 @@ fn run<B: DisplayBackend>(opts: opts::Opt, eww_binary_name: String, display_back
 
                     let (command, response_recv) = action.into_daemon_command();
                     // start the daemon and give it the command
-                    let fork_result = server::initialize_server(paths.clone(), Some(command), display_backend, true)?;
+                    let fork_result = server::initialize_server::<B>(paths.clone(), Some(command), true)?;
                     let is_parent = fork_result == ForkResult::Parent;
                     if let (Some(recv), true) = (response_recv, is_parent) {
                         listen_for_daemon_response(recv);

--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -1,6 +1,11 @@
 use crate::widgets::window::Window;
 use futures::StreamExt;
-use gtk::{cairo::Surface, gdk, gdk::ffi::gdk_cairo_surface_create_from_pixbuf, gdk::NotifyType, glib, prelude::*};
+use gtk::{
+    cairo::Surface,
+    gdk::{self, ffi::gdk_cairo_surface_create_from_pixbuf, NotifyType},
+    glib,
+    prelude::*,
+};
 use std::{cell::RefCell, future::Future, rc::Rc};
 
 // DBus state shared between systray instances, to avoid creating too many connections etc.

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1147,7 +1147,7 @@ const WIDGET_NAME_STACK: &str = "stack";
 fn build_gtk_stack(bargs: &mut BuilderArgs) -> Result<gtk::Stack> {
     let gtk_widget = gtk::Stack::new();
 
-    if bargs.widget_use.children.len() < 1 {
+    if bargs.widget_use.children.is_empty() {
         return Err(DiagError(gen_diagnostic!("stack must contain at least one element", bargs.widget_use.span)).into());
     }
 

--- a/crates/eww/src/window_initiator.rs
+++ b/crates/eww/src/window_initiator.rs
@@ -17,7 +17,6 @@ use crate::window_arguments::WindowArguments;
 pub struct WindowInitiator {
     pub backend_options: BackendWindowOptions,
     pub geometry: Option<WindowGeometry>,
-    pub id: String,
     pub local_variables: HashMap<VarName, DynVal>,
     pub monitor: Option<MonitorIdentifier>,
     pub name: String,
@@ -37,7 +36,6 @@ impl WindowInitiator {
         Ok(WindowInitiator {
             backend_options: window_def.backend_options.eval(&vars)?,
             geometry,
-            id: args.instance_id.clone(),
             monitor,
             name: window_def.name.clone(),
             resizable: window_def.eval_resizable(&vars)?,


### PR DESCRIPTION
## Description
While working on #1144 I noticed some new warnings when compiling. I'm assuming some warnings were stabilized or added.
This pr fixes these warnings, yielding a slight performance increase, for more details see below.
These are some breaking internal changes since APIs are modified and some call sites might now require generic annotations.

### Replacing the field `display_backend` in the `App` struct with `PhantomData`
This field is never read, producing a warning when compiling with 1.80.0.
It seems to only exist for the type parameter `B`, which has not been restricted to `DisplayBackend` even though it probably should be.
By replacing it with a `PhantomData`, there is no need to pass the `DisplayBackend` around at all times since all the information this argument provides is already encoded in the generic type parameters.

### Removal of field `instance_id` in the `EwwWindow` struct
This field is never read, producing a warning when compiling with 1.80.0.
All information it holds is already in the key of the `open_windows` map in the `App` struct. Removing it also makes the `WindowInitiator`'s `id` field obsolete.

## Checklist

- [x] I added my changes to CHANGELOG.md, if appropriate.
*I don't think this is necessary here*
- [x] I used `cargo fmt` to automatically format all code before committing