### PR TITLE
feat: add `raw-output` for `jq`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 
 ### Features
 - Add OnDemand support for focusable on wayland (By: GallowsDove)
+- Add jq `raw-output` support (By: RomanHargrave)
 - Update rust toolchain to 1.81.0 (By: w-lfchen)
 - Add `:fill-svg` and `:preserve-aspect-ratio` properties to images (By: hypernova7, w-lfchen)
 - Add `:truncate` property to labels, disabled by default (except in cases where truncation would be enabled in version `0.5.0` and before) (By: Rayzeq).

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -600,5 +600,9 @@ mod tests {
         lazy_evaluation_or(r#"true || "null".test"#) => Ok(DynVal::from(true)),
         lazy_evaluation_elvis(r#""test"?: "null".test"#) => Ok(DynVal::from("test")),
         jq_basic_index(r#"jq("[7,8,9]", ".[0]")"#) => Ok(DynVal::from(7)),
+        jq_raw_arg(r#"jq("[ \"foo\" ]", ".[0]", "r")"#) => Ok(DynVal::from("foo")),
+        jq_empty_arg(r#"jq("[ \"foo\" ]", ".[0]", "")"#) => Ok(DynVal::from(r#""foo""#)),
+        jq_invalid_arg(r#"jq("[ \"foo\" ]", ".[0]", "hello")"#) => Ok(DynVal::from(r#""foo""#)),
+        jq_no_arg(r#"jq("[ \"foo\" ]", ".[0]")"#) => Ok(DynVal::from(r#""foo""#)),
     }
 }

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -47,14 +47,17 @@ Supported currently are the following features:
     - `degtorad(number)`: Converts a number from degrees to radians
     - `radtodeg(number)`: Converts a number from radians to degrees
     - `replace(string, regex, replacement)`: Replace matches of a given regex in a string
-	- `search(string, regex)`: Search for a given regex in a string (returns array)
-	- `matches(string, regex)`: check if a given string matches a given regex (returns bool)
-	- `captures(string, regex)`: Get the captures of a given regex in a string (returns array)
-	- `strlength(value)`: Gets the length of the string
+  - `search(string, regex)`: Search for a given regex in a string (returns array)
+  - `matches(string, regex)`: check if a given string matches a given regex (returns bool)
+  - `captures(string, regex)`: Get the captures of a given regex in a string (returns array)
+  - `strlength(value)`: Gets the length of the string
     - `substring(string, start, length)`: Return a substring of given length starting at the given index
-	- `arraylength(value)`: Gets the length of the array
-	- `objectlength(value)`: Gets the amount of entries in the object
-	- `jq(value, jq_filter_string)`: run a [jq](https://stedolan.github.io/jq/manual/) style command on a json value. (Uses [jaq](https://crates.io/crates/jaq) internally).
+  - `arraylength(value)`: Gets the length of the array
+  - `objectlength(value)`: Gets the amount of entries in the object
+  - `jq(value, jq_filter_string)`: run a [jq](https://jqlang.github.io/jq/manual/) style command on a json value. (Uses [jaq](https://crates.io/crates/jaq) internally).
+  - `jq(value, jq_filter_string, args)`: Emulate command line flags for jq, see [the docs](https://jqlang.github.io/jq/manual/#invoking-jq) on invoking jq for details. Invalid flags are silently ignored.
+    Currently supported flags:
+    - `"r"`: If the result is a string, it won't be formatted as a JSON string. The equivalent jq flag is `--raw-output`.
   - `get_env(string)`: Gets the specified enviroment variable
   - `formattime(unix_timestamp, format_str, timezone)`: Gets the time in a given format from UNIX timestamp.
      Check [chrono's documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) for more


### PR DESCRIPTION
## Description

- closes #745
- supersedes #952 (can be closed when this pr is open)
- uses the syntax proposed [here](https://github.com/elkowar/eww/issues/745#issuecomment-1569714183)
- backwards compatible
- some small and basic test cases included

## Usage

`jq(<json>, <filters>, <flags>)`

`r` is currently the only supported flag, flags can be left out


## Checklist

- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
