### PR TITLE
Add value-pos to scale widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Support empty string for safe access operator (By: ModProg)
 - Add `log` function calls to simplexpr (By: topongo)
 - Add `:lines` and `:wrap-mode` properties to label widget (By: vaporii)
+- Add `value-pos` to scale widget (By: ipsvn)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -459,7 +459,7 @@ fn build_gtk_scale(bargs: &mut BuilderArgs) -> Result<gtk::Scale> {
         // @prop draw-value - draw the value of the property
         prop(draw_value: as_bool = false) { gtk_widget.set_draw_value(draw_value) },
 
-        // @prop value-pos - position of the drawn value
+        // @prop value-pos - position of the drawn value. possible values: $position
         prop(value_pos: as_string) { gtk_widget.set_value_pos(parse_position_type(&value_pos)?) },
 
         // @prop round-digits - Sets the number of decimals to round the value to when it changes
@@ -1384,9 +1384,9 @@ fn parse_justification(j: &str) -> Result<gtk::Justification> {
     }
 }
 
-/// @var value-pos - "left", "right", "top", "bottom"
+/// @var position - "left", "right", "top", "bottom"
 fn parse_position_type(g: &str) -> Result<gtk::PositionType> {
-    enum_parse! { "gravity", g,
+    enum_parse! { "position", g,
         "left" => gtk::PositionType::Left,
         "right" => gtk::PositionType::Right,
         "top" => gtk::PositionType::Top,

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -459,6 +459,9 @@ fn build_gtk_scale(bargs: &mut BuilderArgs) -> Result<gtk::Scale> {
         // @prop draw-value - draw the value of the property
         prop(draw_value: as_bool = false) { gtk_widget.set_draw_value(draw_value) },
 
+        // @prop value-pos - position of the drawn value
+        prop(value_pos: as_string) { gtk_widget.set_value_pos(parse_position_type(&value_pos)?) },
+
         // @prop round-digits - Sets the number of decimals to round the value to when it changes
         prop(round_digits: as_i32 = 0) { gtk_widget.set_round_digits(round_digits) }
 
@@ -1378,6 +1381,16 @@ fn parse_justification(j: &str) -> Result<gtk::Justification> {
         "right" => gtk::Justification::Right,
         "center" => gtk::Justification::Center,
         "fill" => gtk::Justification::Fill,
+    }
+}
+
+/// @var value-pos - "left", "right", "top", "bottom"
+fn parse_position_type(g: &str) -> Result<gtk::PositionType> {
+    enum_parse! { "gravity", g,
+        "left" => gtk::PositionType::Left,
+        "right" => gtk::PositionType::Right,
+        "top" => gtk::PositionType::Top,
+        "bottom" => gtk::PositionType::Bottom,
     }
 }
 


### PR DESCRIPTION
## Description

Adds `value-pos` to the scale widget, to change the position of where the value on the scale is shown

## Usage

```
(scale
	:draw-value true
	:value-pos "right")
```

## Additional Notes

If I have done anything wrong with the documentation stuff (e.g. the var comment on the parse function) please let me know.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
