### PR TITLE
Made `ast_optional` non-destructive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to eww will be listed here, starting at changes since versio
 - Load systray items that are registered without a path (By: Kage-Yami)
 - `get_locale` now follows POSIX standard for locale selection (By: mirhahn, w-lfchen)
 - Improve multi-monitor handling under wayland (By: bkueng)
+- Fix widgets with multiple command handlers (`eventbox`, `input`) ignoring `:timeout` (By: vojtref)
 
 ### Features
 - Add warning and docs for incompatible `:anchor` and `:exclusive` options

--- a/crates/yuck/src/config/attributes.rs
+++ b/crates/yuck/src/config/attributes.rs
@@ -63,8 +63,8 @@ impl Attributes {
     }
 
     pub fn ast_optional<T: FromAst>(&mut self, key: &str) -> Result<Option<T>, DiagError> {
-        match self.attrs.remove(&AttrName(key.to_string())) {
-            Some(AttrEntry { value, .. }) => T::from_ast(value).map(Some),
+        match self.attrs.get(&AttrName(key.to_string())) {
+            Some(entry) => T::from_ast(entry.value.clone()).map(Some),
             None => Ok(None),
         }
     }


### PR DESCRIPTION
## Description

Made `ast_optional` retrieve attributes from the attribute map non-destructively.

## Additional Notes

Previous behaviour had the `:timeout` attribute (currently the only reused attribute) immediately discarded even when checking non-existent command handlers, with all subsequent uses defaulting to 200 ms (see linked issues below). Keeping optional attributes in the property map avoids this problem, and potential future issues with attribute reuse.
`ast_required` may, at present, be kept destructive, as no required attributes are reused. Making all retrieval non-destructive is, however, worth considering.

Fixes #715.
Fixes #756.
Fixes #965.

## Checklist

- [x] All widgets I've added are correctly documented.
- [x] I added my changes to CHANGELOG.md, if appropriate.
- [x] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
