### PR TITLE
feat(simplexpr): add uppercase and lowercase functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `log` function calls to simplexpr (By: topongo)
 - Add `:lines` and `:wrap-mode` properties to label widget (By: vaporii)
 - Add `value-pos` to scale widget (By: ipsvn)
+- Add `uppercase` and `lowercase` functions for expressions (By: dod-101)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -508,6 +508,20 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
             }
             _ => Err(EvalError::WrongArgCount(name.to_string())),
         },
+        "uppercase" => match args.as_slice() {
+            [string] => {
+                let string = string.as_string()?;
+                Ok(DynVal::from(string.to_uppercase()))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
+        "lowercase" => match args.as_slice() {
+            [string] => {
+                let string = string.as_string()?;
+                Ok(DynVal::from(string.to_lowercase()))
+            }
+            _ => Err(EvalError::WrongArgCount(name.to_string())),
+        },
 
         _ => Err(EvalError::UnknownFunction(name.to_string())),
     }

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -68,3 +68,4 @@ Supported currently are the following features:
      Same as other `formattime`, but does not accept timezone. Instead, it uses system's local timezone.
      Check [chrono's documentation](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) for more
      information about format string.
+  - `uppercase(string)`, `lowercase(string)`: Convert a string to uppercase or lowercase


### PR DESCRIPTION
## Description

Add to functions `upercase(string)` & `lowercase(string)` to convert strings. 

## Usage

```lisp
  (label :text "${uppercase("word")}")
  (label :text "${lowercase("Word")}")
   
   (label
      :class "key-label"
      :text { osk_shift ? "${shift_letter ?: uppercase(letter)}" : "${letter}"}
   )
```


### Showcase

## Additional Notes

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
