### PR TITLE
Fix crash on invalid formattime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to eww will be listed here, starting at changes since versio
   Attempting to index in an empty JSON string (`'""'`) is now an error.
 
 ### Fixes
+- Fix crash on invalid `formattime` format string (By: luca3s)
 - Fix crash on NaN or infinite graph value (By: luca3s)
 - Re-enable some scss features (By: w-lfchen)
 - Fix and refactor nix flake (By: w-lfchen)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,9 +501,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -511,7 +511,7 @@ dependencies = [
  "num-traits",
  "pure-rust-locales",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -3289,6 +3289,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"

--- a/crates/simplexpr/src/eval.rs
+++ b/crates/simplexpr/src/eval.rs
@@ -11,7 +11,6 @@ use eww_shared_util::{get_locale, Span, Spanned, VarName};
 use std::{
     collections::HashMap,
     convert::{Infallible, TryFrom, TryInto},
-    fmt::Write,
     str::FromStr,
     sync::Arc,
 };
@@ -505,8 +504,8 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
                         let format = format.as_string()?;
                         let delayed_format = t.format_localized(&format, get_locale());
                         let mut buffer = String::new();
-                        if write!(&mut buffer, "{delayed_format}").is_err() {
-                            return Err(EvalError::ChronoError("Invalid time formatting string".to_string() + &format));
+                        if delayed_format.write_to(&mut buffer).is_err() {
+                            return Err(EvalError::ChronoError("Invalid time formatting string: ".to_string() + &format));
                         }
                         buffer
                     }
@@ -518,8 +517,8 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
                     let format = format.as_string()?;
                     let delayed_format = t.format_localized(&format, get_locale());
                     let mut buffer = String::new();
-                    if write!(&mut buffer, "{delayed_format}").is_err() {
-                        return Err(EvalError::ChronoError("Invalid time formatting string".to_string() + &format));
+                    if delayed_format.write_to(&mut buffer).is_err() {
+                        return Err(EvalError::ChronoError("Invalid time formatting string: ".to_string() + &format));
                     }
                     buffer
                 }


### PR DESCRIPTION
## Description

Fixes https://github.com/elkowar/eww/issues/1290, by checking for an error when formatting with chrono.
Edit: Also updates chrono to use the [write_to](https://docs.rs/chrono/latest/chrono/format/struct.DelayedFormat.html#method.write_to) API.

## Additional Notes

~~If you would like i could also update chrono, which would allow to use the [write_to](https://docs.rs/chrono/latest/chrono/format/struct.DelayedFormat.html#method.write_to) method instead of the rust write! macro. This would probably be faster and it would be more obvious why there could be an error. This also would remove the need to import `fmt::Write`~~
Maybe this could be made into a function, but because the Chrono time objects are generic with different types of time this isn't obvious how to do, so i just didn't.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] I used `cargo fmt` to automatically format all code before committing
