### PR TITLE
feat: onfocus and onfocuslost in eventbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `value-pos` to scale widget (By: ipsvn)
 - Add `floor` and `ceil` function calls to simplexpr (By: wsbankenstein)
 - Add `formatbytes` function calls to simplexpr (By: topongo)
+- Add `onfocus` and `onfocuslost` properties to eventbox (By: RelativeAlbatros)
 
 ## [0.6.0] (21.04.2024)
 


### PR DESCRIPTION
## Description
I'm currently working on implementing focus event handling. this code is not yet compilable.
I need assistance with checking whether a widget gains or loses focus using the EventFocus struck in order to set the state flags.

## Usage

possible usecase: close a widget/window when it loses focus
(defwidget example-widget :onhoverlost "${EWW_CMD} close example-widget"

## Additional notes

I couldn't find the documentation file 

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
