### PR TITLE
fix systray: window gets unresponsive if app changes icon too fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to eww will be listed here, starting at changes since versio
   Attempting to index in an empty JSON string (`'""'`) is now an error.
 
 ### Fixes
+- Fix systray widget: bar gets unresponsive when application changes icon rapidly (By: 5ila5)
 - Fix crash on NaN or infinite graph value (By: luca3s)
 - Re-enable some scss features (By: w-lfchen)
 - Fix and refactor nix flake (By: w-lfchen)


### PR DESCRIPTION
fixes #1303

## Description

the systray widget would get stuck and not update the icons anymore. Clicking it would lead to the whole window/bar to not update anymore. This happens if apps update their icon very fast which leads to eww to request a new icon every time. It looks like dbus cannot keep up and just does not answer anymore which leads to eww waiting infinitely for an answer.

This PR tries to mitigate this by not updating the icon instantly if the last update was less than 100ms ago but register an "update request" which is checked every 100ms. This approach may not be ideal and I got it to crash like descriped above one time with the applied patch. But it seems not to happen very often anymore. 

This bug appeared for me when using Nextcloud as Nextcloud updates its icon very fast when syncing with a server (probably to display something like an animation)

## Additional Notes

- Mybe adding some additional timeout on the DBus messages may help solve this more elegantly but I could not get it to work very well
- My Rust knowledge is very limited, so I needed to use AI tools to help me write this, So the review should be extra detailed

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] (Not Relevant) All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] (Not Relevant) The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
