### PR TITLE
Improve multi-monitor handling under wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix wayland monitor names support (By: dragonnn)
 - Load systray items that are registered without a path (By: Kage-Yami)
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
+- Improve multi-monitor handling under wayland (By: bkueng)
 
 ### Features
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -153,7 +153,6 @@ async fn wait_for_monitor_model() {
     let display = gdk::Display::default().expect("could not get default display");
     let start = std::time::Instant::now();
     loop {
-        while gtk::events_pending() && !gtk::main_iteration_do(false) {}
         let all_monitors_set =
             (0..display.n_monitors()).all(|i| display.monitor(i).and_then(|monitor| monitor.model()).is_some());
         if all_monitors_set {

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -292,7 +292,7 @@ impl ActionWithServer {
                 })
             }
             ActionWithServer::CloseWindows { windows } => {
-                return with_response_channel(|sender| app::DaemonCommand::CloseWindows { windows, sender });
+                return with_response_channel(|sender| app::DaemonCommand::CloseWindows { windows, auto_reopen: false, sender });
             }
             ActionWithServer::Reload => return with_response_channel(app::DaemonCommand::ReloadConfigAndCss),
             ActionWithServer::ListWindows => return with_response_channel(app::DaemonCommand::ListWindows),


### PR DESCRIPTION
When a monitor gets disconnected, the destroy event of all associated windows gets called, and the window gets removed.

This PR changes that behavior: the window is still closed but the configuration is kept using the existing reload mechanism. In addition, a callback is added to listen for new monitors, triggering a reload when a new monitor gets connected.

This logic also reloads already running windows, which has a positive and negative effect:
- positive: if currently running e.g. on the second monitor specified in the list, the window can get moved to the first monitor
- negative: if reloading starts it on the same monitor, it gets reset (e.g. graphs)

I also had to work around an issue: the monitor model is not yet available immediately when a new monitor callback triggers. Waiting in the callback does not help (I tried 10 seconds). However, waiting outside, it always became available after 10ms.

Tested with a dual monitor setup under KDE through a combinations of:
- enabling/disabling individual monitors
- switching between monitors
- specifying a specific monitor in the yuck config
- specifying a list of specific monitors in the yuck config

In all these cases the behavior is as expected, and the widget gets loaded on the first available monitor (or stays unloaded until one becomes available).
It also works when opening a window without any of the configured monitors being available.

There is one remaining error from GTK when closing the window: `GLib-GObject-CRITICAL **: 20:06:05.912: ../gobject/gsignal.c:2684: instance '0x55a4ab4be2d0' has no handler with id '136'`.
 This comes from the `self.gtk_window.disconnect(handler_id)` call. To prevent that we'd have to reset `destroy_event_handler_id`.

I have not tested under X11, and I'm not sure if the behavior should be the same there.

Fixes https://github.com/elkowar/eww/issues/1158

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
