### PR TITLE
ci: use clippy; abort run on failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,46 +1,36 @@
 name: build
-
 on:
-   push:
-      branches: [master]
-   pull_request:
-      branches: [master]
-
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 env:
-   CARGO_TERM_COLOR: always
-   RUSTFLAGS:        "-Dwarnings"
-
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
 jobs:
-   build:
-      runs-on: ubuntu-latest
-      steps:
-         - name: Install dependencies
-           run: sudo apt-get update && sudo apt-get install libgtk-3-dev libgtk-layer-shell-dev libdbusmenu-gtk3-dev
-
-         - uses: actions/checkout@v4
-
-         - name: Setup rust
-           uses: dtolnay/rust-toolchain@stable
-           with:
-               components: clippy,rustfmt
-
-         - name: Load rust cache
-           uses: Swatinem/rust-cache@v2
-
-         - name: Setup problem matchers
-           uses: r7kamura/rust-problem-matchers@v1
-
-         - name: Check formatting
-           run: cargo fmt -- --check
-
-         - name: Run tests
-           run: cargo test
-
-         - name: Check with default features
-           run: cargo clippy
-         - name: Check x11 only
-           run: cargo clippy --no-default-features --features=x11
-         - name: Check wayland only
-           run: cargo clippy --no-default-features --features=wayland
-         - name: Check no-backend
-           run: cargo clippy --no-default-features
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install libgtk-3-dev libgtk-layer-shell-dev libdbusmenu-gtk3-dev
+      - uses: actions/checkout@v4
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy,rustfmt
+      - name: Load rust cache
+        uses: Swatinem/rust-cache@v2
+      - name: Setup problem matchers
+        uses: r7kamura/rust-problem-matchers@v1
+      - name: Check formatting
+        run: cargo fmt -- --check
+      - name: Run tests
+        run: cargo test
+      - name: Check with default features
+        run: cargo clippy
+      - name: Check x11 only
+        run: cargo clippy --no-default-features --features=x11
+      - name: Check wayland only
+        run: cargo clippy --no-default-features --features=wayland
+      - name: Check no-backend
+        run: cargo clippy --no-default-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
    CARGO_TERM_COLOR: always
+   RUSTFLAGS:        "-Dwarnings"
 
 jobs:
    build:
@@ -31,15 +32,15 @@ jobs:
 
          - name: Check formatting
            run: cargo fmt -- --check
-         - name: Check with default features
-           run: cargo check
 
          - name: Run tests
            run: cargo test
 
+         - name: Check with default features
+           run: cargo clippy
          - name: Check x11 only
-           run: cargo check --no-default-features --features=x11
+           run: cargo clippy --no-default-features --features=x11
          - name: Check wayland only
-           run: cargo check --no-default-features --features=wayland
+           run: cargo clippy --no-default-features --features=wayland
          - name: Check no-backend
-           run: cargo check --no-default-features
+           run: cargo clippy --no-default-features

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,7 @@ jobs:
     build:
         name: Build mdBook
         runs-on: ubuntu-latest
+        if: github.repository == 'elkowar/eww'
         steps:
             # Checkout
             - uses: actions/checkout@master

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,39 +1,36 @@
 name: Build and deploy Github pages
 on:
-    push:
-        branches:
-            - master
-        paths:
-            - "docs/**"
-            - "gen-docs.ts"
-            - "crates/eww/src/widgets/widget_definitions.rs"
-            - "crates/eww/src/config/inbuilt.rs"
-            - ".github/workflows/**"
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - "gen-docs.ts"
+      - "crates/eww/src/widgets/widget_definitions.rs"
+      - "crates/eww/src/config/inbuilt.rs"
+      - ".github/workflows/**"
 jobs:
-    build:
-        name: Build mdBook
-        runs-on: ubuntu-latest
-        if: github.repository == 'elkowar/eww'
-        steps:
-            # Checkout
-            - uses: actions/checkout@master
-
-            # Build widget documentation
-            - name: Use deno to build widget documentation
-              uses: denoland/setup-deno@main
-              with:
-                  deno-version: "v1.x"
-            - run: deno run --allow-read --allow-write gen-docs.ts ./crates/eww/src/widgets/widget_definitions.rs ./crates/eww/src/config/inbuilt.rs
-
-            # Build & deploy
-            - name: build mdBook page
-              uses: peaceiris/actions-mdbook@v1
-              with:
-                  mdbook-version: '0.4.8'
-            - run: mdbook build docs
-
-            - name: Deploy
-              uses: peaceiris/actions-gh-pages@v3
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  publish_dir: ./docs/book/
+  build:
+    name: Build mdBook
+    runs-on: ubuntu-latest
+    if: github.repository == 'elkowar/eww'
+    steps:
+      # Checkout
+      - uses: actions/checkout@master
+      # Build widget documentation
+      - name: Use deno to build widget documentation
+        uses: denoland/setup-deno@main
+        with:
+          deno-version: "v1.x"
+      - run: deno run --allow-read --allow-write gen-docs.ts ./crates/eww/src/widgets/widget_definitions.rs ./crates/eww/src/config/inbuilt.rs
+      # Build & deploy
+      - name: build mdBook page
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.8'
+      - run: mdbook build docs
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book/


### PR DESCRIPTION
## Description
current state:
- clippy is installed in ci but never invoked
- `cargo check` is executed to check for warnings, but no actionis taken if some exist.

this pr changes both of these things.
clippy is used and if there is a warning or a lint, ci fails.

## Additional Notes
- ci should fail for the first commit, i'll push a fix once that happened (worked as expected).
- it might be worth splitting up things in the workflows so that they can run in parallel.
- i am against ci modifying code.
- i might look into applying some changes from #590

## Checklist
- [x] I added my changes to CHANGELOG.md, if appropriate.
*i don't think this applies here*
- [x] I used `cargo fmt` to automatically format all code before committing