### PR TITLE
fix: avoid pointer grab stuck on button press (Wayland)

### DIFF
--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -537,15 +537,28 @@ fn build_gtk_button(bargs: &mut BuilderArgs) -> Result<gtk::Button> {
             // @prop onrightclick - command to run when the button is rightclicked
             onrightclick: as_string = ""
         ) {
-            // animate button upon right-/middleclick (if gtk theme supports it)
-            // since we do this, we can't use `connect_clicked` as that would always run `onclick` as well
+            // Set :active CSS state on press for visual feedback, but do NOT call
+            // emit_activate() — that triggers GTK's internal pointer grab, which is
+            // never released if the onclick command spawns a window that steals
+            // Wayland focus before the button_release_event arrives. This causes
+            // the bar to get "stuck": hover stops working and only the grabbed
+            // button receives events. See: https://github.com/elkowar/eww/issues/1008
+            //                              https://github.com/elkowar/eww/issues/1022
             connect_signal_handler!(gtk_widget, gtk_widget.connect_button_press_event(move |button, _| {
-                button.emit_activate();
+                button.set_state_flags(gtk::StateFlags::ACTIVE, false);
+                glib::Propagation::Proceed
+            }));
+            // Safety net: if the pointer grab is broken (e.g. another window steals
+            // focus), GTK sends grab_broken_event. Clear the :active state so the
+            // button doesn't stay visually stuck.
+            connect_signal_handler!(gtk_widget, gtk_widget.connect_grab_broken_event(move |button, _| {
+                button.unset_state_flags(gtk::StateFlags::ACTIVE);
                 glib::Propagation::Proceed
             }));
             let onclick_ = onclick.clone();
-            // mouse click events
-            connect_signal_handler!(gtk_widget, gtk_widget.connect_button_release_event(move |_, evt| {
+            // mouse click events — also clears :active state
+            connect_signal_handler!(gtk_widget, gtk_widget.connect_button_release_event(move |button, evt| {
+                button.unset_state_flags(gtk::StateFlags::ACTIVE);
                 match evt.button() {
                     1 => run_command(timeout, &onclick, &[] as &[&str]),
                     2 => run_command(timeout, &onmiddleclick, &[] as &[&str]),


### PR DESCRIPTION
## Problem

When a button's `onclick` command opens a window (e.g. a launcher, popup, or overlay) that steals Wayland focus before the `button_release_event` arrives back at the EWW bar, GTK's internal pointer grab is never released. This causes the entire bar to get "stuck":

- Hover highlighting stops working on all other buttons
- Clicks either do nothing or re-trigger the originally grabbed button
- The user must wiggle the mouse to break free

This affects every EWW user on Hyprland/Wayland whose bar buttons open external windows. The community workaround has been adding `sleep 0.1` before commands.

## Root Cause

`emit_activate()` on `button_press_event` (line 542 of `widget_definitions.rs`) triggers GTK's built-in `Button` activation, which includes an implicit pointer grab via [GDK seat grab](https://docs.gtk.org/gdk3/method.Seat.grab.html). If the `button_release_event` is intercepted by another layer-shell surface that opens before the release arrives, the grab is never freed.

As @Rayzeq analyzed in #1022:
> 1. GTK button grabs the pointer on press
> 2. The onclick command opens a window that steals focus
> 3. The release event goes to the new window, not the bar
> 4. GTK never receives the release → grab never freed → all events redirect to the stuck button

## Fix

Replace `emit_activate()` with manual `:active` CSS state management (the same pattern `eventbox` already uses):

- **On press**: Set `StateFlags::ACTIVE` for visual feedback (preserves the button animation)
- **On release**: Clear `ACTIVE` and run the command (unchanged behavior)
- **On grab_broken**: Clear `ACTIVE` as a safety net if the grab is stolen by another surface

This preserves the press/release visual animation while eliminating the pointer grab that causes the stuck state. No user-facing API changes.

## Testing

- Compiled and verified on Arch Linux with Hyprland
- The fix is a single-file change (~18 lines added, 5 removed) in `widget_definitions.rs`
- Bar buttons that launch external windows (launchers, notification centers, calendar overlays) no longer cause the stuck state

Fixes #1008
Fixes #1022