### PR TITLE
Revert hot-reloading regressions

### DIFF
--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -217,10 +217,7 @@ impl<B: DisplayBackend> App<B> {
                                 .filter(|(win_id, ..)| win_id.is_empty() || win_id == id)
                                 .map(|(_, n, v)| (n.clone(), v.clone()))
                                 .collect();
-                            self.open_window(
-                                &WindowArguments::new_from_args(id.to_string(), config_name.clone(), window_args)?,
-                                false,
-                            )
+                            self.open_window(&WindowArguments::new_from_args(id.to_string(), config_name.clone(), window_args)?)
                         }
                     })
                     .filter_map(Result::err);
@@ -245,19 +242,16 @@ impl<B: DisplayBackend> App<B> {
                 let result = if should_toggle && is_open {
                     self.close_window(&instance_id)
                 } else {
-                    self.open_window(
-                        &WindowArguments {
-                            instance_id,
-                            window_name,
-                            pos,
-                            size,
-                            monitor,
-                            anchor,
-                            duration,
-                            args: args.unwrap_or_default().into_iter().collect(),
-                        },
-                        false,
-                    )
+                    self.open_window(&WindowArguments {
+                        instance_id,
+                        window_name,
+                        pos,
+                        size,
+                        monitor,
+                        anchor,
+                        duration,
+                        args: args.unwrap_or_default().into_iter().collect(),
+                    })
                 };
 
                 sender.respond_with_result(result)?;
@@ -391,13 +385,13 @@ impl<B: DisplayBackend> App<B> {
         Ok(())
     }
 
-    fn open_window(&mut self, window_args: &WindowArguments, dirty: bool) -> Result<()> {
+    fn open_window(&mut self, window_args: &WindowArguments) -> Result<()> {
         let instance_id = &window_args.instance_id;
         self.failed_windows.remove(instance_id);
         log::info!("Opening window {} as '{}'", window_args.window_name, instance_id);
 
         // if an instance of this is already running and arguments haven't change, only update duration
-        let reuse_window = if !dirty && self.open_windows.contains_key(instance_id) {
+        let reuse_window = if self.open_windows.contains_key(instance_id) {
             if self.instance_id_to_args.get(instance_id).is_some_and(|args| window_args.can_reuse_window_with_args(args)) {
                 true
             } else {
@@ -536,7 +530,7 @@ impl<B: DisplayBackend> App<B> {
             let window_arguments = self.instance_id_to_args.get(instance_id).with_context(|| {
                 format!("Cannot reopen window, initial parameters were not saved correctly for {instance_id}")
             })?;
-            self.open_window(&window_arguments.clone(), true)?;
+            self.open_window(&window_arguments.clone())?;
         }
         Ok(())
     }

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -390,24 +390,14 @@ impl<B: DisplayBackend> App<B> {
         self.failed_windows.remove(instance_id);
         log::info!("Opening window {} as '{}'", window_args.window_name, instance_id);
 
-        // if an instance of this is already running and arguments haven't change, only update duration
-        let reuse_window = if self.open_windows.contains_key(instance_id) {
-            if self.instance_id_to_args.get(instance_id).is_some_and(|args| window_args.can_reuse_window_with_args(args)) {
-                true
-            } else {
-                self.close_window(instance_id)?;
-                false
-            }
-        } else {
-            false
-        };
+        // if an instance of this is already running, close it
+        if self.open_windows.contains_key(instance_id) {
+            self.close_window(instance_id)?;
+        }
+
         self.instance_id_to_args.insert(instance_id.to_string(), window_args.clone());
 
         let open_result: Result<_> = (|| {
-            if reuse_window {
-                return Ok(());
-            }
-
             let window_name: &str = &window_args.window_name;
 
             let window_def = self.eww_config.get_window(window_name)?.clone();
@@ -464,50 +454,43 @@ impl<B: DisplayBackend> App<B> {
                 }
             }));
 
+            let duration = window_args.duration;
+            if let Some(duration) = duration {
+                let app_evt_sender = self.app_evt_send.clone();
+
+                let (abort_send, abort_recv) = futures::channel::oneshot::channel();
+
+                glib::MainContext::default().spawn_local({
+                    let instance_id = instance_id.to_string();
+                    async move {
+                        tokio::select! {
+                            _ = glib::timeout_future(duration) => {
+                                let (response_sender, mut response_recv) = daemon_response::create_pair();
+                                let command = DaemonCommand::CloseWindows { windows: vec![instance_id.clone()], sender: response_sender };
+                                if let Err(err) = app_evt_sender.send(command) {
+                                    log::error!("Error sending close window command to daemon after gtk window destroy event: {}", err);
+                                }
+                                _ = response_recv.recv().await;
+                            }
+                            _ = abort_recv => {}
+                        }
+                    }
+                });
+
+                if let Some(old_abort_send) = self.window_close_timer_abort_senders.insert(instance_id.to_string(), abort_send) {
+                    _ = old_abort_send.send(());
+                }
+            }
+
             self.open_windows.insert(instance_id.to_string(), eww_window);
             Ok(())
         })();
-
-        self.update_window_duration(instance_id, window_args.duration);
 
         if let Err(err) = open_result {
             self.failed_windows.insert(instance_id.to_string());
             Err(err).with_context(|| format!("failed to open window `{}`", instance_id))
         } else {
             Ok(())
-        }
-    }
-
-    fn update_window_duration(&mut self, instance_id: &str, duration: Option<std::time::Duration>) {
-        if let Some(duration) = duration {
-            let app_evt_sender = self.app_evt_send.clone();
-
-            let (abort_send, abort_recv) = futures::channel::oneshot::channel();
-
-            glib::MainContext::default().spawn_local({
-                let instance_id = instance_id.to_string();
-                async move {
-                    tokio::select! {
-                        _ = glib::timeout_future(duration) => {
-                            let (response_sender, mut response_recv) = daemon_response::create_pair();
-                            let command = DaemonCommand::CloseWindows { windows: vec![instance_id.clone()], sender: response_sender };
-                            if let Err(err) = app_evt_sender.send(command) {
-                                log::error!("Error sending close window command to daemon after gtk window destroy event: {}", err);
-                            }
-                            _ = response_recv.recv().await;
-                        }
-                        _ = abort_recv => {}
-                    }
-                }
-            });
-
-            if let Some(old_abort_send) = self.window_close_timer_abort_senders.insert(instance_id.to_string(), abort_send) {
-                _ = old_abort_send.send(());
-            }
-        } else {
-            if let Some(old_abort_send) = self.window_close_timer_abort_senders.remove(instance_id) {
-                _ = old_abort_send.send(());
-            }
         }
     }
 

--- a/crates/eww/src/window_arguments.rs
+++ b/crates/eww/src/window_arguments.rs
@@ -87,15 +87,4 @@ impl WindowArguments {
 
         Ok(local_variables)
     }
-
-    // Compares all values except `duration`, since it's not used by the window itself
-    pub fn can_reuse_window_with_args(&self, other: &Self) -> bool {
-        self.window_name == other.window_name
-            && self.instance_id == other.instance_id
-            && self.anchor == other.anchor
-            && self.args == other.args
-            && self.monitor == other.monitor
-            && self.pos == other.pos
-            && self.size == other.size
-    }
 }


### PR DESCRIPTION
This PR reverts the commits that introduced regressions in the behavior of hot-reloading.

- **Revert "Force recreating windows on config change (#1284)"**
- **Revert "Avoid recreating windows when only duration changes (#1236)"**
