### PR TITLE
Always redirect daemon output to the log file when detaching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to eww will be listed here, starting at changes since versio
   Attempting to index in an empty JSON string (`'""'`) is now an error.
 
 ### Fixes
+- Fix `eww logs` staying empty when the daemon was not started from a terminal (By: 61021)
 - Fix crash on invalid `formattime` format string (By: luca3s)
 - Fix crash on NaN or infinite graph value (By: luca3s)
 - Re-enable some scss features (By: w-lfchen)

--- a/crates/eww/src/server.rs
+++ b/crates/eww/src/server.rs
@@ -283,12 +283,9 @@ fn do_detach(log_file_path: impl AsRef<Path>) -> Result<ForkResult> {
         .unwrap_or_else(|_| panic!("Error opening log file ({}), for writing", log_file_path.as_ref().to_string_lossy()));
     let fd = file.as_raw_fd();
 
-    if nix::unistd::isatty(1)? {
-        nix::unistd::dup2(fd, std::io::stdout().as_raw_fd())?;
-    }
-    if nix::unistd::isatty(2)? {
-        nix::unistd::dup2(fd, std::io::stderr().as_raw_fd())?;
-    }
+    // unconditional: autostart/launcher spawns have no tty and would otherwise never log
+    nix::unistd::dup2(fd, std::io::stdout().as_raw_fd())?;
+    nix::unistd::dup2(fd, std::io::stderr().as_raw_fd())?;
 
     Ok(ForkResult::Child)
 }


### PR DESCRIPTION
## Description

Fixes #1453.

`do_detach` only redirected the detached daemon's stdout/stderr into the log file when they were a tty. Spawned from a compositor autostart (`exec-once`), a launcher script, systemd, or any redirected shell — i.e. the usual ways to start a bar — the inherited fds are a pipe or `/dev/null`, both `isatty` checks are false, and the log file stays 0 bytes forever. Every runtime diagnostic (including the formatted expression/type errors) went somewhere nobody reads, while the startup banner tells users to check `eww logs`.

This makes the redirection unconditional: after the double fork the process has no controlling terminal to lose, and the log file is the only place diagnostics can survive.

## Usage

No configuration changes. `eww logs` now works for daemons started outside a terminal:

```console
$ eww daemon > /dev/null 2>&1   # or exec-once = eww daemon
$ eww open mywindow             # trigger any runtime expression error
$ eww logs                      # now actually shows it
```

Behavior note: `eww daemon > somefile 2>&1` previously kept daemon output in `somefile`; it now goes to the eww log file like everything else (which is what `eww logs` reads).

### Showcase

Same detached-daemon sequence (`eww daemon > /dev/null 2>&1`, open a window, deflisten emits a value that makes `:visible {feed.x}` evaluate `null`), before and after, master 48f5aa8:

```console
# before
$ wc -c ~/.cache/eww/eww_6295ca38c6c6671a.log
0
$ eww logs
(nothing)

# after
$ grep -ac "Failed to turn" ~/.cache/eww/eww_6295ca38c6c6671a.log
5
$ eww logs
error: Failed to turn `null` into a value of type bool
   ┌─ …/eww.yuck:10:22
   │
10 │     (label :visible {feed.vis} :text "VIS-BOUND")
   │                      ──────── `null` is not of type `bool`
…
```

## Additional Notes

- Verified live on a Wayland/Hyprland session against both the v0.6.0 release binary (bug) and a master build with this patch (fixed).
- CHANGELOG entry added.
