### PR TITLE
Add warning for ':exclusive' with invalid anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
 
 ### Features
+- Add warning and docs for incompatible `:anchor` and `:exclusive` options
 - Add `eww poll` subcommand to force-poll a variable (By: kiana-S)
 - Add OnDemand support for focusable on wayland (By: GallowsDove)
 - Add jq `raw-output` support (By: RomanHargrave)

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -112,6 +112,13 @@ mod platform_wayland {
                 } else {
                     window.set_layer_shell_margin(gtk_layer_shell::Edge::Top, yoffset);
                 }
+                // https://github.com/elkowar/eww/issues/296
+                if window_init.backend_options.wayland.exclusive
+                    && geometry.anchor_point.x != AnchorAlignment::CENTER
+                    && geometry.anchor_point.y != AnchorAlignment::CENTER
+                {
+                    log::warn!("When ':exclusive true' the anchor has to include 'center', otherwise exlcusive won't work")
+                }
             }
             if window_init.backend_options.wayland.exclusive {
                 window.auto_exclusive_zone_enable();

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -89,7 +89,7 @@ Depending on if you are using X11 or Wayland, some additional properties exist:
 |    Property | Description                                                                                                                                                            |
 | ----------: |------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |  `stacking` | Where the window should appear in the stack. Possible values: `fg`, `bg`, `overlay`, `bottom`.                                                                         |
-| `exclusive` | Whether the compositor should reserve space for the window automatically. Either `true` or `false`.                                                                    |
+| `exclusive` | Whether the compositor should reserve space for the window automatically. Either `true` or `false`. If `true` `:anchor` has to include `center`.                       |
 | `focusable` | Whether the window should be able to be focused. This is necessary for any widgets that use the keyboard to work. Possible values: `none`, `exclusive` and `ondemand`. |
 | `namespace` | Set the wayland layersurface namespace eww uses. Accepts a `string` value.                                                                                             |
 


### PR DESCRIPTION
## Description

Fixes https://github.com/elkowar/eww/issues/969 by warning before window creation. Also updated the docs to mention this limitation.

## Additional Notes

I am unsure if this is the correct place for this. Maybe it would make sense to do this in the config parsing, so X11 users still get warnings that their config would not work correctly on wayland.
 
## Checklist

- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
