### PR TITLE
fix: demote two logging statements to debug

### DIFF
--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -58,10 +58,10 @@ fn main() {
     let use_wayland = opts.force_wayland || detected_wayland;
     #[cfg(all(feature = "wayland", feature = "x11"))]
     let result = if use_wayland {
-        log::info!("Running on wayland. force_wayland={}, detected_wayland={}", opts.force_wayland, detected_wayland);
+        log::debug!("Running on wayland. force_wayland={}, detected_wayland={}", opts.force_wayland, detected_wayland);
         run::<display_backend::WaylandBackend>(opts, eww_binary_name)
     } else {
-        log::info!("Running on X11. force_wayland={}, detected_wayland={}", opts.force_wayland, detected_wayland);
+        log::debug!("Running on X11. force_wayland={}, detected_wayland={}", opts.force_wayland, detected_wayland);
         run::<display_backend::X11Backend>(opts, eww_binary_name)
     };
 

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -57,7 +57,7 @@ pub fn initialize_server<B: DisplayBackend>(
 ┏━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃Initializing eww daemon┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━┛
-    "#
+"#
     );
 
     simple_signal::set_handler(&[simple_signal::Signal::Int, simple_signal::Signal::Term], move |_| {


### PR DESCRIPTION
## Description
~~noticed~~ got annoyed by this while testing #1179.
i don't think this is intended behavior:
```bash
$ eww get foo
 2024-08-30T15:12:35.798Z INFO  eww > Running on wayland. force_wayland=false, detected_wayland=true
true
```
when running eww with `--debug`, the line is still printed so this should be fine

also removes some unnecessary whitespace from a raw string literal
## Checklist
- [x] I used `cargo fmt` to automatically format all code before committing