### PR TITLE
Fix build on loongarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Load systray items that are registered without a path (By: Kage-Yami)
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
 - Improve multi-monitor handling under wayland (By: bkueng)
+- Fix build on loongarch64 (By: wezm)
 
 ### Features
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,9 +1850,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libm"


### PR DESCRIPTION
## Description

Fix build on `loongarch64`.

## Usage

Build on a `loongarch64` machine.

### Showcase

N/A

## Additional Notes

eww failed to build on `loongarch64` machines due to lack of support in the version of `libc` in the lock file. This PR bumps it to a compatible version resolving the build errors.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [ ] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing

I ticked the relevant items.