### PR TITLE
Add placeholder property to input widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `value-pos` to scale widget (By: ipsvn)
 - Add `floor` and `ceil` function calls to simplexpr (By: wsbankenstein)
 - Add `formatbytes` function calls to simplexpr (By: topongo)
+- Add `:placeholder` property to input widget (By: Kn4ughty)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -515,6 +515,10 @@ fn build_gtk_input(bargs: &mut BuilderArgs) -> Result<gtk::Entry> {
         // @prop password - if the input is obscured
         prop(password: as_bool = false) {
             gtk_widget.set_visibility(!password);
+        },
+        // @prop placeholder - placeholder text to show before typing
+        prop(placeholder: as_string) {
+            gtk_widget.set_placeholder_text(Some(&placeholder));
         }
     });
     Ok(gtk_widget)


### PR DESCRIPTION

## Description
Add `:placeholder` text property to input widget.

## Usage

`(input :placeholder "Add task")`

### Showcase
<img width="796" height="294" alt="image" src="https://github.com/user-attachments/assets/b22d6ad2-477a-49ed-9af2-9b941e811bea" />

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
