### PR TITLE
Fix nth children in loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Load systray items that are registered without a path (By: Kage-Yami)
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
 - Improve multi-monitor handling under wayland (By: bkueng)
+- Fix nth children of custom widgets not appering when widget is created by a for loop (By: UnnaturalTwilight)
 
 ### Features
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options

--- a/crates/eww/src/widgets/build_widget.rs
+++ b/crates/eww/src/widgets/build_widget.rs
@@ -293,6 +293,7 @@ fn build_children_special_widget(
         // This should be a custom gtk::Bin subclass,..
         let child_container = gtk::Box::new(Orientation::Horizontal, 0);
         child_container.set_homogeneous(true);
+        child_container.show();
         gtk_container.add(&child_container);
 
         tree.register_listener(


### PR DESCRIPTION
## Description
Fixes children of custom widgets that use the nth property never appearing if the custom widget is placed in a for loop.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
