### PR TITLE
fix: get_locale follows posix standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix values in the `EWW_NET` variable (By: mario-kr)
 - Fix the gtk `expander` widget (By: ovalkonia)
 - Fix wayland monitor names support (By: dragonnn)
-- `get_locale` now follows POSIX standard for locale selection (By: mirhahn)
+- `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
 
 ### Features
 - Add OnDemand support for focusable on wayland (By: GallowsDove)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix values in the `EWW_NET` variable (By: mario-kr)
 - Fix the gtk `expander` widget (By: ovalkonia)
 - Fix wayland monitor names support (By: dragonnn)
+- `get_locale` now follows POSIX standard for locale selection (By: mirhahn)
 
 ### Features
 - Add OnDemand support for focusable on wayland (By: GallowsDove)

--- a/crates/eww_shared_util/src/locale.rs
+++ b/crates/eww_shared_util/src/locale.rs
@@ -1,11 +1,12 @@
 use chrono::Locale;
 use std::env::var;
 
-/// Returns the `Locale` enum based on the `LC_TIME` environment variable.
+/// Returns the `Locale` enum based on the `LC_ALL`, `LC_TIME`, and `LANG` environment variables in
+/// that order, which is the precedence order prescribed by Section 8.2 of POSIX.1-2008.
 /// If the environment variable is not defined or is malformed use the POSIX locale.
 pub fn get_locale() -> Locale {
-    let locale_string: String =
-        var("LC_TIME").map_or_else(|_| "C".to_string(), |v| v.split(".").next().unwrap_or("C").to_string());
+    let locale_env = var("LC_ALL").or_else(|_| var("LC_TIME").or_else(|_| var("LANG")));
+    let locale_string: String = locale_env.map_or_else(|_| "C".to_string(), |v| v.split(".").next().unwrap_or("C").to_string());
 
     match (&*locale_string).try_into() {
         Ok(x) => x,

--- a/crates/eww_shared_util/src/locale.rs
+++ b/crates/eww_shared_util/src/locale.rs
@@ -2,14 +2,11 @@ use chrono::Locale;
 use std::env::var;
 
 /// Returns the `Locale` enum based on the `LC_ALL`, `LC_TIME`, and `LANG` environment variables in
-/// that order, which is the precedence order prescribed by Section 8.2 of POSIX.1-2008.
+/// that order, which is the precedence order prescribed by Section 8.2 of POSIX.1-2017.
 /// If the environment variable is not defined or is malformed use the POSIX locale.
 pub fn get_locale() -> Locale {
-    let locale_env = var("LC_ALL").or_else(|_| var("LC_TIME").or_else(|_| var("LANG")));
-    let locale_string: String = locale_env.map_or_else(|_| "C".to_string(), |v| v.split(".").next().unwrap_or("C").to_string());
-
-    match (&*locale_string).try_into() {
-        Ok(x) => x,
-        Err(_) => Locale::POSIX,
-    }
+    var("LC_ALL")
+        .or_else(|_| var("LC_TIME"))
+        .or_else(|_| var("LANG"))
+        .map_or(Locale::POSIX, |v| v.split('.').next().and_then(|x| x.try_into().ok()).unwrap_or_default())
 }


### PR DESCRIPTION
## Description

This change brings the behavior of the `get_locale` function in the `eww_shared_util` in line with the POSIX standard. Previously, the function relied exclusively on the `LC_TIME` environment variable. However, this variable is almost never set because it is technically only needed if different locales are used for different categories.

The changed function uses the environment variables `LC_ALL`, `LC_TIME`, and `LANG` in this specific order of preference. This order is prescribed by [Section 8.2 of IEEE Std 1003.1-2008](https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/basedefs/V1_chap08.html#tag_08_02) as mandatory for implementations of that version of the POSIX standard, so this should blend in well in all environments that follow that standard.

## Additional Notes

I have classified this as a non-breaking change. It technically alters behavior on systems where both `LC_ALL` and `LC_TIME` are set because `LC_ALL` will now take precedence, but there are no API changes.

The precise method of locale determination does not seem to be mentioned in the documentation, so I did not change anything there.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [X] All widgets I've added are correctly documented.
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [X] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
