### PR TITLE
feat: add a way to dinamically only change GTK CSS configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
 
 ### Features
+- Add `--onlycss` flag to `eww reload` (By: nwnbark)
 - Add `eww poll` subcommand to force-poll a variable (By: kiana-S)
 - Add OnDemand support for focusable on wayland (By: GallowsDove)
 - Add jq `raw-output` support (By: RomanHargrave)

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -174,7 +174,11 @@ pub enum ActionWithServer {
 
     /// Reload the configuration
     #[command(name = "reload", alias = "r")]
-    Reload,
+    Reload {
+        /// Only Reload the eww.(s)css file
+        #[arg(long = "onlycss")]
+        onlycss: bool,
+    },
 
     /// Kill the eww daemon
     #[command(name = "kill", alias = "k")]
@@ -294,7 +298,9 @@ impl ActionWithServer {
             ActionWithServer::CloseWindows { windows } => {
                 return with_response_channel(|sender| app::DaemonCommand::CloseWindows { windows, sender });
             }
-            ActionWithServer::Reload => return with_response_channel(app::DaemonCommand::ReloadConfigAndCss),
+            ActionWithServer::Reload { onlycss } => {
+                return with_response_channel(|sender| app::DaemonCommand::ReloadConfigAndCss { onlycss, sender });
+            }
             ActionWithServer::ListWindows => return with_response_channel(app::DaemonCommand::ListWindows),
             ActionWithServer::ListActiveWindows => return with_response_channel(app::DaemonCommand::ListActiveWindows),
             ActionWithServer::ShowState { all } => {

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -191,7 +191,9 @@ async fn run_filewatch<P: AsRef<Path>>(config_dir: P, evt_send: UnboundedSender<
         Ok(notify::Event { kind: notify::EventKind::Modify(_), paths, .. }) => {
             let relevant_files_changed = paths.iter().any(|path| {
                 let ext = path.extension().unwrap_or_default();
-                ext == "yuck" || ext == "scss" || ext == "css"
+                let skip = path.with_extension("").file_name().unwrap_or_default().to_str().expect("").ends_with("__");
+
+                !skip && (ext == "yuck" || ext == "scss" || ext == "css")
             });
             if relevant_files_changed {
                 if let Err(err) = tx.send(()) {

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -222,7 +222,7 @@ async fn run_filewatch<P: AsRef<Path>>(config_dir: P, evt_send: UnboundedSender<
                 // and eww being too fast, thus reading the file while it's empty.
                 // There should be some cleaner solution for this, but this will do for now.
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                evt_send.send(app::DaemonCommand::ReloadConfigAndCss(daemon_resp_sender))?;
+                evt_send.send(app::DaemonCommand::ReloadConfigAndCss { onlycss: false, sender: daemon_resp_sender })?;
                 tokio::spawn(async move {
                     match daemon_resp_response.recv().await {
                         Some(daemon_response::DaemonResponse::Success(_)) => log::info!("Reloaded config successfully"),

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -19,6 +19,8 @@ as well as most layout-related CSS properties such as flexbox, `float`, absolute
 To get started, you'll need to create two files: `eww.yuck` and `eww.scss` (or `eww.css`, if you prefer).
 These files must be placed under `$XDG_CONFIG_HOME/eww` (this is most likely `~/.config/eww`).
 
+Keep in mind that all `.yuck`, `.css` and `.scss` files on the config folder are monitored recursively. Any changes to these files will automatically trigger a reload of all the eww configuration, recreating all the windows on the process. If this behaviour is not desired see [Unmonitoring Files and Only Reloading GTK CSS](working_with_gtk.md).
+
 Now that those files are created, you can start writing your first widget!
 
 ## Creating your first window

--- a/docs/src/working_with_gtk.md
+++ b/docs/src/working_with_gtk.md
@@ -12,6 +12,8 @@ If you have **NO** clue about how to do CSS, check out some online guides or tut
 
 SCSS is _very_ close to CSS, so if you know CSS you'll have no problem learning SCSS.
 
+If you need to make specific CSS changes, such as modifying colors or font styles, without recreating all windows, use the `--onlycss` flag when reloading eww. Additionally, to complement this feature, you can append `__` to the filename to exclude it from monitoring like: `colors__.scss`, or simply use symlinks as an alternative.
+
 ## GTK-Debugger
 
 The debugger can be used for **a lot** of things, especially if something doesn't work or isn't styled right.


### PR DESCRIPTION
## Description

This PR adds a flag to only Reload the GTK CSS code:
```shell
eww reload --onlycss
``` 
The `--onlycss` flag will skip the parsing of any eww or yuck config, and only reload the scss config (It was practically already done).

Also adding a feature to not monitor any file which ends their filename with "__", to allow an easy way to "enable" this feature.

## Additional Notes

Basically, in case a file of '.scss' or '.css' is not on the config folder (symlinked), or their filename ends with "\_\_", they are not going to be watched or monitored for any changes, allowing for scripting, mostly done with the purpose of using pywal and i3 without the hassle of reserving areas so the layout doesn't flick on eww recreating windows, wasting cpu on reacreating and recalling all the scripts, etc.
I think a better method could be thought (instead of using the "__" at the end of filenames to ignore them), so i will gladly modify it if another method is more convenient or intuitive.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [X] I added my changes to CHANGELOG.md, if appropriate.
- [X] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
