### PR TITLE
Proper escaping for string literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,6 +2711,7 @@ dependencies = [
  "strsim",
  "strum",
  "thiserror",
+ "unescape",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,6 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tokio-util",
- "unescape",
  "wait-timeout",
  "x11rb",
  "yuck",

--- a/crates/eww/Cargo.toml
+++ b/crates/eww/Cargo.toml
@@ -54,6 +54,5 @@ simple-signal.workspace = true
 sysinfo = { workspace = true }
 tokio-util.workspace = true
 tokio = { workspace = true, features = ["full"] }
-unescape.workspace = true
 wait-timeout.workspace = true
 zbus = { workspace = true, default-features = false, features = ["tokio"] }

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -1008,7 +1008,6 @@ fn build_gtk_label(bargs: &mut BuilderArgs) -> Result<gtk::Label> {
                 }
             };
 
-            let text = unescape::unescape(&text).context(format!("Failed to unescape label text {}", &text))?;
             let text = if unindent { util::unindent(&text) } else { text };
             gtk_widget.set_text(&text);
         },

--- a/crates/simplexpr/Cargo.toml
+++ b/crates/simplexpr/Cargo.toml
@@ -33,6 +33,7 @@ static_assertions.workspace = true
 strsim.workspace = true
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
+unescape.workspace = true
 
 
 [build-dependencies]

--- a/docs/src/expression_language.md
+++ b/docs/src/expression_language.md
@@ -36,7 +36,7 @@ Supported currently are the following features:
       not an object or an array.
       (`Number` or `String`).
 - conditionals (`condition ? 'value' : 'other value'`)
-- numbers, strings, booleans and variable references (`12`, `'hi'`, `true`, `some_variable`)
+- numbers, strings (with support to escaping), booleans and variable references (`12`, `'hi'`, `true`, `some_variable`)
 - json access (`object.field`, `array[12]`, `object["field"]`)
     - for this, the object/array value needs to refer to a variable that contains a valid json string.
 - some function calls:


### PR DESCRIPTION
## Description

Applies unescaping for string literals in the lexer.
No things have been added to implement this, since it makes use of the `unescape` crate that was used in a different place.

## Usage

"next line\ntabbed\tspace using hex code\x20"

## Additional Notes

I'm not sure if this is a fix or a feature, so for now I haven't added anything to `CHANGELOG.md`

## Checklist

- [x] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
