### PR TITLE
fix openbsd battery: obtain statistics from sysctl, using OpenBSD's apm as fallback, and return an empty string on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Fix wayland monitor names support (By: dragonnn)
 - Load systray items that are registered without a path (By: Kage-Yami)
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
+- Fix crash on OpenBSD when trying to obtain battery information (By: spflaumer)
 
 ### Features
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options

--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -311,8 +311,8 @@ pub fn get_battery_capacity() -> Result<String> {
             String::from("")
         })
     } else {
-        // if all hope is lost, just return a dummy table, instead of crashing
-        Ok(String::from(r#"{"BAT0":{"status":"Unknown","capacity":0.0},"total_avg":0.0}"#))
+        // if all hope is lost, just return an empty string, instead of crashing
+        Ok(String::from(""))
     }
 }
 


### PR DESCRIPTION
## Description
Hello everyone,
eww currently crashes when launched on OpenBSD, as the output from OpenBSD's apm tool isn't similar to the one from FreeBSD, which has a slightly different format from FreeBSD (NetBSD could potentially suffer from the same issue).

I've thus written an OpenBSD specific battery statistics handler, which simply obtains the information from the sysctl interface to acpibat (with acpisbs currently lacking an implementation).

Additionally, the OpenBSD specific handler will return a dummy JSON string, instead of crashing outright, if it can't launch one of the two programs.

Also, this is the first time I've written anything serious in Rust, and only the second time I've written Rust at all, so the code is almost certainly terrible.

## Additional Notes
- only the acpibat driver code has been implemented and no fallback to apm is currently done when a battery that uses acpibat isn't discovered. (most likely, the only change necessary will be to remove `acpibat` from the regex, but since I don't have a system where the acpisbs driver would initialize I don't have a quick and easy way to confirm that they work the same way)
- some codepaths use .unwrap(), and will crash the whole daemon, even though a simple fallback to a dummy JSON string could be performed

## Checklist
- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
