### PR TITLE
Fixing examples.md

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -7,4 +7,4 @@ An eww bar configuration:
 
 A demo on how to declare and use data structures:
 
-![Data structure example](/examples/data-structures/data-structures-preview.png)
+![Data structure example](https://github.com/elkowar/eww/raw/master/examples/data-structures/data-structures-preview.png)


### PR DESCRIPTION
Error for the path load of the image for the data structure example
![image](https://github.com/user-attachments/assets/a6fe989a-3b94-434a-b652-6ce2d0151c6a)

## Description
Changing the relative path usage for a full path for the error of the relative path how can't load in the html

## Usage
Change the relative path for a full path usage of the example of data-structures

### Showcase
This it's the corrected view( I modify the path in the develop tools of the browser )
![image](https://github.com/user-attachments/assets/f284028f-0b84-4587-9529-da8793df266f)