### PR TITLE
fix(system_stats): add missing regex lib

### DIFF
--- a/crates/eww/src/config/system_stats.rs
+++ b/crates/eww/src/config/system_stats.rs
@@ -1,4 +1,5 @@
 use crate::util::IterAverage;
+use crate::regex;
 use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
 use std::{fs::read_to_string, sync::Mutex};


### PR DESCRIPTION
Please follow this template, if applicable.

## Description

Hi, with latest version on BSD faced that the file of system stats missing regex import, without it doesn't build.

## Usage

When adding a widget or anything else that affects the configuration,
please provide a minimal example configuration snippet showcasing how to use it and

### Showcase

When adding widgets, please provide screenshots showcasing how your widget looks.
This is not strictly required, but strongly appreciated.

## Additional Notes

Anything else you want to add, such as remaining questions or explanations.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
