### PR TITLE
fix: improve scope handling

### DIFF
--- a/crates/eww/src/state/scope_graph.rs
+++ b/crates/eww/src/state/scope_graph.rs
@@ -220,6 +220,9 @@ impl ScopeGraph {
             let listener = Rc::new(listener);
             for required_var in &listener.needed_variables {
                 scope.listeners.entry(required_var.clone()).or_default().push(listener.clone());
+                // debug print: if this number grows indefinetly, something is wrong, otherwise this shows that there is activity
+                // TODO: remove
+                log::info!("{:?} listeners for {required_var}", scope.listeners.get(&required_var.clone()).map(|x| x.len()));
             }
 
             let required_variables = self.lookup_variables_in_scope(scope_index, &listener.needed_variables)?;

--- a/crates/eww/src/state/scope_graph.rs
+++ b/crates/eww/src/state/scope_graph.rs
@@ -220,9 +220,6 @@ impl ScopeGraph {
             let listener = Rc::new(listener);
             for required_var in &listener.needed_variables {
                 scope.listeners.entry(required_var.clone()).or_default().push(listener.clone());
-                // debug print: if this number grows indefinetly, something is wrong, otherwise this shows that there is activity
-                // TODO: remove
-                log::info!("{:?} listeners for {required_var}", scope.listeners.get(&required_var.clone()).map(|x| x.len()));
             }
 
             let required_variables = self.lookup_variables_in_scope(scope_index, &listener.needed_variables)?;


### PR DESCRIPTION
## Description
i hate state.

this pr aims to close #992 and close #794
there are architectural issues which cause the behavior described in the issue

basically, the `CustomWidgetInvocation.scope` field is only set once and then used for the scopes of children widgets. since it is never updated, it will never change, but this is needed when variables update.

## Additional Notes
this should be tested well to prevent introducing a regression here.
### if you are reading this, please test this with your configs and report whether the changes broke anything or if everything still works

## Checklist
- [x] I added my changes to CHANGELOG.md, if appropriate.
  *i don't think this is noteworthy enough*
- [x] I used `cargo fmt` to automatically format all code before committing
- [x] clean up warnings that result from the changes