### PR TITLE
Add :escape property to label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `transform-origin-x`/`transform-origin-y` properties to transform widget (By: mario-kr)
 - Add keyboard support for button presses (By: julianschuler)
 - Support empty string for safe access operator (By: ModProg)
+- Add `:escape` property to label. Determines weather escape sequences are interpreted in the `:text` property. (By: silicon-salamander)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -965,12 +965,13 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
 
     def_widget!(bargs, _g, gtk_widget, {
         // @prop text - the text to display
+        // @prop escape - whether to interpret escape sequences in the text
         // @prop truncate - whether to truncate text (or pango markup). If `show-truncated` is `false`, or if `limit-width` has a value, this property has no effect and truncation is enabled.
         // @prop limit-width - maximum count of characters to display
         // @prop truncate-left - whether to truncate on the left side
         // @prop show-truncated - show whether the text was truncated. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
         // @prop unindent - whether to remove leading spaces
-        prop(text: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true) {
+        prop(text: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true, escape: as_bool = true) {
             let text = if show_truncated {
                 // gtk does weird thing if we set max_width_chars to i32::MAX
                 if limit_width == i32::MAX {
@@ -1005,7 +1006,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
                 }
             };
 
-            let text = unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))?;
+            let text = if escape { unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))? } else { text };
             let text = if unindent { util::unindent(&text) } else { text };
             gtk_widget.set_text(&text);
         },


### PR DESCRIPTION
## Description

Add `:escape` property to the label widget in order to disable interpreting escape sequences. Defaults to true.

## Usage

```yuck
(label :class "window-title"
  :escape false
  :text {title} ; could contain any text that I don't want interpreted
)
```

### Showcase

With `:escape true` the window title on my bar shows newlines and expands the bar.
![screenshot_2024-12-17_12:12:51](https://github.com/user-attachments/assets/725a6d4a-a773-432a-995c-51c7427b9452)

With `:escape false` the window title correctly displays `\n` as literal text.
![screenshot_2024-12-17_12:12:25](https://github.com/user-attachments/assets/a263a4ec-583e-471f-8838-7cb974f187e0)


## Additional Notes

I'm not sure if I need to add documentation anywhere else. Let me know if I do.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
