### PR TITLE
Avoid recreating windows when only `duration` changes

### DIFF
--- a/crates/eww/src/window_arguments.rs
+++ b/crates/eww/src/window_arguments.rs
@@ -87,4 +87,15 @@ impl WindowArguments {
 
         Ok(local_variables)
     }
+
+    // Compares all values except `duration`, since it's not used by the window itself
+    pub fn can_reuse_window_with_args(&self, other: &Self) -> bool {
+        self.window_name == other.window_name
+            && self.instance_id == other.instance_id
+            && self.anchor == other.anchor
+            && self.args == other.args
+            && self.monitor == other.monitor
+            && self.pos == other.pos
+            && self.size == other.size
+    }
 }


### PR DESCRIPTION
## Description

Avoid recreating windows when only `duration` changes, and instead only updates the window close timer.
This avoids possible flicker with windows such as OSDs. The logic to do this was added in #263 but broke when durations were added.
Fixes #260.  

## Usage

N/A

### Showcase

N/A, but here's my OSD that was flickering (WIP, haven't figured out the scss to remove the margin above the progress):

![image](https://github.com/user-attachments/assets/de28d51b-3e94-4211-86a7-f8ee73748229)

## Additional Notes

N/A

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented. (N/A)
- [x] I added my changes to CHANGELOG.md, if appropriate. (N/A)
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes. (N/A)
- [x] I used `cargo fmt` to automatically format all code before committing
