### PR TITLE
feat: support empty string for safe access operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ## Unreleased
 
+### BREAKING CHANGES
+- #1176 changed safe access (`?.`) behavior:
+  Attempting to index in an empty JSON string (`'""'`) is now an error.
+
 ### Fixes
 - Re-enable some scss features (By: w-lfchen)
 - Fix and refactor nix flake (By: w-lfchen)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `flip-x`, `flip-y`, `vertical` options to the graph widget to determine its direction
 - Add `transform-origin-x`/`transform-origin-y` properties to transform widget (By: mario-kr)
 - Add keyboard support for button presses (By: julianschuler)
+- Support empty string for safe access operator (By: ModProg)
 
 ## [0.6.0] (21.04.2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ## Unreleased
 
 ### BREAKING CHANGES
-- #1176 changed safe access (`?.`) behavior:
+- [#1176](https://github.com/elkowar/eww/pull/1176) changed safe access (`?.`) behavior:
   Attempting to index in an empty JSON string (`'""'`) is now an error.
 
 ### Fixes

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -566,7 +566,7 @@ mod tests {
         safe_access_to_existing(r#"{ "a": { "b": 2 } }.a?.b"#) => Ok(DynVal::from(2)),
         safe_access_to_missing(r#"{ "a": { "b": 2 } }.b?.b"#) => Ok(DynVal::from(&serde_json::Value::Null)),
         safe_access_to_empty(r#"""?.test"#) => Ok(DynVal::from(&serde_json::Value::Null)),
-        safe_access_to_empty_json_string(r#"'""'?.test"#) => Ok(DynVal::from(&serde_json::Value::Null)),
+        safe_access_to_empty_json_string(r#"'""'?.test"#) => Err(super::EvalError::CannotIndex("\"\"".to_string())),
         safe_access_index_to_existing(r#"[1, 2]?.[1]"#) => Ok(DynVal::from(2)),
         safe_access_index_to_missing(r#""null"?.[1]"#) => Ok(DynVal::from(&serde_json::Value::Null)),
         safe_access_index_to_non_indexable(r#"32?.[1]"#) => Err(super::EvalError::CannotIndex("32".to_string())),

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -285,11 +285,6 @@ impl SimplExpr {
                             .unwrap_or(&serde_json::Value::Null);
                         Ok(DynVal::from(indexed_value).at(*span))
                     }
-                    // TODO decide if this should be removed
-                    // this would be a json string in a string: '""'
-                    serde_json::Value::String(val) if val.is_empty() && is_safe => {
-                        Ok(DynVal::from(&serde_json::Value::Null).at(*span))
-                    }
                     serde_json::Value::Null if is_safe => Ok(DynVal::from(&serde_json::Value::Null).at(*span)),
                     _ => Err(EvalError::CannotIndex(format!("{}", val)).at(*span)),
                 }

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -28,8 +28,8 @@ Supported currently are the following features:
     - if the left side is `""` or a JSON `null`, then returns the right side,
       otherwise evaluates to the left side.
 - Safe Access operator (`?.`) or (`?.[index]`)
-    - if the left side is an empty string a JSON `null`, then return `null`. Otherwise,
-      attempt to index. Note that indexing an empty JSON string (`'""'`) is an error here.
+    - if the left side is an empty string or a JSON `null`, then return `null`. Otherwise,
+      attempt to index. Note that indexing an empty JSON string (`'""'`) is an error.
     - This can still cause an error to occur if the left hand side exists but is
       not an object or an array.
       (`Number` or `String`).

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -28,10 +28,10 @@ Supported currently are the following features:
     - if the left side is `""` or a JSON `null`, then returns the right side,
       otherwise evaluates to the left side.
 - Safe Access operator (`?.`) or (`?.[index]`)
-    - if the left side is `""` or a JSON `null`, then return `null`. Otherwise,
-      attempt to index.
+    - if the left side is an empty string a JSON `null`, then return `null`. Otherwise,
+      attempt to index. Note that indexing an empty JSON string (`'""'`) is an error here.
     - This can still cause an error to occur if the left hand side exists but is
-      not an object.
+      not an object or an array.
       (`Number` or `String`).
 - conditionals (`condition ? 'value' : 'other value'`)
 - numbers, strings, booleans and variable references (`12`, `'hi'`, `true`, `some_variable`)


### PR DESCRIPTION
## Description
- Supersedes #629
resolves it's changes requested [here](https://github.com/elkowar/eww/pull/629#issuecomment-1445115831)
- closes #1209

## Additional Notes
This contains the breaking change of no longer supporting safe access for JSON strings (noted in the changelog).

## Checklist

- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
