### PR TITLE
feat: Add `unfocus-close` property in defwindow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Add `value-pos` to scale widget (By: ipsvn)
 - Add `floor` and `ceil` function calls to simplexpr (By: wsbankenstein)
 - Add `formatbytes` function calls to simplexpr (By: topongo)
+- Add `unfocus-close` property in defwindow (By: liegle)
 
 ## [0.6.0] (21.04.2024)
 

--- a/crates/eww/src/app.rs
+++ b/crates/eww/src/app.rs
@@ -473,6 +473,32 @@ impl<B: DisplayBackend> App<B> {
                 }
             }
 
+            if initiator.unfocus_close {
+                eww_window.gtk_window.connect_focus_out_event({
+                    let app_evt_sender = self.app_evt_send.clone();
+                    let instance_id = instance_id.to_string();
+                    move |_, _| {
+                        // we don't care about the actual error response from the daemon as this is mostly just a fallback.
+                        // Generally, this should get disconnected before the gtk window gets destroyed.
+                        // This callback is triggered in 2 cases:
+                        // - When the monitor of this window gets disconnected
+                        // - When the window is closed manually.
+                        // We don't distinguish here and assume the window should be reopened once a monitor
+                        // becomes available again
+                        let (response_sender, _) = daemon_response::create_pair();
+                        let command = DaemonCommand::CloseWindows {
+                            windows: vec![instance_id.clone()],
+                            auto_reopen: false,
+                            sender: response_sender,
+                        };
+                        if let Err(err) = app_evt_sender.send(command) {
+                            log::error!("Error sending close window command to daemon after gtk window destroy event: {}", err);
+                        }
+                        gtk::glib::Propagation::Proceed
+                    }
+                });
+            }
+
             eww_window.destroy_event_handler_id = Some(eww_window.gtk_window.connect_destroy({
                 let app_evt_sender = self.app_evt_send.clone();
                 let instance_id = instance_id.to_string();

--- a/crates/eww/src/window_initiator.rs
+++ b/crates/eww/src/window_initiator.rs
@@ -21,6 +21,7 @@ pub struct WindowInitiator {
     pub monitor: Option<MonitorIdentifier>,
     pub name: String,
     pub resizable: bool,
+    pub unfocus_close: bool,
     pub stacking: WindowStacking,
 }
 
@@ -40,6 +41,7 @@ impl WindowInitiator {
             name: window_def.name.clone(),
             resizable: window_def.eval_resizable(&vars)?,
             stacking: window_def.eval_stacking(&vars)?,
+            unfocus_close: window_def.eval_close_on_focus_lost(&vars)?,
             local_variables: vars,
         })
     }

--- a/crates/yuck/src/config/window_definition.rs
+++ b/crates/yuck/src/config/window_definition.rs
@@ -39,6 +39,7 @@ pub struct WindowDefinition {
     pub monitor: Option<SimplExpr>,
     pub widget: WidgetUse,
     pub resizable: Option<SimplExpr>,
+    pub unfocus_close: Option<SimplExpr>,
     pub backend_options: BackendWindowOptionsDef,
 }
 
@@ -72,6 +73,13 @@ impl WindowDefinition {
             None => Ok(WindowStacking::Foreground),
         }
     }
+
+    pub fn eval_close_on_focus_lost(&self, local_variables: &HashMap<VarName, DynVal>) -> Result<bool, EvalError> {
+        Ok(match &self.unfocus_close {
+            Some(expr) => expr.eval(local_variables)?.as_bool()?,
+            None => false,
+        })
+    }
 }
 
 impl FromAstElementContent for WindowDefinition {
@@ -86,10 +94,22 @@ impl FromAstElementContent for WindowDefinition {
         let resizable = attrs.ast_optional("resizable")?;
         let stacking = attrs.ast_optional("stacking")?;
         let geometry = attrs.ast_optional("geometry")?;
+        let unfocus_close = attrs.ast_optional("unfocus-close")?;
         let backend_options = BackendWindowOptionsDef::from_attrs(&mut attrs)?;
         let widget = iter.expect_any().map_err(DiagError::from).and_then(WidgetUse::from_ast)?;
         iter.expect_done()?;
-        Ok(Self { name, expected_args, args_span, monitor, resizable, widget, stacking, geometry, backend_options })
+        Ok(Self {
+            name,
+            expected_args,
+            args_span,
+            monitor,
+            resizable,
+            widget,
+            stacking,
+            geometry,
+            unfocus_close,
+            backend_options,
+        })
     }
 }
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -52,6 +52,7 @@ You can now open your first window by running `eww open example`! Glorious!
 | ---------: | ------------------------------------------------------------ |
 |  `monitor` | Which monitor this window should be displayed on. See below for details.|
 | `geometry` | Geometry of the window.  |
+| `unfocus-close` | Automaticly close this window when losing keyboard focus. |
 
 
 **`monitor`-property**


### PR DESCRIPTION
## Description

Add `unfocus-close` property in defwindow to automaticly close the window when it loses keyboard focus.

## Usage

```
(defwindow menu [monitor]
    :monitor monitor
    :geometry (geometry
        :x '0px'
        :y '2px'
        :anchor 'top center')
    :stacking 'overlay'
    :exclusive false
    :focusable 'ondemand'
    :unfocus-close true ; It is used here
    :namespace 'eww-menu'
    'This is a menu')
```

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [x] All widgets I've added are correctly documented.
_no widgets added_
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
