### PR TITLE
feat: add subcommand to force-poll variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix wayland monitor names support (By: dragonnn)
 
 ### Features
+- Add `eww poll` subcommand to force-poll a variable (By: kiana-S)
 - Update rust toolchain to 1.81.0 (By: w-lfchen)
 - Add `:fill-svg` and `:preserve-aspect-ratio` properties to images (By: hypernova7, w-lfchen)
 - Add `:truncate` property to labels, disabled by default (except in cases where truncation would be enabled in version `0.5.0` and before) (By: Rayzeq).

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -98,6 +98,16 @@ pub enum ActionWithServer {
         mappings: Vec<(VarName, DynVal)>,
     },
 
+    /// Update a polling variable using its script.
+    ///
+    /// This will force the variable to be updated even if its
+    /// automatic polling is disabled.
+    #[command(name = "poll")]
+    Poll {
+        /// Variables to be polled
+        names: Vec<VarName>,
+    },
+
     /// Open the GTK debugger
     #[command(name = "inspector", alias = "debugger")]
     OpenInspector,
@@ -254,6 +264,7 @@ impl ActionWithServer {
     pub fn into_daemon_command(self) -> (app::DaemonCommand, Option<daemon_response::DaemonResponseReceiver>) {
         let command = match self {
             ActionWithServer::Update { mappings } => app::DaemonCommand::UpdateVars(mappings),
+            ActionWithServer::Poll { names } => app::DaemonCommand::PollVars(names),
             ActionWithServer::OpenInspector => app::DaemonCommand::OpenInspector,
 
             ActionWithServer::KillServer => app::DaemonCommand::KillServer,

--- a/crates/eww/src/script_var_handler.rs
+++ b/crates/eww/src/script_var_handler.rs
@@ -196,7 +196,7 @@ impl PollVarHandler {
     }
 }
 
-fn run_poll_once(var: &PollScriptVar) -> Result<DynVal> {
+pub fn run_poll_once(var: &PollScriptVar) -> Result<DynVal> {
     match &var.command {
         VarSource::Shell(span, command) => {
             script_var::run_command(command).map_err(|e| anyhow!(create_script_var_failed_warn(*span, &var.name, &e.to_string())))

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -209,6 +209,9 @@ and thus are the perfect choice for showing your time, date, as well as other bi
 You can also specify an initial-value. This should prevent eww from waiting for the result of a given command during startup, thus
 making the startup time faster.
 
+To externally update a polling variable, `eww update` can be used like with basic variables to assign a value.
+You can also call `eww poll` to poll the variable outside of its usual interval, or even while it isn't running at all.
+
 **Listening variables (`deflisten`)**
 
 ```lisp


### PR DESCRIPTION
## Description

This PR adds a subcommand to the CLI to manually poll a polling variable:

```sh
eww poll [NAMES]...
```

This command will force the variable to be polled outside of its interval. It will also ignore `:run-while` conditions.
An error will be thrown if the variable isn't defined with `defpoll` (or if it doesn't exist, obviously).

Resolves #1005

## Additional Notes

This is my first time contributing, and I haven't been able to fully ensure that this code works as intended. Suggestions and bug fixes would be greatly appreciated.

## Checklist

- [x] I added my changes to CHANGELOG.md.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
