### PR TITLE
fix: improve escaping in yuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tokio-util",
- "unescape",
+ "unescaper",
  "wait-timeout",
  "x11rb",
  "yuck",
@@ -2933,10 +2933,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "unescape"
-version = "0.1.0"
+name = "unescaper"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
+checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -3092,7 +3095,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ sysinfo = "0.31.2"
 thiserror = "1.0"
 tokio-util = "0.7.11"
 tokio = { version = "1.39.2", features = ["full"] }
-unescape = "0.1"
+unescaper = "0.1"
 wait-timeout = "0.2"
 zbus = { version = "4.4.0", default-features = false, features = ["tokio"] }
 

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -54,6 +54,6 @@ simple-signal.workspace = true
 sysinfo = { workspace = true }
 tokio-util.workspace = true
 tokio = { workspace = true, features = ["full"] }
-unescape.workspace = true
+unescaper.workspace = true
 wait-timeout.workspace = true
 zbus = { workspace = true, default-features = false, features = ["tokio"] }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -992,7 +992,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
                 }
             };
 
-            let text = unescaper::unescape(&text)?;
+            let text = if text.contains("\\u") { unescaper::unescape(&text)? } else { text };
             let text = if unindent { util::unindent(&text) } else { text };
             gtk_widget.set_text(&text);
         },

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -992,7 +992,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
                 }
             };
 
-            let text = unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))?;
+            let text = unescaper::unescape(&text)?;
             let text = if unindent { util::unindent(&text) } else { text };
             gtk_widget.set_text(&text);
         },


### PR DESCRIPTION
## Description

currently, everything has to be escaped twice due to the (extremely outdated) `unescape` crate being run over text after all other processing has already happened
this pr, when opened, aims to:
- use a newer crate, `unescaper`, or find a better solution
- close #1117 
- close #1193 

## Additional Notes

this might introduce breaking changes, don't know yet.
we should probably evaluate how to best approach this; at the time of opening this pr as a draft, the implementation is very dumb.
i just want to get this idea out there and iterate over it, hopefully improving things in the process

## Checklist

- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
