### PR TITLE
fix(systray): survive StatusNotifierWatcher ownership handoff at startup

### DIFF
--- a/crates/eww/src/widgets/systray.rs
+++ b/crates/eww/src/widgets/systray.rs
@@ -10,7 +10,7 @@ use std::{cell::RefCell, future::Future, rc::Rc};
 
 // DBus state shared between systray instances, to avoid creating too many connections etc.
 struct DBusSession {
-    snw: notifier_host::proxy::StatusNotifierWatcherProxy<'static>,
+    con: zbus::Connection,
 }
 
 async fn dbus_session() -> zbus::Result<&'static DBusSession> {
@@ -22,9 +22,7 @@ async fn dbus_session() -> zbus::Result<&'static DBusSession> {
             let con = zbus::Connection::session().await?;
             notifier_host::Watcher::new().attach_to(&con).await?;
 
-            let (_, snw) = notifier_host::register_as_host(&con).await?;
-
-            Ok(DBusSession { snw })
+            Ok(DBusSession { con })
         })
         .await
 }
@@ -83,7 +81,7 @@ pub fn spawn_systray(container: &gtk::Box, props: &Props) {
         };
 
         systray.container.show();
-        let e = notifier_host::run_host(&mut systray, &s.snw).await;
+        let e = notifier_host::run_host_forever(&mut systray, &s.con).await;
         log::error!("notifier host error: {}", e);
     });
 
@@ -112,6 +110,12 @@ impl notifier_host::Host for Tray {
             self.items.remove(id);
         } else {
             log::warn!("Tried to remove nonexistent item {:?} from systray", id);
+        }
+    }
+
+    fn clear(&mut self) {
+        for (_, item) in self.items.drain() {
+            self.container.remove(&item.widget);
         }
     }
 }

--- a/crates/notifier_host/src/host.rs
+++ b/crates/notifier_host/src/host.rs
@@ -10,19 +10,30 @@ pub trait Host {
 
     /// Called when an item is removed from the tray.
     fn remove_item(&mut self, id: &str);
+
+    /// Called by [`run_host_forever`] before re-bootstrapping against a new StatusNotifierWatcher
+    /// owner. Implementations should remove all currently-displayed items; they will be
+    /// re-enumerated against the new owner.
+    fn clear(&mut self);
 }
 
-// TODO We aren't really thinking about what happens when we shut down a host. Currently, we don't
-// provide a way to unregister as a host.
+// The StatusNotifier spec defines no method to unregister a host; a host's lifetime is tracked
+// implicitly by the watcher watching its well-known name, so the name is held for the lifetime of
+// the connection and released only when the connection drops. Accordingly we acquire a single
+// stable host name per connection and reuse it across re-registrations (see `register_as_host`).
 //
 // It would also be good to combine `register_as_host` and `run_host`, so that we're only
 // registered while we're running.
 
 /// Register this DBus connection as a StatusNotifierHost (i.e. system tray).
 ///
-/// This associates with the DBus connection new name of the format
-/// `org.freedesktop.StatusNotifierHost-{pid}-{nr}`, and registers it to active
+/// This associates the DBus connection with a name of the format
+/// `org.freedesktop.StatusNotifierHost-{pid}-{nr}`, and registers it to the active
 /// StatusNotifierWatcher. The name and the StatusNotifierWatcher proxy are returned.
+///
+/// If the connection already owns such a host name (e.g. from a previous call), that name is
+/// reused rather than a fresh one being claimed, so repeated registrations on one connection do
+/// not accumulate host names on the bus.
 ///
 /// You still need to call [`run_host`] to have the instance of [`Host`] be notified of new and
 /// removed items.
@@ -43,9 +54,10 @@ pub async fn register_as_host(
 
         let flags = [zbus::fdo::RequestNameFlags::DoNotQueue];
         match con.request_name_with_flags(&wellknown, flags.into_iter().collect()).await? {
-            PrimaryOwner => break wellknown,
-            Exists => {}
-            AlreadyOwner => {}
+            // Reuse a name we already hold instead of claiming a fresh one, so repeated
+            // registrations on this connection don't accumulate host names on the bus.
+            PrimaryOwner | AlreadyOwner => break wellknown,
+            Exists => {} // owned by another connection; try the next index
             InQueue => unreachable!("request_name_with_flags returned InQueue even though we specified DoNotQueue"),
         };
     };
@@ -132,4 +144,82 @@ pub async fn run_host(host: &mut dyn Host, snw: &proxy::StatusNotifierWatcherPro
 
     // I do not know whether this is possible to reach or not.
     unreachable!("StatusNotifierWatcher stopped producing events")
+}
+
+/// Run a Host indefinitely, re-bootstrapping host registration and signal subscriptions whenever
+/// the `org.kde.StatusNotifierWatcher` well-known name changes ownership.
+///
+/// This is the recommended entry point for hosts that may start before the system's
+/// StatusNotifierWatcher is fully owned by a single stable process (e.g. when a transient
+/// fallback watcher like libayatana-appindicator's claims the name during graphical session
+/// startup, then exits when a longer-lived watcher takes over).
+pub async fn run_host_forever(host: &mut dyn Host, con: &zbus::Connection) -> zbus::Error {
+    macro_rules! try_ {
+        ($e:expr) => {
+            match $e {
+                Ok(x) => x,
+                Err(e) => return e.into(),
+            }
+        };
+    }
+
+    let dbus = try_!(zbus::fdo::DBusProxy::new(con).await);
+    let watcher_bus = zbus::names::BusName::try_from(crate::names::WATCHER_BUS)
+        .expect("WATCHER_BUS is a valid well-known name");
+
+    loop {
+        let mut owner_changes = try_!(dbus.receive_name_owner_changed_with_args(&[(0, &watcher_bus)]).await);
+
+        // Block until the watcher name has an owner so `register_as_host` has something to call.
+        // Handles both the initial-startup case (no watcher yet) and a fast owner-flap where the
+        // previous owner has departed but no replacement has claimed the name yet.
+        let initial_owner = loop {
+            match dbus.get_name_owner(watcher_bus.as_ref()).await {
+                Ok(name) => break name.to_string(),
+                Err(zbus::fdo::Error::NameHasNoOwner(_)) => {
+                    while let Some(sig) = owner_changes.next().await {
+                        let args = match sig.args() {
+                            Ok(a) => a,
+                            Err(_) => continue,
+                        };
+                        if args.new_owner().is_some() {
+                            break;
+                        }
+                    }
+                }
+                Err(e) => return e.into(),
+            }
+        };
+
+        log::debug!("clearing tray items before (re-)bootstrap against watcher owner {}", initial_owner);
+        host.clear();
+
+        let (_, snw) = try_!(register_as_host(con).await);
+
+        let owner_changed = async {
+            while let Some(sig) = owner_changes.next().await {
+                let args = match sig.args() {
+                    Ok(a) => a,
+                    Err(_) => continue,
+                };
+                let new_owner = args.new_owner().as_ref().map(|n| n.to_string());
+
+                if new_owner.as_deref() != Some(initial_owner.as_str()) {
+                    return;
+                }
+            }
+        };
+
+        // Exiting the select drops `snw` and its signal subscriptions, so the next iteration
+        // rebinds against whoever owns the watcher name then.
+        tokio::select! {
+            err = run_host(host, &snw) => return err,
+            _ = owner_changed => {
+                log::info!(
+                    "StatusNotifierWatcher ownership changed (was {}); re-bootstrapping host",
+                    initial_owner
+                );
+            }
+        }
+    }
 }

--- a/crates/notifier_host/src/watcher.rs
+++ b/crates/notifier_host/src/watcher.rs
@@ -9,12 +9,11 @@ use zbus::{dbus_interface, export::ordered_stream::OrderedStreamExt, Interface};
 /// [`org.kde.StatusNotifierWatcher`]: https://freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierWatcher/
 #[derive(Debug, Default)]
 pub struct Watcher {
-    tasks: tokio::task::JoinSet<()>,
-
     // Intentionally using std::sync::Mutex instead of tokio's async mutex, since we don't need to
     // hold the mutex across an await.
     //
     // See <https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use>
+    tasks: std::sync::Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>,
     hosts: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
     items: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
 }
@@ -58,7 +57,7 @@ impl Watcher {
         }
         Watcher::status_notifier_host_registered(&ctxt).await?;
 
-        self.tasks.spawn({
+        self.tasks.lock().unwrap().spawn({
             let hosts = self.hosts.clone();
             let ctxt = ctxt.to_owned();
             let con = con.to_owned();
@@ -131,7 +130,7 @@ impl Watcher {
         self.registered_status_notifier_items_changed(&ctxt).await?;
         Watcher::status_notifier_item_registered(&ctxt, item.as_ref()).await?;
 
-        self.tasks.spawn({
+        self.tasks.lock().unwrap().spawn({
             let items = self.items.clone();
             let ctxt = ctxt.to_owned();
             let con = con.to_owned();
@@ -189,7 +188,17 @@ impl Watcher {
     }
 
     /// Attach and run the Watcher (in the background) on a connection.
+    ///
+    /// If another process already owns the `org.kde.StatusNotifierWatcher` well-known name, a
+    /// background task is spawned that monitors `NameOwnerChanged` and claims the name as soon
+    /// as the current owner departs. This avoids the silent state-desync that would otherwise
+    /// occur if eww queued for the name and later became primary owner while its host-side
+    /// registrations were still bound to the original owner.
     pub async fn attach_to(self, con: &zbus::Connection) -> zbus::Result<()> {
+        // Clone before moving `self` into the object server so we can still spawn the claim task
+        // onto the Watcher's JoinSet if needed.
+        let tasks = self.tasks.clone();
+
         if !con.object_server().at(names::WATCHER_OBJECT, self).await? {
             return Err(zbus::Error::Failure(format!(
                 "Object already exists at {} on this connection -- is StatusNotifierWatcher already running?",
@@ -197,11 +206,28 @@ impl Watcher {
             )));
         }
 
-        // not AllowReplacement, not ReplaceExisting, not DoNotQueue
-        let flags: [zbus::fdo::RequestNameFlags; 0] = [];
+        // zbus 3.x maps a `RequestNameReply::Exists` response to `Err(NameTaken)`, so both arms
+        // mean "another process owns the name."
+        let flags = [zbus::fdo::RequestNameFlags::DoNotQueue];
         match con.request_name_with_flags(names::WATCHER_BUS, flags.into_iter().collect()).await {
-            Ok(zbus::fdo::RequestNameReply::PrimaryOwner) => Ok(()),
-            Ok(_) | Err(zbus::Error::NameTaken) => Ok(()), // defer to existing
+            Ok(zbus::fdo::RequestNameReply::PrimaryOwner) | Ok(zbus::fdo::RequestNameReply::AlreadyOwner) => Ok(()),
+            Err(zbus::Error::NameTaken) => {
+                log::info!(
+                    "{} is already owned by another process; will claim it when the current owner departs",
+                    names::WATCHER_BUS
+                );
+                let con = con.clone();
+                // Self-terminates once the name is acquired. Lives on the Watcher's JoinSet so
+                // it's aborted alongside the other background tasks when the Watcher is dropped.
+                tasks.lock().unwrap().spawn(async move {
+                    if let Err(e) = claim_watcher_name_when_free(&con).await {
+                        log::error!("failed to claim {}: {}", names::WATCHER_BUS, e);
+                    }
+                });
+
+                Ok(())
+            }
+            Ok(reply) => unreachable!("unexpected RequestName reply with DoNotQueue: {:?}", reply),
             Err(e) => Err(e),
         }
     }
@@ -274,6 +300,39 @@ async fn parse_service<'a>(
                     Err(e)
                 }
             }
+        }
+    }
+}
+
+/// Wait until the current owner of `org.kde.StatusNotifierWatcher` departs, then claim the name.
+///
+/// Loops to handle the case where a third party claims the name between when the previous owner
+/// departed and when we issued our own `RequestName`.
+async fn claim_watcher_name_when_free(con: &zbus::Connection) -> zbus::Result<()> {
+    let dbus = zbus::fdo::DBusProxy::new(con).await?;
+    let watcher_bus =
+        zbus::names::BusName::try_from(names::WATCHER_BUS).expect("WATCHER_BUS is a valid well-known name");
+    let mut owner_changes = dbus.receive_name_owner_changed_with_args(&[(0, &watcher_bus)]).await?;
+
+    loop {
+        let flags = [zbus::fdo::RequestNameFlags::DoNotQueue];
+        match con.request_name_with_flags(names::WATCHER_BUS, flags.into_iter().collect()).await {
+            Ok(zbus::fdo::RequestNameReply::PrimaryOwner) | Ok(zbus::fdo::RequestNameReply::AlreadyOwner) => {
+                log::info!("acquired {} after previous owner departed", names::WATCHER_BUS);
+
+                return Ok(());
+            }
+            Err(zbus::Error::NameTaken) => {
+                // Someone else still owns it; wait for the next departure and retry.
+                while let Some(sig) = owner_changes.next().await {
+                    let args = sig.args()?;
+                    if args.new_owner().is_none() {
+                        break;
+                    }
+                }
+            }
+            Ok(reply) => unreachable!("unexpected RequestName reply with DoNotQueue: {:?}", reply),
+            Err(e) => return Err(e),
         }
     }
 }

--- a/crates/notifier_host/tests/integration.rs
+++ b/crates/notifier_host/tests/integration.rs
@@ -1,0 +1,350 @@
+//! Integration tests against a real DBus session bus.
+//!
+//! Each test spawns a private `dbus-daemon` so the tests do not depend on the developer's session
+//! bus and do not interfere with each other. They are gated behind `#[ignore]` so the default
+//! `cargo test` keeps working in environments where `dbus-daemon` is unavailable. Run with:
+//!
+//! ```bash
+//! cargo test -p notifier_host -- --ignored
+//! ```
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+const WATCHER_BUS: &str = "org.kde.StatusNotifierWatcher";
+const WATCHER_OBJECT: &str = "/StatusNotifierWatcher";
+
+// ---------- Temp bus harness ----------
+
+/// A private `dbus-daemon` session bus, killed on drop.
+struct TempBus {
+    child: Child,
+    address: String,
+    _config: tempconfig::TempConfig,
+}
+
+impl TempBus {
+    fn spawn() -> Self {
+        let config = tempconfig::TempConfig::write();
+        let mut child = Command::new("dbus-daemon")
+            .arg("--config-file")
+            .arg(config.path())
+            .args(["--print-address", "--nofork"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn dbus-daemon; is it installed?");
+
+        let stdout = child.stdout.take().expect("dbus-daemon stdout missing");
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("failed to read dbus-daemon address");
+        let address = line.trim().to_string();
+        assert!(!address.is_empty(), "dbus-daemon printed empty address");
+
+        Self { child, address, _config: config }
+    }
+
+    async fn connect(&self) -> zbus::Connection {
+        zbus::ConnectionBuilder::address(self.address.as_str())
+            .expect("invalid bus address")
+            .build()
+            .await
+            .expect("failed to connect to temp bus")
+    }
+}
+
+impl Drop for TempBus {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+mod tempconfig {
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+
+    pub struct TempConfig {
+        path: PathBuf,
+    }
+
+    impl TempConfig {
+        pub fn write() -> Self {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("notifier-host-test-{}-{}.conf", std::process::id(), nanos));
+            let contents = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <listen>unix:tmpdir=/tmp</listen>
+  <policy context="default">
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>
+"#;
+            let mut f = std::fs::File::create(&path).expect("failed to create temp dbus config");
+            f.write_all(contents.as_bytes()).expect("failed to write temp dbus config");
+
+            Self { path }
+        }
+
+        pub fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempConfig {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+// ---------- Stub watcher interface ----------
+
+struct StubWatcher {
+    items: Arc<Mutex<Vec<String>>>,
+}
+
+#[zbus::dbus_interface(name = "org.kde.StatusNotifierWatcher")]
+impl StubWatcher {
+    async fn register_status_notifier_host(&self, _service: &str) -> zbus::fdo::Result<()> {
+        Ok(())
+    }
+
+    async fn register_status_notifier_item(
+        &self,
+        service: &str,
+        #[zbus(signal_context)] ctxt: zbus::SignalContext<'_>,
+    ) -> zbus::fdo::Result<()> {
+        self.items.lock().unwrap().push(service.to_string());
+        StubWatcher::status_notifier_item_registered(&ctxt, service).await?;
+
+        Ok(())
+    }
+
+    #[dbus_interface(signal)]
+    async fn status_notifier_item_registered(ctxt: &zbus::SignalContext<'_>, service: &str) -> zbus::Result<()>;
+
+    #[dbus_interface(signal)]
+    async fn status_notifier_item_unregistered(ctxt: &zbus::SignalContext<'_>, service: &str) -> zbus::Result<()>;
+
+    #[dbus_interface(property)]
+    async fn registered_status_notifier_items(&self) -> Vec<String> {
+        self.items.lock().unwrap().clone()
+    }
+
+    #[dbus_interface(property)]
+    async fn is_status_notifier_host_registered(&self) -> bool {
+        true
+    }
+
+    #[dbus_interface(property)]
+    fn protocol_version(&self) -> i32 {
+        0
+    }
+}
+
+async fn start_stub_watcher(bus_address: &str, items: Vec<String>) -> zbus::Connection {
+    let con = zbus::ConnectionBuilder::address(bus_address)
+        .unwrap()
+        .build()
+        .await
+        .expect("stub: failed to connect");
+    con.object_server()
+        .at(WATCHER_OBJECT, StubWatcher { items: Arc::new(Mutex::new(items)) })
+        .await
+        .expect("stub: failed to install interface");
+    con.request_name_with_flags(
+        WATCHER_BUS,
+        [zbus::fdo::RequestNameFlags::DoNotQueue].into_iter().collect(),
+    )
+    .await
+    .expect("stub: failed to request name");
+
+    con
+}
+
+// ---------- Test host ----------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HostEvent {
+    Add(String),
+    Remove(String),
+    Clear,
+}
+
+#[derive(Default)]
+struct TestHost {
+    events: Arc<Mutex<Vec<HostEvent>>>,
+}
+
+impl TestHost {
+    fn events_handle(&self) -> Arc<Mutex<Vec<HostEvent>>> {
+        self.events.clone()
+    }
+}
+
+impl notifier_host::Host for TestHost {
+    fn add_item(&mut self, id: &str, _item: notifier_host::Item) {
+        self.events.lock().unwrap().push(HostEvent::Add(id.to_string()));
+    }
+
+    fn remove_item(&mut self, id: &str) {
+        self.events.lock().unwrap().push(HostEvent::Remove(id.to_string()));
+    }
+
+    fn clear(&mut self) {
+        self.events.lock().unwrap().push(HostEvent::Clear);
+    }
+}
+
+// ---------- Helpers ----------
+
+async fn wait_for<F, Fut, T>(timeout: Duration, mut f: F) -> Option<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<T>>,
+{
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if let Some(v) = f().await {
+            return Some(v);
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    None
+}
+
+async fn get_owner(con: &zbus::Connection, name: &str) -> Option<String> {
+    let dbus = zbus::fdo::DBusProxy::new(con).await.unwrap();
+    match dbus.get_name_owner(zbus::names::BusName::try_from(name).unwrap()).await {
+        Ok(o) => Some(o.to_string()),
+        Err(zbus::fdo::Error::NameHasNoOwner(_)) => None,
+        Err(e) => panic!("unexpected get_name_owner error: {}", e),
+    }
+}
+
+// ---------- Tests ----------
+
+#[tokio::test]
+#[ignore]
+async fn watcher_claims_name_when_initial_owner_departs() {
+    let bus = TempBus::spawn();
+
+    let stub = start_stub_watcher(&bus.address, vec![]).await;
+    let stub_unique = stub.unique_name().unwrap().to_string();
+
+    let eww_con = bus.connect().await;
+    notifier_host::Watcher::new().attach_to(&eww_con).await.expect("attach_to failed");
+
+    let observer = bus.connect().await;
+    let owner_now = get_owner(&observer, WATCHER_BUS).await;
+    assert_eq!(owner_now.as_deref(), Some(stub_unique.as_str()));
+
+    drop(stub);
+
+    let eww_unique = eww_con.unique_name().unwrap().to_string();
+    let acquired = wait_for(Duration::from_secs(5), || async {
+        let owner = get_owner(&observer, WATCHER_BUS).await;
+        (owner.as_deref() == Some(eww_unique.as_str())).then_some(())
+    })
+    .await;
+    assert!(acquired.is_some(), "eww failed to claim {} after stub departed", WATCHER_BUS);
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore]
+async fn run_host_forever_waits_for_initial_owner_then_rebootstraps() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let bus = TempBus::spawn();
+            let host_con = bus.connect().await;
+            let mut host = TestHost::default();
+            let events = host.events_handle();
+
+            let host_task = tokio::task::spawn_local(async move {
+                notifier_host::run_host_forever(&mut host, &host_con).await
+            });
+
+            // No watcher on the bus: run_host_forever should block, not emit any events.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert!(events.lock().unwrap().is_empty(), "host should not have received events before any watcher exists");
+
+            // Bring up stub #1. Expect the first Clear (bootstrap).
+            let stub1 = start_stub_watcher(&bus.address, vec![]).await;
+
+            let clear_count = |evs: &[HostEvent]| evs.iter().filter(|e| matches!(e, HostEvent::Clear)).count();
+
+            let saw_first_bootstrap = wait_for(Duration::from_secs(5), || async {
+                (clear_count(&events.lock().unwrap()) >= 1).then_some(())
+            })
+            .await;
+            assert!(
+                saw_first_bootstrap.is_some(),
+                "host did not bootstrap after first watcher came up; got {:?}",
+                events.lock().unwrap()
+            );
+
+            // Swap to stub #2; expect a second Clear from the rebootstrap.
+            drop(stub1);
+            let _stub2 = start_stub_watcher(&bus.address, vec![]).await;
+
+            let saw_rebootstrap = wait_for(Duration::from_secs(5), || async {
+                (clear_count(&events.lock().unwrap()) >= 2).then_some(())
+            })
+            .await;
+            assert!(
+                saw_rebootstrap.is_some(),
+                "host did not see a second Clear after watcher swap; got {:?}",
+                events.lock().unwrap()
+            );
+
+            host_task.abort();
+        })
+        .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn register_as_host_reuses_single_name_across_calls() {
+    let bus = TempBus::spawn();
+    let _stub = start_stub_watcher(&bus.address, vec![]).await;
+    let con = bus.connect().await;
+
+    // Simulate three open/close cycles on the same (shared) connection.
+    let (name1, _) = notifier_host::register_as_host(&con).await.expect("first register");
+    let (name2, _) = notifier_host::register_as_host(&con).await.expect("second register");
+    let (name3, _) = notifier_host::register_as_host(&con).await.expect("third register");
+
+    // The same well-known name is reused, not incremented (-1, -2, -3).
+    assert_eq!(name1, name2);
+    assert_eq!(name2, name3);
+
+    // And the bus shows exactly one StatusNotifierHost-* name, not a growing list.
+    let dbus = zbus::fdo::DBusProxy::new(&con).await.unwrap();
+    let names = dbus.list_names().await.unwrap();
+    let host_names: Vec<String> = names
+        .iter()
+        .map(|n| n.as_str().to_string())
+        .filter(|n| n.starts_with("org.freedesktop.StatusNotifierHost-"))
+        .collect();
+
+    assert_eq!(host_names.len(), 1, "expected exactly one host name, got {:?}", host_names);
+}
+
+#[allow(dead_code)]
+const _: () = {
+    // Silence unused warnings for HostEvent::Remove if no test uses it.
+    let _ = HostEvent::Remove;
+};


### PR DESCRIPTION
The systray's DBus connection was attached to whichever process owned the `org.kde.StatusNotifierWatcher` well-known name at the moment eww started. On graphical sessions where a transient fallback watcher (e.g. libayatana-appindicator's) claims the name during boot and then exits when a longer-lived watcher takes over, eww silently desynced: its host-side registrations and signal subscriptions stayed bound to the now-dead original owner, and the tray appeared empty until the user restarted eww. The same failure mode also occurred when eww queued for the name without `DoNotQueue` and later became primary owner. The host had no way to notice it was now talking to itself instead of the watcher it had registered against.

The fix has two halves. On the watcher side, name acquisition uses `DoNotQueue`; if another process holds the name, a background task monitors `NameOwnerChanged` and claims the name once the current owner departs (looping to handle a third party racing in between). On the host side, a new `run_host_forever` entry point subscribes to `NameOwnerChanged` for the watcher bus name and re-bootstraps the entire host registration whenever the owner changes, calling a new `Host::clear` hook so the UI can drop stale items before they are re-enumerated against the new owner. `run_host_forever` blocks until an owner exists before registering, so neither the initial-startup race nor a fast owner-flap can leave the host calling a missing watcher.

This should address #1224 (systray empty on boot, "fixed" by sleeping and restarting eww) and likely #1065 (systray failing to come back after a window-manager reload), which present the same underlying ownership-handoff race.

Closes #1224
Closes #1065
