### PR TITLE
Feature(wayland): Add a property that allow mouse to pass through window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `value-pos` to scale widget (By: ipsvn)
 - Add `floor` and `ceil` function calls to simplexpr (By: wsbankenstein)
 - Add `formatbytes` function calls to simplexpr (By: topongo)
+- Add `:passthrough` property (wayland) to allow mouse pass through for `:focusable "none"` window (By: LemonKronos)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -30,10 +30,10 @@ impl DisplayBackend for NoBackend {
 mod platform_wayland {
     use super::DisplayBackend;
     use crate::{widgets::window::Window, window_initiator::WindowInitiator};
+    use gtk::cairo::Region;
     use gtk::gdk;
     use gtk::prelude::*;
     use gtk_layer_shell::{KeyboardMode, LayerShell};
-    use gtk::cairo::Region;
     use yuck::config::backend_window_options::WlWindowFocusable;
     use yuck::config::{window_definition::WindowStacking, window_geometry::AnchorAlignment};
 
@@ -129,7 +129,9 @@ mod platform_wayland {
             if opts.passthrough {
                 if opts.focusable == WlWindowFocusable::None {
                     window.connect_map(|win| {
-                        if let Some(g) = win.window() { g.input_shape_combine_region(&Region::create(), 0, 0); }
+                        if let Some(g) = win.window() {
+                            g.input_shape_combine_region(&Region::create(), 0, 0);
+                        }
                     });
                 } else {
                     log::warn!("Property ':passthrough true' only work with ':focusable \"none\"'")

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -124,10 +124,16 @@ mod platform_wayland {
             if window_init.backend_options.wayland.exclusive {
                 window.auto_exclusive_zone_enable();
             }
-            if window_init.backend_options.wayland.passthrough {
-                window.connect_map(|win| {
-                    if let Some(g) = win.window() { g.input_shape_combine_region(&Region::create(), 0, 0); }
-                });
+
+            let opts = &window_init.backend_options.wayland;
+            if opts.passthrough {
+                if opts.focusable == WlWindowFocusable::None {
+                    window.connect_map(|win| {
+                        if let Some(g) = win.window() { g.input_shape_combine_region(&Region::create(), 0, 0); }
+                    });
+                } else {
+                    log::warn!("Property ':passthrough true' only work with ':focusable \"none\"'")
+                }
             }
             Some(window)
         }

--- a/crates/eww/src/display_backend.rs
+++ b/crates/eww/src/display_backend.rs
@@ -33,6 +33,7 @@ mod platform_wayland {
     use gtk::gdk;
     use gtk::prelude::*;
     use gtk_layer_shell::{KeyboardMode, LayerShell};
+    use gtk::cairo::Region;
     use yuck::config::backend_window_options::WlWindowFocusable;
     use yuck::config::{window_definition::WindowStacking, window_geometry::AnchorAlignment};
 
@@ -122,6 +123,11 @@ mod platform_wayland {
             }
             if window_init.backend_options.wayland.exclusive {
                 window.auto_exclusive_zone_enable();
+            }
+            if window_init.backend_options.wayland.passthrough {
+                window.connect_map(|win| {
+                    if let Some(g) = win.window() { g.input_shape_combine_region(&Region::create(), 0, 0); }
+                });
             }
             Some(window)
         }

--- a/crates/yuck/src/config/backend_window_options.rs
+++ b/crates/yuck/src/config/backend_window_options.rs
@@ -56,6 +56,7 @@ impl BackendWindowOptionsDef {
         };
         let wayland = WlBackendWindowOptionsDef {
             exclusive: attrs.ast_optional("exclusive")?,
+            passthrough: attrs.ast_optional("passthrough")?,
             focusable,
             namespace: attrs.ast_optional("namespace")?,
         };
@@ -112,6 +113,7 @@ impl X11BackendWindowOptionsDef {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct WlBackendWindowOptions {
     pub exclusive: bool,
+    pub passthrough: bool,
     pub focusable: WlWindowFocusable,
     pub namespace: Option<String>,
 }
@@ -120,6 +122,7 @@ pub struct WlBackendWindowOptions {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct WlBackendWindowOptionsDef {
     pub exclusive: Option<SimplExpr>,
+    pub passthrough: Option<SimplExpr>,
     pub focusable: Option<SimplExpr>,
     pub namespace: Option<SimplExpr>,
 }
@@ -128,6 +131,7 @@ impl WlBackendWindowOptionsDef {
     fn eval(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<WlBackendWindowOptions, Error> {
         Ok(WlBackendWindowOptions {
             exclusive: eval_opt_expr_as_bool(&self.exclusive, false, local_variables)?,
+            passthrough: eval_opt_expr_as_bool(&self.passthrough, false, local_variables)?,
             focusable: match &self.focusable {
                 Some(expr) => WlWindowFocusable::from_dynval(&expr.eval(local_variables)?)?,
                 None => WlWindowFocusable::default(),

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -91,6 +91,7 @@ Depending on if you are using X11 or Wayland, some additional properties exist:
 |  `stacking` | Where the window should appear in the stack. Possible values: `fg`, `bg`, `overlay`, `bottom`.                                                                         |
 | `exclusive` | Whether the compositor should reserve space for the window automatically. Either `true` or `false`. If `true` `:anchor` has to include `center`.                       |
 | `focusable` | Whether the window should be able to be focused. This is necessary for any widgets that use the keyboard to work. Possible values: `none`, `exclusive` and `ondemand`. |
+| `passthrough` | Only work with property `:focusable "none"`. Allow mouse to passthrough the window. |
 | `namespace` | Set the wayland layersurface namespace eww uses. Accepts a `string` value.                                                                                             |
 
 


### PR DESCRIPTION
## Description

This PR introduces a `:passthrough` property for Wayland windows, allowing pointer events (like mouse clicks) to pass through the regions of an Eww widget to the applications underneath. 

**Why?** This let me set up Eww window as notify, remider, etc to "flash" my screen, but still let me click pass them, maintain my work flow. Idk!

**Implementation details:**
- Added the `passthrough` boolean to the `WlBackendWindowOptions` and the Yuck parser.
- Modified `crates/eww/src/display_backend.rs` for the `platform_wayland` module.
- Hooked into the GTK `connect_map` signal (to ensure GTK has finished its internal geometry calculations) to fetch the underlying `gdk::Window`.
- Applied an empty `gtk::cairo::Region` using `input_shape_combine_region` to tell the Wayland compositor the window has no clickable pixels.

## Usage

Set `:passthrough true` in your window definition. 
*Note: For the property to work, you must also set `:focusable "none"`.*

```yuck
(defwindow click_through_box
  :monitor 0
  :geometry (geometry :width "400px" :height "400px" :anchor "center")
  :stacking "fg"
  :focusable "none" 
  :passthrough true
  (box :style "background-color: rgba(255, 0, 0, 0.5);" 
    (label :text "You can click straight through this window!")))
```
### Showcase

I can still click the files below this Text widget
<img width="1920" height="1080" alt="Screenshot_14-May_15-52-52_6388" src="https://github.com/user-attachments/assets/62aed8fd-3775-4d57-bbf6-5876c18c5614" />

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
