### PR TITLE
Release profile settings in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ zbus = { version = "3.15.2", default-features = false, features = ["tokio"] }
 
 [profile.dev]
 split-debuginfo = "unpacked"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,7 @@ zbus = { version = "3.15.2", default-features = false, features = ["tokio"] }
 split-debuginfo = "unpacked"
 
 [profile.release]
+opt-level = "z"
 lto = "fat"
+strip = "symbols"
 codegen-units = 1


### PR DESCRIPTION
Adds release profile settings in `Cargo.toml` of the repository for smaller binary sizes. It takes the binary size of eww down to `10M` from the previous `17M`.