### PR TITLE
Allow ignore exclusive for layer shell windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 ### BREAKING CHANGES
 - [#1176](https://github.com/elkowar/eww/pull/1176) changed safe access (`?.`) behavior:
   Attempting to index in an empty JSON string (`'""'`) is now an error.
+- `:exclusive` window parameter is now an enum (`none`, `exclusive` or `ignore`) instead of a boolean
 
 ### Fixes
 - Fix crash on invalid `formattime` format string (By: luca3s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Improve multi-monitor handling under wayland (By: bkueng)
 
 ### Features
+- Add `exclusive`, `ignore` and `none` to window `:exclusive` argument.
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options
 - Add `eww poll` subcommand to force-poll a variable (By: kiana-S)
 - Add OnDemand support for focusable on wayland (By: GallowsDove)

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -33,6 +33,7 @@ mod platform_wayland {
     use gtk::gdk;
     use gtk::prelude::*;
     use gtk_layer_shell::{KeyboardMode, LayerShell};
+    use yuck::config::backend_window_options::WlWindowExclusive;
     use yuck::config::backend_window_options::WlWindowFocusable;
     use yuck::config::{window_definition::WindowStacking, window_geometry::AnchorAlignment};
 
@@ -113,15 +114,19 @@ mod platform_wayland {
                     window.set_layer_shell_margin(gtk_layer_shell::Edge::Top, yoffset);
                 }
                 // https://github.com/elkowar/eww/issues/296
-                if window_init.backend_options.wayland.exclusive
+                if matches!(window_init.backend_options.wayland.exclusive, WlWindowExclusive::Exclusive)
                     && geometry.anchor_point.x != AnchorAlignment::CENTER
                     && geometry.anchor_point.y != AnchorAlignment::CENTER
                 {
-                    log::warn!("When ':exclusive true' the anchor has to include 'center', otherwise exlcusive won't work")
+                    log::warn!(
+                        "When ':exclusive \"exclusive\"' the anchor has to include 'center', otherwise exlcusive won't work"
+                    )
                 }
             }
-            if window_init.backend_options.wayland.exclusive {
-                window.auto_exclusive_zone_enable();
+            match window_init.backend_options.wayland.exclusive {
+                WlWindowExclusive::None => (),
+                WlWindowExclusive::Exclusive => window.auto_exclusive_zone_enable(),
+                WlWindowExclusive::IgnoreOthers => window.set_exclusive_zone(-1),
             }
             Some(window)
         }

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -111,7 +111,7 @@ impl X11BackendWindowOptionsDef {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct WlBackendWindowOptions {
-    pub exclusive: bool,
+    pub exclusive: WlWindowExclusive,
     pub focusable: WlWindowFocusable,
     pub namespace: Option<String>,
 }
@@ -127,7 +127,10 @@ pub struct WlBackendWindowOptionsDef {
 impl WlBackendWindowOptionsDef {
     fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<WlBackendWindowOptions, Error> {
         Ok(WlBackendWindowOptions {
-            exclusive: eval_opt_expr_as_bool(&self.exclusive, false, local_variables)?,
+            exclusive: match &self.exclusive {
+                Some(expr) => WlWindowExclusive::from_dynval(&expr.eval(local_variables)?)?,
+                None => WlWindowExclusive::default(),
+            },
             focusable: match &self.focusable {
                 Some(expr) => WlWindowFocusable::from_dynval(&expr.eval(local_variables)?)?,
                 None => WlWindowFocusable::default(),
@@ -169,6 +172,25 @@ impl FromStr for WlWindowFocusable {
             // legacy support
             "true" => Self::Exclusive,
             "false" => Self::None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, smart_default::SmartDefault, serde::Serialize)]
+pub enum WlWindowExclusive {
+    #[default]
+    None,
+    Exclusive,
+    IgnoreOthers,
+}
+impl FromStr for WlWindowExclusive {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        enum_parse! { "exclusive", s,
+            "none" => Self::None,
+            "exclusive" => Self::Exclusive,
+            "ignore" => Self::IgnoreOthers
         }
     }
 }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -89,7 +89,7 @@ Depending on if you are using X11 or Wayland, some additional properties exist:
 |    Property | Description                                                                                                                                                            |
 | ----------: |------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |  `stacking` | Where the window should appear in the stack. Possible values: `fg`, `bg`, `overlay`, `bottom`.                                                                         |
-| `exclusive` | How the compositor should reserve space for the window automatically. `exclusive` to reserve space, `none` to not reserve space and `ignore` to ignore space reserved by other windows (useful for background or with Niri's `place-within-backdrop`). If `exclusive` `:anchor` has to include `center`.                       |
+| `exclusive` | How the compositor should reserve space for the window. `exclusive` to reserve space, `none` to not reserve space and `ignore` to ignore space reserved by other windows (useful for background or with Niri's `place-within-backdrop`). If `exclusive` `:anchor` has to include `center`.                       |
 | `focusable` | Whether the window should be able to be focused. This is necessary for any widgets that use the keyboard to work. Possible values: `none`, `exclusive` and `ondemand`. |
 | `namespace` | Set the wayland layersurface namespace eww uses. Accepts a `string` value.                                                                                             |
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -89,7 +89,7 @@ Depending on if you are using X11 or Wayland, some additional properties exist:
 |    Property | Description                                                                                                                                                            |
 | ----------: |------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |  `stacking` | Where the window should appear in the stack. Possible values: `fg`, `bg`, `overlay`, `bottom`.                                                                         |
-| `exclusive` | Whether the compositor should reserve space for the window automatically. Either `true` or `false`. If `true` `:anchor` has to include `center`.                       |
+| `exclusive` | How the compositor should reserve space for the window automatically. `exclusive` to reserve space, `none` to not reserve space and `ignore` to ignore space reserved by other windows (useful for background or with Niri's `place-within-backdrop`). If `exclusive` `:anchor` has to include `center`.                       |
 | `focusable` | Whether the window should be able to be focused. This is necessary for any widgets that use the keyboard to work. Possible values: `none`, `exclusive` and `ondemand`. |
 | `namespace` | Set the wayland layersurface namespace eww uses. Accepts a `string` value.                                                                                             |
 


### PR DESCRIPTION
## Description

I changed the `:exclusive` argument for a window from a boolean to an enum to be able to use the "ignore" behavior as described in https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:request:set_exclusive_zone. This allows the use of [Niri's `place-within-backdrop` layer feature](https://niri-wm.github.io/niri/Configuration%3A-Layer-Rules.html#place-within-backdrop), which only works when the layer exclusive mode is set to `-1`. This is now possible with the `ignore` flag.

## Usage

```yuck
(defwindow mywindow
  :monitor 0
  :geometry (geometry
    :x "70px"
    :y "70px"
    :anchor "bottom left"
  )
  :stacking "bg"
  :exclusive "ignore" ; or "exclusive" or "none"
  "hola"
)
```

## Additional Notes

Closes #1415, I have not followed the suggested implementation but I can update accordingly if needed.

Thanks for this amazing tool !
This is one of my first PRs, if I did anything wrong don't hesitate to mention it.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [N/A] All widgets I've added are correctly documented.
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [X] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [X] I used `cargo fmt` to automatically format all code before committing
