### PR TITLE
fix optional args for windows (fixes #1310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Load systray items that are registered without a path (By: Kage-Yami)
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
 - Improve multi-monitor handling under wayland (By: bkueng)
+- Fix optional arguments for windows (By: Ma_124)
 
 ### Features
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options


### PR DESCRIPTION
Instantiating a window with unset optional arguments currently leads to an error message.

```
(defwindow bar [?test] "Test")
```

```
$ eww open bar 
variables  unexpectedly defined when creating window with id 'bar'
```

This is PR fixes the issue by defaulting to an empty string for any optional argument. 
I also took the opportunity to quote any spurious arguments in the error message.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
