### PR TITLE
Export magic constants during server initialization

### DIFF
--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -33,7 +33,6 @@ pub fn initialize_server<B: DisplayBackend>(
     log::info!("Loading paths: {}", &paths);
 
     let read_config = config::read_from_eww_paths(&paths);
-
     let eww_config = match read_config {
         Ok(config) => config,
         Err(err) => {
@@ -41,6 +40,10 @@ pub fn initialize_server<B: DisplayBackend>(
             config::EwwConfig::default()
         }
     };
+
+    for (name, definition) in config::inbuilt::get_magic_constants(&paths) {
+        std::env::set_var(name.0, definition.initial_value.0);
+    }
 
     cleanup_log_dir(paths.get_log_dir())?;
 


### PR DESCRIPTION
## Description

I was thinking about https://github.com/elkowar/eww/issues/1165 and being able to access the variables within `defvar`, `deflisten` and `defpoll` doesn't really make sense most of the time since they constantly update and there is much trickery involved. So instead why not export the magic constants as environmental variables by default. Makes sense, I suppose

Closes https://github.com/elkowar/eww/issues/1165

## Usage

N/A

### Showcase

![30 08 2024_00-55-54](https://github.com/user-attachments/assets/5edce1c0-ce04-46f3-a654-75ecc49f114b)

## Additional Notes

I also wanted to add some docs regarding this pr and some others where I forgot to do so. Although, `docs/src/magic-vars.md` seems to be almost empty and it doesn't match https://elkowar.github.io/eww/magic-vars.html. I also checked the prs with freshly added features, like `:fill-svg` attribute, but it doesn't change any docs. Still, the website reflects the changes. Am I missing something? Please point me in the right direction

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [] All widgets I've added are correctly documented.
- [] I added my changes to CHANGELOG.md, if appropriate.
- [] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
