### PR TITLE
Update `--duration` when opening an existing window to get rid of the flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `value-pos` to scale widget (By: ipsvn)
 - Add `floor` and `ceil` function calls to simplexpr (By: wsbankenstein)
 
+### Notable fixes and other changes
+- Window will no longer be closed if `eww open` was called on an already opened window
+and timer set by the `--duration` option will be updated or removed (By: Elvyria)
+
 ## [0.6.0] (21.04.2024)
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ strsim = "0.11"
 strum = { version = "0.26", features = ["derive"] }
 sysinfo = "0.31.2"
 thiserror = "1.0"
-tokio-util = "0.7.11"
+tokio-util = "0.7.15"
 tokio = { version = "1.39.2", features = ["full"] }
 unescape = "0.1"
 wait-timeout = "0.2"

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -90,7 +90,7 @@ pub fn initialize_server<B: DisplayBackend>(
         css_provider: gtk::CssProvider::new(),
         script_var_handler,
         app_evt_send: ui_send.clone(),
-        window_close_timer_abort_senders: HashMap::new(),
+        window_close_timer_abort_tokens: HashMap::new(),
         paths,
         phantom: PhantomData,
     };


### PR DESCRIPTION
## Description

This is an alternative rewrite of #1120 that removes timer if no duration was provided per https://github.com/elkowar/eww/pull/1120#issuecomment-2308867930 and simplifies the code by utilizing [CancellationToken](https://docs.rs/tokio-util/0.7.15/tokio_util/sync/struct.CancellationToken.html) from `tokio-utils`, since the package is already here anyways.

* `select!` macro was used without `biased`, so no more RNG overhead.
* Got rid of a useless `String` clone.
* Bumps `tokio-util` version from `0.7.11` to `0.7.15` for [run_until_cancelled_owned](https://docs.rs/tokio-util/0.7.15/tokio_util/sync/struct.CancellationToken.html#method.run_until_cancelled_owned).

## Additional Notes

Fixes #892 
Closes #1120 

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
