### PR TITLE
feat(eventbox-keypress-command): First implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add keyboard support for button presses (By: julianschuler)
 - Support empty string for safe access operator (By: ModProg)
 - Add `log` function calls to simplexpr (By: topongo)
+- Add support for `:keypress` for eventbox (By: AlexandrePicavet)
 
 ## [0.6.0] (21.04.2024)
 


### PR DESCRIPTION
## Description

I wanted to be able to close my window by pressing the `Escape` key, but I could not find a way to do that, so I added a way to handle `keypress` to execute a command on the `eventbox` widget.

## Usage

The `keypress` property is written like this:

```
Enter |> echo 'You pressed the Enter key'
───── ── ────────────────────────────────
  │   │    └─── The command
  │   └─── The separator
  └─── The key to press
```

Here's an example of how to use it:

```lisp
(defwindow my-window
	:monitor 0
	:stacking "fg"
	:exclusive false
	:focusable true
	:geometry (geometry
		:anchor "top left"
		:x 0
		:y 0
		:width "100%"
		:height "100%"
	)
	(eventbox
		:keypress "Escape |> eww close my-window"
		(label :text "Press the Escape key to close the window")
	)
)
```

### Showcase

https://github.com/user-attachments/assets/4bfa0afc-1949-41c8-8ebd-9339b158ca59

## Additional Notes

I have some questions:
- I did not have any idea which syntax you would prefer for this feature, so if you have a better one, I can implement it.
- As shown on the video above, I added a debug log on `keypress` telling the user which key has been pressed and which widget caught this event. Do you think it is useful, or do you want me to remove it ?
- It is my first rust contribution, so I may have done some things not quite up to the standards, if so, I'll happily fix them.

## Checklist

- [ ] All widgets I've added are correctly documented. <- I don't know where to document my additions.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes. <- I could not find this directory.
- [x] I used `cargo fmt` to automatically format all code before committing.
