### PR TITLE
Fix typo in widget definition documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Load systray items that are registered without a path (By: Kage-Yami)
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
 - Improve multi-monitor handling under wayland (By: bkueng)
+- Fix typo in widget definition documentation (By: Kn4ughty)
 
 ### Features
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -854,7 +854,7 @@ fn build_gtk_event_box(bargs: &mut BuilderArgs) -> Result<gtk::EventBox> {
             }));
         },
         // @prop timeout - timeout of the command. Default: "200ms"
-        // @prop onhoverlost - event to execute when the user losts hovers over the widget
+        // @prop onhoverlost - event to execute when the user loses hover over the widget
         prop(timeout: as_duration = Duration::from_millis(200), onhoverlost: as_string) {
             gtk_widget.add_events(gdk::EventMask::LEAVE_NOTIFY_MASK);
             connect_signal_handler!(gtk_widget, gtk_widget.connect_leave_notify_event(move |_, evt| {


### PR DESCRIPTION

## Description

Fix a small typo in `crates/eww/src/widgets/widget_definitions.rs`  for eventbox widget.
"when the user losts hovers" -> " when the user loses hover"

## Checklist

- [X] All widgets I've added are correctly documented.
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes. (what directory?)
- [X] I used `cargo fmt` to automatically format all code before committing
