### PR TITLE
feat(widgets): add base64 property to image widget.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Improve multi-monitor handling under wayland (By: bkueng)
 
 ### Features
+- Add `:base64` property to the `image` widget to allow rendering images directly from base64-encoded strings in memory (By: Suvius)
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options
 - Add `eww poll` subcommand to force-poll a variable (By: kiana-S)
 - Add OnDemand support for focusable on wayland (By: GallowsDove)

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -588,6 +588,30 @@ const WIDGET_NAME_IMAGE: &str = "image";
 fn build_gtk_image(bargs: &mut BuilderArgs) -> Result<gtk::Image> {
     let gtk_widget = gtk::Image::new();
     def_widget!(bargs, _g, gtk_widget, {
+
+        // @prop base64 - Base64 encoded image data
+        // @prop image-width - width of the image
+        // @prop image-height - height of the image
+        // @prop preserve-aspect-ratio - whether to keep the aspect ratio when resizing an image
+        prop(base64: as_string, image_width: as_i32 = -1, image_height: as_i32 = -1, preserve_aspect_ratio: as_bool = true) {
+            if base64.is_empty() {
+                gtk_widget.clear();
+            } else {
+                let decoded_bytes = gtk::glib::base64_decode(&base64);
+                let stream = gtk::gio::MemoryInputStream::from_bytes(&gtk::glib::Bytes::from(&decoded_bytes));
+
+                let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_stream_at_scale(
+                    &stream,
+                    image_width,
+                    image_height,
+                    preserve_aspect_ratio,
+                    None::<&gtk::gio::Cancellable>
+                ).context("Failed to parse image from base64 string")?;
+
+                stream.close(None::<&gtk::gio::Cancellable>)?;
+                gtk_widget.set_from_pixbuf(Some(&pixbuf));
+            }
+        },
         // @prop path - path to the image file
         // @prop image-width - width of the image
         // @prop image-height - height of the image


### PR DESCRIPTION
## Description

Added a new `:base64` property to the `(image)` widget. This allows users to pass Base64-encoded image data directly to Eww, completely bypassing the need to write and read temporary image files to/from disk. 

Under the hood, it decodes the string natively using `glib::base64_decode` and pipes the raw bytes into a GTK `MemoryInputStream` to be consumed efficiently by `gdk_pixbuf::Pixbuf::from_stream_at_scale`. It also includes graceful error handling if an invalid string is passed.

## Usage

You can pass a Base64-encoded image string directly into the `image` widget. 

```yuck
;; Example of a dynamically updated base64 image
(defwidget workspace_icon [icon_data]
  (image :base64 icon_data 
         :image-width 24 
         :image-height 24 
         :preserve-aspect-ratio true))
```

## Additional Notes

**My use case:**
I was building a fast DWM ipc integration and needed a better way to handle app icons. Instead of the usual annoying route of doing slow .desktop file lookups or writing temporary images to the hard drive from memory I just pass the raw `_NET_WM_ICON` ARGB pixel data from the X11 server encoded to Base64 straight into Eww. This skips disk I/O.

**Other Potential Use Cases:**
* **Media Players:** Scripts that fetch album art directly from APIs and can push the Base64 data directly to Eww without needing to manage a `/tmp/current_album.png` file.
* **Notification Daemons:** Passing inline notification icons directly through IPC without saving them to disk first.
etc...

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing