### PR TITLE
add `log` to expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `transform-origin-x`/`transform-origin-y` properties to transform widget (By: mario-kr)
 - Add keyboard support for button presses (By: julianschuler)
 - Support empty string for safe access operator (By: ModProg)
+- Add `log` function calls to simplexpr (By: topongo)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -500,6 +500,14 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
             })),
             _ => Err(EvalError::WrongArgCount(name.to_string())),
         },
+        "log" => match args.as_slice() {
+            [num, n] => {
+                let num = num.as_f64()?;
+                let n = n.as_f64()?;
+                Ok(DynVal::from(f64::log(num, n)))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
 
         _ => Err(EvalError::UnknownFunction(name.to_string())),
     }

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -44,6 +44,7 @@ Supported currently are the following features:
     - `sin(number)`, `cos(number)`, `tan(number)`, `cot(number)`: Calculate the trigonometric value of a given number in **radians**
     - `min(a, b)`, `max(a, b)`: Get the smaller or bigger number out of two given numbers
     - `powi(num, n)`, `powf(num, n)`: Raise number `num` to power `n`. `powi` expects `n` to be of type `i32`
+    - `log(num, n)`: Calculate the base `n` logarithm of `num`. `num`, `n` and return type are `f64`
     - `degtorad(number)`: Converts a number from degrees to radians
     - `radtodeg(number)`: Converts a number from radians to degrees
     - `replace(string, regex, replacement)`: Replace matches of a given regex in a string


### PR DESCRIPTION
## Description

add the `log` function to eww expressions. mainly used (at least in my experience) to calculate ordes of magnitude in metrics. for example, i used it for choosing between B/s, KB/s, MB/s for my network traffic widget.

## Usage

already added usage to the documentation, citing myself:
> `log(num, n)`: Calculate the base `n` logarithm of `num`. `num`, `n` and return type are of type `f64`

### Showcase

![image](https://github.com/user-attachments/assets/f92f3f44-7827-4a29-b474-dc1767272567)
![image](https://github.com/user-attachments/assets/e2920bee-7567-4fc8-bc4f-9b230fd02218)

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] ~~I used `cargo fmt` to automatically format all code before committing~~ (i did but it wasn't necessary ;P)

Edit: changelog entry