### PR TITLE
feat: use lockfiles to determine if daemon is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Improve multi-monitor handling under wayland (By: bkueng)
 
 ### Features
+- Use a lock file to determine if a daemon is already running, instead of pinging (By: paperluigis)
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options
 - Add `eww poll` subcommand to force-poll a variable (By: kiana-S)
 - Add OnDemand support for focusable on wayland (By: GallowsDove)

--- a/crates/eww/src/main.rs
+++ b/crates/eww/src/main.rs
@@ -119,20 +119,20 @@ fn run<B: DisplayBackend>(opts: opts::Opt, eww_binary_name: String) -> Result<()
             false
         }
 
-        // make sure that there isn't already a Eww daemon running.
-        opts::Action::Daemon if check_server_running(paths.get_ipc_socket_file()) => {
-            eprintln!("Eww server already running.");
-            true
-        }
         opts::Action::Daemon => {
-            log::info!("Initializing Eww server. ({})", paths.get_ipc_socket_file().display());
-            let _ = std::fs::remove_file(paths.get_ipc_socket_file());
+            if let Some(lock_file) = server::try_lock_file(&paths)? {
+                log::info!("Initializing Eww server. ({})", paths.get_ipc_socket_file().display());
+                let _ = std::fs::remove_file(paths.get_ipc_socket_file());
 
-            if !opts.show_logs {
-                println!("Run `{} logs` to see any errors while editing your configuration.", eww_binary_name);
+                if !opts.show_logs {
+                    println!("Run `{} logs` to see any errors while editing your configuration.", eww_binary_name);
+                }
+                let fork_result = server::initialize_server::<B>(paths.clone(), None, !opts.no_daemonize, lock_file)?;
+                opts.no_daemonize || fork_result == ForkResult::Parent
+            } else {
+                eprintln!("Eww server already running.");
+                true
             }
-            let fork_result = server::initialize_server::<B>(paths.clone(), None, !opts.no_daemonize)?;
-            opts.no_daemonize || fork_result == ForkResult::Parent
         }
 
         opts::Action::WithServer(ActionWithServer::KillServer) => {
@@ -144,33 +144,32 @@ fn run<B: DisplayBackend>(opts: opts::Opt, eww_binary_name: String) -> Result<()
 
         // a running daemon is necessary for this command
         opts::Action::WithServer(action) => {
-            // attempt to just send the command to a running daemon
-            match handle_server_command(&paths, &action, 5) {
-                Ok(Some(response)) => {
-                    handle_daemon_response(response);
-                    true
+            // try to start the daemon if if isn't already running and the action is allowed to do so
+            if let (true, Some(lock_file)) = (action.can_start_daemon() && !opts.no_daemonize, server::try_lock_file(&paths)?) {
+                log::info!("Initializing eww server. ({})", paths.get_ipc_socket_file().display());
+                let _ = std::fs::remove_file(paths.get_ipc_socket_file());
+                if !opts.show_logs {
+                    println!("Run `{} logs` to see any errors while editing your configuration.", eww_binary_name);
                 }
-                Ok(None) => true,
 
-                Err(err) if action.can_start_daemon() && !opts.no_daemonize => {
-                    // connecting to the daemon failed. Thus, start the daemon here!
-                    log::warn!("Failed to connect to daemon: {}", err);
-                    log::info!("Initializing eww server. ({})", paths.get_ipc_socket_file().display());
-                    let _ = std::fs::remove_file(paths.get_ipc_socket_file());
-                    if !opts.show_logs {
-                        println!("Run `{} logs` to see any errors while editing your configuration.", eww_binary_name);
-                    }
-
-                    let (command, response_recv) = action.into_daemon_command();
-                    // start the daemon and give it the command
-                    let fork_result = server::initialize_server::<B>(paths.clone(), Some(command), true)?;
-                    let is_parent = fork_result == ForkResult::Parent;
-                    if let (Some(recv), true) = (response_recv, is_parent) {
-                        listen_for_daemon_response(recv);
-                    }
-                    is_parent
+                let (command, response_recv) = action.into_daemon_command();
+                // start the daemon and give it the command
+                let fork_result = server::initialize_server::<B>(paths.clone(), Some(command), true, lock_file)?;
+                let is_parent = fork_result == ForkResult::Parent;
+                if let (Some(recv), true) = (response_recv, is_parent) {
+                    listen_for_daemon_response(recv);
                 }
-                Err(err) => Err(err)?,
+                is_parent
+            } else {
+                // otherwise just send the command over IPC
+                match handle_server_command(&paths, &action, 5) {
+                    Ok(Some(response)) => {
+                        handle_daemon_response(response);
+                        true
+                    }
+                    Ok(None) => true,
+                    Err(err) => Err(err)?,
+                }
             }
         }
     };
@@ -222,12 +221,4 @@ fn attempt_connect(socket_path: impl AsRef<Path>, attempts: usize) -> Option<net
         std::thread::sleep(Duration::from_millis(200));
     }
     None
-}
-
-/// Check if a eww server is currently running by trying to send a ping message to it.
-fn check_server_running(socket_path: impl AsRef<Path>) -> bool {
-    let response = net::UnixStream::connect(socket_path)
-        .ok()
-        .and_then(|mut stream| client::do_server_call(&mut stream, &opts::ActionWithServer::Ping).ok());
-    response.is_some()
 }

--- a/crates/eww/src/paths.rs
+++ b/crates/eww/src/paths.rs
@@ -12,6 +12,7 @@ pub struct EwwPaths {
     pub log_file: PathBuf,
     pub log_dir: PathBuf,
     pub ipc_socket_file: PathBuf,
+    pub lock_file: PathBuf,
     pub config_dir: PathBuf,
 }
 
@@ -39,6 +40,8 @@ impl EwwPaths {
             .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"))
             .join(format!("eww-server_{}", daemon_id));
 
+        let lock_file = std::path::PathBuf::from(format!("{}.lock", ipc_socket_file.display()));
+
         // 100 as the limit isn't quite 108 everywhere (i.e 104 on BSD or mac)
         if format!("{}", ipc_socket_file.display()).len() > 100 {
             log::warn!("The IPC socket file's absolute path exceeds 100 bytes, the socket may fail to create.");
@@ -54,7 +57,7 @@ impl EwwPaths {
             std::fs::create_dir_all(&log_dir)?;
         }
 
-        Ok(EwwPaths { config_dir, log_file: log_dir.join(format!("eww_{}.log", daemon_id)), log_dir, ipc_socket_file })
+        Ok(EwwPaths { config_dir, log_file: log_dir.join(format!("eww_{}.log", daemon_id)), log_dir, ipc_socket_file, lock_file })
     }
 
     pub fn default() -> Result<Self> {
@@ -76,6 +79,10 @@ impl EwwPaths {
 
     pub fn get_ipc_socket_file(&self) -> &Path {
         self.ipc_socket_file.as_path()
+    }
+
+    pub fn get_lock_file(&self) -> &Path {
+        self.lock_file.as_path()
     }
 
     pub fn get_config_dir(&self) -> &Path {

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
+    fs::File,
     io::Write,
     marker::PhantomData,
     os::unix::io::AsRawFd,
@@ -20,10 +21,30 @@ use std::{
 };
 use tokio::sync::mpsc::*;
 
+/// The lockfile that is held for as long as `initialize_server` is running.
+pub struct LockFile(#[allow(unused)] File);
+
+/// Try creating and locking the lock file. This will then be passed into `initialize_server`.
+/// This function returns Ok(None) if the file is already locked by another process.
+pub fn try_lock_file(paths: &EwwPaths) -> Result<Option<LockFile>> {
+    let path = paths.get_lock_file();
+    let lock_file = File::create(path).with_context(|| format!("Failed to create lock file {}", path.display()))?;
+    match lock_file.try_lock() {
+        Ok(()) => Ok(Some(LockFile(lock_file))),
+        // already locked
+        Err(std::fs::TryLockError::WouldBlock) => Ok(None),
+        Err(std::fs::TryLockError::Error(e)) => {
+            Err(e).with_context(|| format!("Failed to get lock on file {}", path.display()))?
+        }
+    }
+}
+
 pub fn initialize_server<B: DisplayBackend>(
     paths: EwwPaths,
     action: Option<DaemonCommand>,
     should_daemonize: bool,
+    // only needs to be kept in scope
+    _lock_file: LockFile,
 ) -> Result<ForkResult> {
     let (ui_send, mut ui_recv) = tokio::sync::mpsc::unbounded_channel();
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.89.0"
 components = [ "rust-src" ]
 profile = "default"


### PR DESCRIPTION
## Description
This PR makes the daemon create and lock a file next to the IPC socket (ex. "/run/user/1000/eww-server_f12a67507f690016.lock"). It also makes the program check if the daemon is running by seeing if the file is locked by another process, instead of sending a ping command to the daemon.

This will fix #255, where a timeout in sending an `open` command over IPC caused the program to create a new daemon, leading to "zombie windows" being left over by the existing daemon.
This will also hopefully make the daemon launch a bit quicker when started as `eww open bar`.

## Additional Notes
i haven't tested this on platforms other than linux

is this a feature or a fix?

this uses the `std::fs::File::try_lock` method which is cleaner but only available in rust 1.89.0 and above; i have an alternative implementation that uses `nix::fcntl::Flock` instead, should i submit the alternative instead?

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
