### PR TITLE
Render image widgets correctly on HiDPI displays when the display's window scale is not equal to 1.

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -13,6 +13,7 @@ use gdk::{ModifierType, NotifyType};
 use glib::translate::FromGlib;
 use gtk::{self, glib, prelude::*, DestDefaults, TargetEntry, TargetList};
 use gtk::{gdk, pango};
+use gtk::{cairo, gdk::ffi::gdk_cairo_surface_create_from_pixbuf};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 
@@ -591,6 +592,7 @@ fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
         // @prop preserve-aspect-ratio - whether to keep the aspect ratio when resizing an image. Default: true, false doesn't work for all image types
         // @prop fill-svg - sets the color of svg images
         prop(path: as_string, image_width: as_i32 = -1, image_height: as_i32 = -1, preserve_aspect_ratio: as_bool = true, fill_svg: as_string = "") {
+
             if !path.ends_with(".svg") && !fill_svg.is_empty() {
                 log::warn!("Fill attribute ignored, file is not an svg image");
             }
@@ -599,9 +601,11 @@ fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
                 let pixbuf_animation = gtk::gdk_pixbuf::PixbufAnimation::from_file(std::path::PathBuf::from(path))?;
                 gtk_widget.set_from_animation(&pixbuf_animation);
             } else {
-                let pixbuf;
+                let scale = gtk_widget.scale_factor();
+                let pixbuf: gtk::gdk_pixbuf::Pixbuf;
+
                 // populate the pixel buffer
-                if path.ends_with(".svg") && !fill_svg.is_empty() {
+                if path.ends_with(".svg") && !fill_svg.is_empty() { // render with fill
                     let svg_data = std::fs::read_to_string(std::path::PathBuf::from(path.clone()))?;
                     // The fastest way to add/change fill color
                     let svg_data = if svg_data.contains("fill=") {
@@ -612,12 +616,25 @@ fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
                         reg.replace(&svg_data, &format!("<svg fill=\"{}\"", fill_svg))
                     };
                     let stream = gtk::gio::MemoryInputStream::from_bytes(&gtk::glib::Bytes::from(svg_data.as_bytes()));
-                    pixbuf = gtk::gdk_pixbuf::Pixbuf::from_stream_at_scale(&stream, image_width, image_height, preserve_aspect_ratio, None::<&gtk::gio::Cancellable>)?;
+                    pixbuf = gtk::gdk_pixbuf::Pixbuf::from_stream_at_scale(&stream, image_width * scale, image_height * scale, preserve_aspect_ratio, None::<&gtk::gio::Cancellable>)?;
                     stream.close(None::<&gtk::gio::Cancellable>)?;
                 } else {
-                    pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(std::path::PathBuf::from(path), image_width, image_height, preserve_aspect_ratio)?;
+                    pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(std::path::PathBuf::from(path), image_width * scale, image_height * scale, preserve_aspect_ratio)?;
+                    //gtk_widget.set_from_pixbuf(Some(&pixbuf));
                 }
-                gtk_widget.set_from_pixbuf(Some(&pixbuf));
+
+                // render to surface
+                let surface = unsafe {
+                    // gtk::cairo::Surface will destroy the underlying surface on drop
+                    let ptr = gdk_cairo_surface_create_from_pixbuf(
+                        pixbuf.as_ptr(),
+                        scale,
+                        std::ptr::null_mut(),
+                    );
+                    cairo::Surface::from_raw_full(ptr)?
+                };
+
+                gtk_widget.set_from_surface(Some(surface.as_ref()));
             }
         },
         // @prop icon - name of a theme icon


### PR DESCRIPTION
## Description

Fixes #761. 

This fix applies to high resolution displays (or any display where the user has set the display scale to something other than 100%). For example, imagine you want to render a 16x16 image (in yuck: `:image-height 16 :image-width 16`) at 2x scale. The resulting image will be 32x32 physical pixels on the display. If your image source has the fidelity (e.g. you have a >32x32 pixel PNG or an SVG), the resulting image should be sharp, but previously, it was being rendered at the _logical_ resolution (16x16) and upscaled to the physical resolution, creating a blurry image.

## Usage

No configuration changes. Images will simply be rendered at high resolution if possible.

### Showcase

Before and after:
![Screenshot from 2024-12-01 13-48-26](https://github.com/user-attachments/assets/43414c53-3b3d-40f9-99e3-82910c6239c0) ![Screenshot from 2024-12-01 13-54-54](https://github.com/user-attachments/assets/68c7e3a1-be95-420e-a713-41a8cccc73ba)


## Additional Notes

All of the practical code is taken from src/widgets/systray.rs. Thank you to whoever wrote that code! Also, I am relatively new to Rust, any comments on style etc. are welcome.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
