### PR TITLE
fix: remove unused import

### DIFF
--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -1,4 +1,4 @@
-use crate::{regex, util::IterAverage};
+use crate::util::IterAverage;
 use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
 use std::{fs::read_to_string, sync::Mutex};


### PR DESCRIPTION
## Description
one of the prs merged today introduced a warning about an unused import.
maybe a ci job for `cargo clippy` is worth adding, i could look into that.

## Additional Notes
if you want to merge more prs today, just tell me, don't merge this and i'll append more fixes if anything comes up.

## Checklist

- [x] I used `cargo fmt` to automatically format all code before committing
