### PR TITLE
Create an LSP for yuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dbusmenu-glib"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,8 +2112,12 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 name = "lsp"
 version = "0.1.0"
 dependencies = [
+ "codespan-reporting",
+ "dashmap 6.1.0",
+ "eww_shared_util",
  "tokio",
  "tower-lsp",
+ "yuck",
 ]
 
 [[package]]
@@ -3300,7 +3318,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "httparse",
  "lsp-types",

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+dashmap = "6.1.0"
 tokio.workspace = true
 tower-lsp = "0.20.0"
+yuck = { path = "../yuck"}
+eww_shared_util = { path = "../eww_shared_util"}
+codespan-reporting.workspace = true

--- a/crates/lsp/src/documents.rs
+++ b/crates/lsp/src/documents.rs
@@ -1,0 +1,120 @@
+use dashmap::{
+    mapref::{multiple::RefMulti, one::Ref},
+    DashMap,
+};
+use eww_shared_util::Span;
+use tower_lsp::lsp_types::Url;
+use yuck::{
+    config::{
+        file_provider::{FilesError, YuckFileProvider},
+        Config,
+    },
+    error::DiagError,
+    parser::ast::Ast,
+};
+
+#[derive(PartialEq, Clone)]
+pub enum DocSource {
+    String,
+    File(Url),
+}
+
+#[derive(Clone)]
+pub struct Document {
+    name: String,
+    text: String,
+    source: DocSource,
+    line_starts: Vec<usize>,
+    source_len_bytes: usize,
+}
+
+#[derive(Clone)]
+pub struct LspDocuments(pub DashMap<usize, Document>);
+
+impl LspDocuments {
+    pub fn new() -> Self {
+        Self(DashMap::new())
+    }
+
+    pub fn get_file(&self, url: &Url) -> Result<RefMulti<'_, usize, Document>, codespan_reporting::files::Error> {
+        self.0
+            .iter()
+            .find(|v| match &v.source {
+                DocSource::File(f) => f == url,
+                _ => false,
+            })
+            .ok_or(codespan_reporting::files::Error::FileMissing)
+    }
+
+    pub fn get_file_from_idx(&self, index: usize) -> Result<Ref<'_, usize, Document>, codespan_reporting::files::Error> {
+        self.0.get(&index).ok_or(codespan_reporting::files::Error::FileMissing)
+    }
+
+    pub fn insert_file(&self, doc: Document) -> usize {
+        let id = self.0.len();
+        self.0.insert(id, doc).ok_or(codespan_reporting::files::Error::FileMissing);
+        id
+    }
+
+    pub fn insert_string(&self, name: String, content: String) -> usize {
+        let line_starts: Vec<_> = codespan_reporting::files::line_starts(&content).collect();
+        let id = self.0.len();
+        self.0
+            .insert(id, Document { name, source: DocSource::String, line_starts, source_len_bytes: content.len(), text: content })
+            .ok_or(codespan_reporting::files::Error::FileMissing);
+        id
+    }
+
+    pub fn insert_url(&self, url: Url, content: String) -> usize {
+        let line_starts: Vec<_> = codespan_reporting::files::line_starts(&content).collect();
+        let doc = Document {
+            name: url.to_string(),
+            source: DocSource::File(url.clone()),
+            line_starts,
+            source_len_bytes: content.len(),
+            text: content,
+        };
+
+        if let Ok(res) = self.get_file(&url) {
+            let id = *res.key();
+            self.0.insert(id, doc);
+            return id;
+        }
+
+        let id = self.0.len();
+        self.0.insert(id, doc).ok_or(codespan_reporting::files::Error::FileMissing);
+        id
+    }
+}
+
+impl YuckFileProvider for LspDocuments {
+    fn load_yuck_file(&mut self, path: std::path::PathBuf) -> Result<(Span, Vec<Ast>), FilesError> {
+        let file_content = std::fs::read_to_string(&path)?;
+        let line_starts = codespan_reporting::files::line_starts(&file_content).collect();
+
+        // TODO this is very bad and very stupid
+        let source = match Url::from_file_path(&path) {
+            Ok(v) => DocSource::File(v),
+            Err(_) => DocSource::String,
+        };
+
+        let document = Document {
+            name: path.display().to_string(),
+            text: file_content.clone(),
+            line_starts,
+            source_len_bytes: file_content.len(),
+            source,
+        };
+        let file_id = self.insert_file(document);
+        Ok(yuck::parser::parse_toplevel(file_id, file_content)?)
+    }
+
+    fn load_yuck_str(&mut self, name: String, content: String) -> Result<(Span, Vec<Ast>), DiagError> {
+        let file_id = self.insert_string(name, content.clone());
+        yuck::parser::parse_toplevel(file_id, content)
+    }
+
+    fn unload(&mut self, id: usize) {
+        self.0.remove(&id);
+    }
+}

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -1,8 +1,23 @@
+use std::sync::{Arc, Mutex};
+
+use dashmap::DashMap;
+use documents::LspDocuments;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::{lsp_types::*, Client, LanguageServer};
+use yuck::config::Config;
+
+mod documents;
+
+use yuck::error::DiagError;
+use yuck::parser::parse_toplevel;
+
+pub type ArcM<T> = Arc<Mutex<T>>;
 
 pub struct Backend {
     pub client: Client,
+    documents: LspDocuments,
+    config: ArcM<Option<Config>>,
+    errors: ArcM<Vec<DiagError>>,
 }
 
 #[tower_lsp::async_trait]
@@ -13,7 +28,68 @@ impl LanguageServer for Backend {
             server_info: None,
         })
     }
+
     async fn shutdown(&self) -> Result<()> {
-        todo!()
+        Ok(())
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client.log_message(MessageType::INFO, "server initialized!").await;
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        self.change_document(TextDocumentItem {
+            uri: params.text_document.uri,
+            version: Some(params.text_document.version),
+            text: params.text_document.text,
+        })
+        .await;
+    }
+
+    async fn did_change(&self, mut params: DidChangeTextDocumentParams) {
+        self.change_document(TextDocumentItem {
+            uri: params.text_document.uri,
+            version: Some(params.text_document.version),
+            text: params.content_changes.swap_remove(0).text,
+        })
+        .await;
+    }
+}
+
+pub struct TextDocumentItem {
+    uri: Url,
+    text: String,
+    version: Option<i32>,
+}
+
+impl Backend {
+    pub fn new(client: Client) -> Self {
+        Self { client, documents: LspDocuments::new(), config: Default::default(), errors: Default::default() }
+    }
+
+    async fn change_document(&self, doc: TextDocumentItem) {
+        let file_id = self.documents.insert_url(doc.uri, doc.text.clone());
+        let mut new_errors = Vec::new();
+
+        let mut errors = self.errors.lock().unwrap();
+        let mut config = self.config.lock().unwrap();
+
+        let mut new_documents = self.documents.clone();
+        *config = match parse_toplevel(file_id, doc.text).map(|(_, asts)| Config::generate(&mut new_documents, asts)) {
+            Ok(Ok(v)) => Some(v),
+            Err(e) | Ok(Err(e)) => {
+                new_errors.push(e);
+                None
+            }
+        };
+        *errors = new_errors;
+
+        // TODO this is extremely stupid, but I need to do this so I don't mutate self.
+        // A solution that doesn't need to mutate `self.documents` would be ideal, but
+        // `Config::generate` needs to mutate the documents. Unsure how best to handle this
+        self.documents.0.clear();
+        new_documents.0.into_iter().for_each(|v| {
+            self.documents.0.insert(v.0, v.1);
+        });
     }
 }

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -6,7 +6,7 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::build(|client| Backend { client }).finish();
+    let (service, socket) = LspService::build(|client| Backend::new(client)).finish();
 
     Server::new(stdin, stdout, socket).serve(service).await;
 }


### PR DESCRIPTION
## Description
Closes #1232.

Features of the LSP (will) include

- autocomplete for widgets and widget's variables
- hover documentation for builtin widgets
- diagnostic messages for any errors
- goto definition for user-made widgets
- auto formatting
- Document aware syntax highlighting 
    - Treesitter grammar exists, this would allow for more syntax highlighting possibilities, perhaps even allowing for syntax highlighting inside `(literal)` expressions.


## Additional Notes

I am far from finished for now.

The goals of this draft PR is 
1. To make sure my handling of yuck configuration is correct.
2. To discuss future implementation of LSP features, as I believe some things will need to be altered to allow the LSP to have sufficient data to operate.

Check the top comment for further discussion

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
