### PR TITLE
Fix :visible updates being lost for unmapped widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to eww will be listed here, starting at changes since versio
   Attempting to index in an empty JSON string (`'""'`) is now an error.
 
 ### Fixes
+- Fix `:visible` updates being lost for widgets that have not yet been mapped, e.g. inside a closed revealer (By: 61021)
 - Fix crash on invalid `formattime` format string (By: luca3s)
 - Fix crash on NaN or infinite graph value (By: luca3s)
 - Re-enable some scss features (By: w-lfchen)

--- a/crates/eww/src/widgets/widget_definitions.rs
+++ b/crates/eww/src/widgets/widget_definitions.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     cmp::Ordering,
     collections::{HashMap, HashSet},
     rc::Rc,
@@ -150,15 +150,22 @@ pub(super) fn resolve_widget_attrs(bargs: &mut BuilderArgs, gtk_widget: &gtk::Wi
     let css_provider = gtk::CssProvider::new();
     let css_provider2 = css_provider.clone();
 
+    // the first-map handler reads this cell so `visible` updates before the first map aren't lost
+    // (a closed revealer's children map long after build)
+    let latest_visible = Rc::new(Cell::new(true));
     let visible_result: Result<_> = (|| {
         let visible_expr = bargs.widget_use.attrs.attrs.get("visible").map(|x| x.value.as_simplexpr()).transpose()?;
         if let Some(visible_expr) = visible_expr {
             let visible = bargs.scope_graph.evaluate_simplexpr_in_scope(bargs.calling_scope, &visible_expr)?.as_bool()?;
-            connect_first_map(gtk_widget, move |w| {
-                if visible {
-                    w.show();
-                } else {
-                    w.hide();
+            latest_visible.set(visible);
+            connect_first_map(gtk_widget, {
+                let latest_visible = latest_visible.clone();
+                move |w| {
+                    if latest_visible.get() {
+                        w.show();
+                    } else {
+                        w.hide();
+                    }
                 }
             });
         }
@@ -207,6 +214,7 @@ pub(super) fn resolve_widget_attrs(bargs: &mut BuilderArgs, gtk_widget: &gtk::Wi
         },
         // @prop visible - visibility of the widget
         prop(visible: as_bool = true) {
+            latest_visible.set(visible);
             if visible { gtk_widget.show(); } else { gtk_widget.hide(); }
         },
         // @prop style - inline scss style applied to the widget


### PR DESCRIPTION
## Description

Fixes #1451.

The initial value of `:visible` is applied at the widget's **first map** (`connect_first_map`) so that it survives the window's `show_all` — but the value was captured at build time. For widgets whose first map happens later (children of a closed `revealer` being the common case), every reactive `:visible` update issued in between was clobbered by that stale snapshot the moment the widget finally mapped: `update vis=true` while the revealer was closed left the widget hidden after revealing, even though `eww state` showed the right value.

The fix keeps the latest value in a shared `Rc<Cell<bool>>`: the reactive `visible` prop writes to it, and the first-map handler reads it instead of a build-time copy. No behavior change for the ordinary cases (initial value application and reactive toggling while mapped work exactly as before — the cell starts with the evaluated initial value).

## Usage

No configuration changes — existing configs just start behaving as expected:

```lisp
(defvar reveal false)
(defvar vis false)

(revealer :reveal reveal
  (label :visible vis :text "hello"))
```

```console
$ eww update vis=true     ; while the revealer is closed
$ eww update reveal=true  ; label now correctly appears
```

### Showcase

Same sequence (`vis=true` while closed → reveal), before and after, on master 48f5aa8:

| before (bug: `vis: true` but widget hidden) | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/61021/eww/shots/visible-latch/before-master.png) | ![after](https://raw.githubusercontent.com/61021/eww/shots/visible-latch/after-fixed.png) |

The hide-while-closed direction (which already worked, since a hidden widget never maps) is unchanged:

![hide direction](https://raw.githubusercontent.com/61021/eww/shots/visible-latch/after-fixed-hide-direction.png)

## Additional Notes

- Verified on a live Wayland/Hyprland session (both directions, plus toggling while revealed).
- `cargo fmt` and `cargo clippy` clean; CHANGELOG entry added.
