### PR TITLE
add lines and wrap-mode properties to label widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add keyboard support for button presses (By: julianschuler)
 - Support empty string for safe access operator (By: ModProg)
 - Add `log` function calls to simplexpr (By: topongo)
+- Add `:lines` property to label widget (By: vaporii)
 
 ## [0.6.0] (21.04.2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add keyboard support for button presses (By: julianschuler)
 - Support empty string for safe access operator (By: ModProg)
 - Add `log` function calls to simplexpr (By: topongo)
-- Add `:lines` property to label widget (By: vaporii)
+- Add `:lines` and `:wrap-mode` properties to label widget (By: vaporii)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -970,7 +970,8 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         // @prop truncate-left - whether to truncate on the left side
         // @prop show-truncated - show whether the text was truncated. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
         // @prop unindent - whether to remove leading spaces
-        prop(text: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true) {
+        // @prop lines - maximum number of lines to display (only works when `limit-width` has a value)
+        prop(text: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true, lines: as_i32 = -1) {
             let text = if show_truncated {
                 // gtk does weird thing if we set max_width_chars to i32::MAX
                 if limit_width == i32::MAX {
@@ -1007,6 +1008,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
 
             let text = unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))?;
             let text = if unindent { util::unindent(&text) } else { text };
+            gtk_widget.set_lines(lines);
             gtk_widget.set_text(&text);
         },
         // @prop markup - Pango markup to display

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -970,8 +970,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         // @prop truncate-left - whether to truncate on the left side
         // @prop show-truncated - show whether the text was truncated. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
         // @prop unindent - whether to remove leading spaces
-        // @prop lines - maximum number of lines to display (only works when `limit-width` has a value)
-        prop(text: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true, lines: as_i32 = -1) {
+        prop(text: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true, unindent: as_bool = true) {
             let text = if show_truncated {
                 // gtk does weird thing if we set max_width_chars to i32::MAX
                 if limit_width == i32::MAX {
@@ -1008,14 +1007,13 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
 
             let text = unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))?;
             let text = if unindent { util::unindent(&text) } else { text };
-            gtk_widget.set_lines(lines);
             gtk_widget.set_text(&text);
         },
         // @prop markup - Pango markup to display
         // @prop truncate - whether to truncate text (or pango markup). If `show-truncated` is `false`, or if `limit-width` has a value, this property has no effect and truncation is enabled.
         // @prop limit-width - maximum count of characters to display
         // @prop truncate-left - whether to truncate on the left side
-        // @prop show-truncated - show whether the text was truncatedd. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
+        // @prop show-truncated - show whether the text was truncated. Disabling it will also disable dynamic truncation (the labels won't be truncated more than `limit-width`, even if there is not enough space for them), and will completly disable truncation on pango markup.
         prop(markup: as_string, truncate: as_bool = false, limit_width: as_i32 = i32::MAX, truncate_left: as_bool = false, show_truncated: as_bool = true) {
             if (truncate || limit_width != i32::MAX) && show_truncated {
                 // gtk does weird thing if we set max_width_chars to i32::MAX
@@ -1052,6 +1050,14 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         prop(justify: as_string = "left") {
             gtk_widget.set_justify(parse_justification(&justify)?);
         },
+        // @prop wrap-mode - how text is wrapped. possible options: $wrap-mode
+        prop(wrap_mode: as_string = "word") {
+            gtk_widget.set_wrap_mode(parse_wrap_mode(&wrap_mode)?);
+        },
+        // @prop lines - maximum number of lines to display (only works when `limit-width` has a value)
+        prop(lines: as_i32 = -1) {
+            gtk_widget.set_lines(lines);
+        }
     });
     Ok(gtk_widget)
 }
@@ -1383,6 +1389,14 @@ fn parse_gravity(g: &str) -> Result<gtk::pango::Gravity> {
         "west" => gtk::pango::Gravity::West,
         "north" => gtk::pango::Gravity::North,
         "auto" => gtk::pango::Gravity::Auto,
+    }
+}
+
+/// @var wrap-mode - "word", "char"
+fn parse_wrap_mode(w: &str) -> Result<gtk::pango::WrapMode> {
+    enum_parse! { "wrap-mode", w,
+        "word" => gtk::pango::WrapMode::Word,
+        "char" => gtk::pango::WrapMode::Char
     }
 }
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1054,7 +1054,7 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
         prop(wrap_mode: as_string = "word") {
             gtk_widget.set_wrap_mode(parse_wrap_mode(&wrap_mode)?);
         },
-        // @prop lines - maximum number of lines to display (only works when `limit-width` has a value)
+        // @prop lines - maximum number of lines to display (only works when `limit-width` has a value). A value of -1 (default) disables the limit.
         prop(lines: as_i32 = -1) {
             gtk_widget.set_lines(lines);
         }


### PR DESCRIPTION
## Description

Add the `:lines` and `:wrap-mode` properties to the label widget. Used for setting the number of lines to display when wrapping is enabled, and how it should display wrapped text, respectively.

## Usage

To set the `lines` and `wrap-mode` properties, you could do something like this:
```
(label
  :text "this is some label text blah blkaghk kwjhndlkaj wbn akj hba jkhawbjakhjhawjkdbh jahbw ajkhbakjawja"
  :wrap true
  :limit-width 15
  :lines 4 ; the number of lines to display
  :wrap-mode "char" ; wraps on characters, ignoring words
)
```
This will look like the first image in the showcase below.

### Showcase

![line-wrap-example](https://github.com/user-attachments/assets/f6dc8367-127b-444b-8d13-289153af80bb)

## Additional Notes

When the label text contains newlines, they aren't interpreted as lines. This fix involves changing the implementation of newlines in labels, or implementing some janky fix elsewhere

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
