### PR TITLE
Fixed typo

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -227,7 +227,7 @@ In the example given above, the value of `foo` will start out as `"whatever"`, a
 These are particularly useful when you want to apply changes instantaneously when an operation happens if you have a script
 that can monitor some value on its own. Volume, brightness, workspaces that get added/removed at runtime,
 monitoring currently focused desktop/tag, etc. are the most common usecases of this type of variable.
-These are particularly efficient and should be preffered if possible.
+These are particularly efficient and should be preferred if possible.
 
 For example, the command `xprop -spy -root _NET_CURRENT_DESKTOP` writes the currently focused desktop whenever it changes.
 Another example usecase is monitoring the currently playing song with playerctl: `playerctl --follow metadata --format {{title}}`.


### PR DESCRIPTION
## Description

This fixes typo in the eww documentations, `eww/docs/src/configuration.md`.
Line 230, `preffered` => `preferred` :)


## Usage

N/A

### Showcase

N/A

## Additional Notes

Apologies for the extremely trivial fix.

## Checklist

**N/A**

- [ ] All widgets I've added are correctly documented.
- [ ] I added my changes to CHANGELOG.md, if appropriate.
- [ ] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [ ] I used `cargo fmt` to automatically format all code before committing
