### PR TITLE
`powi`/`powf` simplexpr functions

### DIFF
--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -345,6 +345,22 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
             }
             _ => Err(EvalError::WrongArgCount(name.to_string())),
         },
+        "powi" => match args.as_slice() {
+            [num, n] => {
+                let num = num.as_f64()?;
+                let n = n.as_i32()?;
+                Ok(DynVal::from(f64::powi(num, n)))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
+        "powf" => match args.as_slice() {
+            [num, n] => {
+                let num = num.as_f64()?;
+                let n = n.as_f64()?;
+                Ok(DynVal::from(f64::powf(num, n)))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
         "sin" => match args.as_slice() {
             [num] => {
                 let num = num.as_f64()?;

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -43,6 +43,7 @@ Supported currently are the following features:
     - `round(number, decimal_digits)`: Round a number to the given amount of decimals
     - `sin(number)`, `cos(number)`, `tan(number)`, `cot(number)`: Calculate the trigonometric value of a given number in **radians**
     - `min(a, b)`, `max(a, b)`: Get the smaller or bigger number out of two given numbers
+    - `powi(num, n)`, `powf(num, n)`: Raise number `num` to power `n`. `powi` expects `n` to be of type `i32`
     - `degtorad(number)`: Converts a number from degrees to radians
     - `radtodeg(number)`: Converts a number from radians to degrees
     - `replace(string, regex, replacement)`: Replace matches of a given regex in a string


### PR DESCRIPTION
## Description

Yep, `powi`/`powf`, why not

Resolves https://github.com/elkowar/eww/issues/1226

## Usage

In the showcase

### Showcase

![23-12-24 at 23:08:48](https://github.com/user-attachments/assets/063d24d4-0926-450b-8c17-7bfea4fe6cf4)

## Additional Notes

Sooo, it's two separate expressions. They can be reduced down to a single one, that acts like `powf`. I just though it sometimes miiight be useful to have two of them. Just shrink it down to one expression if that's more appropriate

## Checklist

- [x] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing