### PR TITLE
feat: Add option to disable hot reloading config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `:lines` and `:wrap-mode` properties to label widget (By: vaporii)
 - Add `value-pos` to scale widget (By: ipsvn)
 - Add `floor` and `ceil` function calls to simplexpr (By: wsbankenstein)
+- Add `--no-hot-reload` option to disable hot reloading config (By: Kn4ughty)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -131,7 +131,7 @@ fn run<B: DisplayBackend>(opts: opts::Opt, eww_binary_name: String) -> Result<()
             if !opts.show_logs {
                 println!("Run `{} logs` to see any errors while editing your configuration.", eww_binary_name);
             }
-            let fork_result = server::initialize_server::<B>(paths.clone(), None, !opts.no_daemonize)?;
+            let fork_result = server::initialize_server::<B>(paths.clone(), None, !opts.no_daemonize, !opts.no_hot_reload)?;
             opts.no_daemonize || fork_result == ForkResult::Parent
         }
 
@@ -163,7 +163,7 @@ fn run<B: DisplayBackend>(opts: opts::Opt, eww_binary_name: String) -> Result<()
 
                     let (command, response_recv) = action.into_daemon_command();
                     // start the daemon and give it the command
-                    let fork_result = server::initialize_server::<B>(paths.clone(), Some(command), true)?;
+                    let fork_result = server::initialize_server::<B>(paths.clone(), Some(command), true, !opts.no_hot_reload)?;
                     let is_parent = fork_result == ForkResult::Parent;
                     if let (Some(recv), true) = (response_recv, is_parent) {
                         listen_for_daemon_response(recv);

--- a/crates/eww/src/opts.rs
+++ b/crates/eww/src/opts.rs
@@ -23,6 +23,7 @@ pub struct Opt {
     pub config_path: Option<std::path::PathBuf>,
     pub action: Action,
     pub no_daemonize: bool,
+    pub no_hot_reload: bool,
 }
 
 #[derive(Parser, Debug, Serialize, Deserialize, PartialEq)]
@@ -48,6 +49,10 @@ pub(super) struct RawOpt {
     /// Avoid daemonizing eww.
     #[arg(long = "no-daemonize", global = true)]
     no_daemonize: bool,
+
+    /// Disable hot reloading config changes
+    #[arg(long = "no-hot-reload", global = true)]
+    no_hot_reload: bool,
 
     /// Restart the daemon completely before running the command
     #[arg(long = "restart", global = true)]
@@ -225,8 +230,8 @@ impl Opt {
 
 impl From<RawOpt> for Opt {
     fn from(other: RawOpt) -> Self {
-        let RawOpt { log_debug, force_wayland, config, show_logs, no_daemonize, restart, action } = other;
-        Opt { log_debug, force_wayland, show_logs, restart, config_path: config, action, no_daemonize }
+        let RawOpt { log_debug, force_wayland, config, show_logs, no_daemonize, no_hot_reload, restart, action } = other;
+        Opt { log_debug, force_wayland, show_logs, restart, config_path: config, action, no_daemonize, no_hot_reload }
     }
 }
 


### PR DESCRIPTION
## Description

Disables the eww server from hot reloading with the flag `--no-hot-reload`.
If the flag is set, the `filewatch_join_handle` is set to a nop.

## Usage
`eww daemon --no-hot-reload`

Closes #1300

## Additional Notes

The `initialize_server` function now has 2 options being passed to it. Maybe the whole opts module should be passed instead. Lmk if I should implement that.

## Checklist

- [X] All widgets I've added are correctly documented.
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [X] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
