### PR TITLE
feat: button improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `min` and `max` function calls to simplexpr (By: ovalkonia)
 - Add `flip-x`, `flip-y`, `vertical` options to the graph widget to determine its direction
 - Add `transform-origin-x`/`transform-origin-y` properties to transform widget (By: mario-kr)
+- Add keyboard support for button presses (By: julianschuler)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -801,26 +801,26 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
     // Support :hover selector
     gtk_widget.connect_enter_notify_event(|gtk_widget, evt| {
         if evt.detail() != NotifyType::Inferior {
-            gtk_widget.clone().set_state_flags(gtk::StateFlags::PRELIGHT, false);
+            gtk_widget.set_state_flags(gtk::StateFlags::PRELIGHT, false);
         }
         glib::Propagation::Proceed
     });
 
     gtk_widget.connect_leave_notify_event(|gtk_widget, evt| {
         if evt.detail() != NotifyType::Inferior {
-            gtk_widget.clone().unset_state_flags(gtk::StateFlags::PRELIGHT);
+            gtk_widget.unset_state_flags(gtk::StateFlags::PRELIGHT);
         }
         glib::Propagation::Proceed
     });
 
     // Support :active selector
     gtk_widget.connect_button_press_event(|gtk_widget, _| {
-        gtk_widget.clone().set_state_flags(gtk::StateFlags::ACTIVE, false);
+        gtk_widget.set_state_flags(gtk::StateFlags::ACTIVE, false);
         glib::Propagation::Proceed
     });
 
     gtk_widget.connect_button_release_event(|gtk_widget, _| {
-        gtk_widget.clone().unset_state_flags(gtk::StateFlags::ACTIVE);
+        gtk_widget.unset_state_flags(gtk::StateFlags::ACTIVE);
         glib::Propagation::Proceed
     });
 
@@ -942,7 +942,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
             onrightclick: as_string = ""
         ) {
             gtk_widget.add_events(gdk::EventMask::BUTTON_PRESS_MASK);
-            connect_signal_handler!(gtk_widget, gtk_widget.connect_button_press_event(move |_, evt| {
+            connect_signal_handler!(gtk_widget, gtk_widget.connect_button_release_event(move |_, evt| {
                 match evt.button() {
                     1 => run_command(timeout, &onclick, &[] as &[&str]),
                     2 => run_command(timeout, &onmiddleclick, &[] as &[&str]),
@@ -1193,8 +1193,7 @@ fn build_gtk_stack(bargs: &mut BuilderArgs) -> Result<gtk::Stack> {
 
 const WIDGET_NAME_TRANSFORM: &str = "transform";
 /// @widget transform
-/// @desc A widget that applies transformations to its content. They are applied in the following
-/// order: rotate->translate->scale)
+/// @desc A widget that applies transformations to its content. They are applied in the following order: rotate -> translate -> scale
 fn build_transform(bargs: &mut BuilderArgs) -> Result<Transform> {
     let w = Transform::new();
     def_widget!(bargs, _g, w, {

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -518,7 +518,7 @@ fn build_gtk_input(bargs: &mut BuilderArgs) -> Result<gtk::Entry> {
 
 const WIDGET_NAME_BUTTON: &str = "button";
 /// @widget button
-/// @desc A button
+/// @desc A button containing any widget as it's child. Events are triggered on release.
 fn build_gtk_button(bargs: &mut BuilderArgs) -> Result<gtk::Button> {
     let gtk_widget = gtk::Button::new();
 
@@ -526,11 +526,11 @@ fn build_gtk_button(bargs: &mut BuilderArgs) -> Result<gtk::Button> {
         prop(
             // @prop timeout - timeout of the command. Default: "200ms"
             timeout: as_duration = Duration::from_millis(200),
-            // @prop onclick - a command that get's run when the button is clicked
+            // @prop onclick - command to run when the button is activated either by leftclicking or keyboard
             onclick: as_string = "",
-            // @prop onmiddleclick - a command that get's run when the button is middleclicked
+            // @prop onmiddleclick - command to run when the button is middleclicked
             onmiddleclick: as_string = "",
-            // @prop onrightclick - a command that get's run when the button is rightclicked
+            // @prop onrightclick - command to run when the button is rightclicked
             onrightclick: as_string = ""
         ) {
             // animate button upon right-/middleclick (if gtk theme supports it)
@@ -934,11 +934,11 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
         prop(
             // @prop timeout - timeout of the command. Default: "200ms"
             timeout: as_duration = Duration::from_millis(200),
-            // @prop onclick - a command that get's run when the button is clicked
+            // @prop onclick - command to run when the widget is clicked
             onclick: as_string = "",
-            // @prop onmiddleclick - a command that get's run when the button is middleclicked
+            // @prop onmiddleclick - command to run when the widget is middleclicked
             onmiddleclick: as_string = "",
-            // @prop onrightclick - a command that get's run when the button is rightclicked
+            // @prop onrightclick - command to run when the widget is rightclicked
             onrightclick: as_string = ""
         ) {
             gtk_widget.add_events(gdk::EventMask::BUTTON_PRESS_MASK);


### PR DESCRIPTION
## Description
- supersedes #640 (that pr can be closed)
- buttons can be activated using the keyboard now
- if buttons play animations on click (catppuccin gtk theme for example), these are now played when they are right-/middleclicked as well
- buttons and eventboxes now consistently activate on key/button release
- some more cleanup in `widget_definitions.rs`

## Usage
currently supported keys:
- space
- return/enter

### Showcase
here's the config i tested with:
```
(defvar left 0)
(defvar mid 0)
(defvar right 0)
(defwindow example
  :monitor 0
  :focusable true
  :geometry (geometry
    :width "100%"
    :height "30px"
    :anchor "top center"
  )
  (button
    :onclick "eww update left=${left+1}"
    :onmiddleclick "eww update mid=${mid+1}"
    :onrightclick "eww update right=${right+1}; eww close example"
    "l: ${left}, m: ${mid}, r: ${right}"
  ))
```

## Additional Notes
we could achieve a bit better performance if we don't want the fancy animation support.
i think the trade-off is worth it, but if you (the person reading this) think differently, feel free to comment. testing is also appreciated

### :warning: help wanted :warning:
i've attempted to implement this logic for eventboxes as well and failed, i don't think this is possible for those, but i'm not sure.
i'd appreaciate it a lot if someone could investigate this further (in a new pr so that this one can be merged)

## Checklist

- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
