### PR TITLE
docs(examples): add a standalone weather widget example

### DIFF
--- a/examples/weather-widget/assets/icons/cloudy.svg
+++ b/examples/weather-widget/assets/icons/cloudy.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="c-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3AB0B4"/>
+      <stop offset="100%" stop-color="#1A7A9E"/>
+    </linearGradient>
+    <linearGradient id="c-gloss" x1="0%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+    <filter id="c-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="1.5" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <path d="M8 33 Q8 28 13 26 Q17 22 22 24 Q26 20 31 22 Q35 18 39 22 Q43 22 43 28 Q43 32 39 33 L8 33Z" fill="url(#c-grad)" filter="url(#c-glow)"/>
+  <ellipse cx="18" cy="28" rx="12" ry="3.5" fill="url(#c-gloss)"/>
+  <path d="M12 37 Q12 32 17 30 Q21 26 27 28 Q31 24 36 26 Q40 26 40 32 Q40 36 36 37 L12 37Z" fill="url(#c-grad)" opacity="0.5"/>
+</svg>

--- a/examples/weather-widget/assets/icons/foggy.svg
+++ b/examples/weather-widget/assets/icons/foggy.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="f-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3AB0B4"/>
+      <stop offset="100%" stop-color="#1A7A9E"/>
+    </linearGradient>
+    <linearGradient id="f-gloss" x1="0%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.20)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+    <filter id="f-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="1.5" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <path d="M6 22 Q6 18 12 18 Q16 14 22 18 Q26 14 32 18 Q36 14 42 18 Q46 18 46 22 Q46 26 42 26 L6 26Z" fill="url(#f-grad)" filter="url(#f-glow)" opacity="0.5"/>
+  <ellipse cx="20" cy="22" rx="14" ry="3" fill="url(#f-gloss)"/>
+  <path d="M6 30 Q6 26 12 26 Q16 22 22 26 Q26 22 32 26 Q36 22 42 26 Q46 26 46 30 Q46 34 42 34 L6 34Z" fill="url(#f-grad)" filter="url(#f-glow)" opacity="0.5"/>
+  <ellipse cx="22" cy="30" rx="14" ry="3" fill="url(#f-gloss)"/>
+</svg>

--- a/examples/weather-widget/assets/icons/partly-cloudy.svg
+++ b/examples/weather-widget/assets/icons/partly-cloudy.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="pc-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3AB0B4"/>
+      <stop offset="100%" stop-color="#1299CA"/>
+    </linearGradient>
+    <linearGradient id="pc-gloss" x1="0%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.30)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+    <filter id="pc-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="1.5" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="18" cy="18" r="7" fill="url(#pc-grad)" filter="url(#pc-glow)"/>
+  <ellipse cx="16" cy="15" rx="3" ry="2" fill="url(#pc-gloss)"/>
+  <path d="M14 31 Q14 26 19 26 Q22 22 27 24 Q31 20 36 23 Q40 23 40 28 Q40 32 36 33 L14 33Z" fill="url(#pc-grad)" filter="url(#pc-glow)"/>
+  <ellipse cx="22" cy="27" rx="10" ry="3.5" fill="url(#pc-gloss)"/>
+</svg>

--- a/examples/weather-widget/assets/icons/rainy.svg
+++ b/examples/weather-widget/assets/icons/rainy.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="r-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4A7A9E"/>
+      <stop offset="100%" stop-color="#1A5A7E"/>
+    </linearGradient>
+    <linearGradient id="r-gloss" x1="0%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.20)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+    <linearGradient id="rain" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3AB0B4"/>
+      <stop offset="100%" stop-color="#1299CA"/>
+    </linearGradient>
+    <filter id="r-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="1.5" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <path d="M6 28 Q6 23 11 21 Q15 17 21 19 Q25 15 30 17 Q34 13 39 17 Q43 17 43 23 Q43 27 39 28 L6 28Z" fill="url(#r-grad)" filter="url(#r-glow)"/>
+  <ellipse cx="16" cy="24" rx="10" ry="3" fill="url(#r-gloss)"/>
+  <g stroke="url(#rain)" stroke-width="1.5" stroke-linecap="round" opacity="0.6">
+    <line x1="12" y1="32" x2="10" y2="38"/>
+    <line x1="20" y1="32" x2="18" y2="39"/>
+    <line x1="28" y1="32" x2="26" y2="38"/>
+    <line x1="36" y1="32" x2="34" y2="39"/>
+  </g>
+</svg>

--- a/examples/weather-widget/assets/icons/snowy.svg
+++ b/examples/weather-widget/assets/icons/snowy.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="n-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5AB0B4"/>
+      <stop offset="100%" stop-color="#2A8A9E"/>
+    </linearGradient>
+    <linearGradient id="n-gloss" x1="0%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+    <filter id="n-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="1.5" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <path d="M6 26 Q6 21 11 19 Q15 15 21 17 Q25 13 30 15 Q34 11 39 15 Q43 15 43 21 Q43 25 39 26 L6 26Z" fill="url(#n-grad)" filter="url(#n-glow)"/>
+  <ellipse cx="16" cy="22" rx="10" ry="3" fill="url(#n-gloss)"/>
+  <g stroke="#C8F0F0" stroke-width="1.5" stroke-linecap="round" opacity="0.5">
+    <line x1="14" y1="30" x2="14" y2="38"/>
+    <line x1="10" y1="34" x2="18" y2="34"/>
+    <line x1="24" y1="30" x2="24" y2="38"/>
+    <line x1="20" y1="34" x2="28" y2="34"/>
+    <line x1="34" y1="30" x2="34" y2="38"/>
+    <line x1="30" y1="34" x2="38" y2="34"/>
+  </g>
+</svg>

--- a/examples/weather-widget/assets/icons/sunny.svg
+++ b/examples/weather-widget/assets/icons/sunny.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="s-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3AB0B4"/>
+      <stop offset="100%" stop-color="#1299CA"/>
+    </linearGradient>
+    <linearGradient id="s-gloss" x1="0%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.35)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+    <filter id="s-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="2" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <g stroke="url(#s-grad)" stroke-width="1.8" stroke-linecap="round" opacity="0.5">
+    <line x1="24" y1="7" x2="24" y2="4"/>
+    <line x1="24" y1="41" x2="24" y2="44"/>
+    <line x1="7" y1="24" x2="4" y2="24"/>
+    <line x1="41" y1="24" x2="44" y2="24"/>
+    <line x1="12.5" y1="12.5" x2="10" y2="10"/>
+    <line x1="35.5" y1="12.5" x2="38" y2="10"/>
+    <line x1="12.5" y1="35.5" x2="10" y2="38"/>
+    <line x1="35.5" y1="35.5" x2="38" y2="38"/>
+  </g>
+  <circle cx="24" cy="24" r="10" fill="url(#s-grad)" filter="url(#s-glow)"/>
+  <ellipse cx="21" cy="20" rx="6" ry="4" fill="url(#s-gloss)"/>
+</svg>

--- a/examples/weather-widget/eww.scss
+++ b/examples/weather-widget/eww.scss
@@ -1,0 +1,182 @@
+.weather-container {
+  background: rgba(10, 22, 40, 0.90);
+  border: 1px solid #1B3D5C;
+  border-radius: 26px;
+  padding: 24px 26px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 24px rgba(18, 153, 202, 0.15),
+    0 4px 32px rgba(10, 22, 40, 0.50),
+    0 8px 44px rgba(0, 0, 0, 0.25);
+}
+
+.weather-header {
+  margin-bottom: 10px;
+  padding: 0 2px;
+}
+
+.loc-icon {
+  font-size: 14px;
+  margin-right: 6px;
+  color: #1299CA;
+}
+
+.loc-text {
+  font-size: 17px;
+  font-weight: 600;
+  color: #C8F0F0;
+}
+
+.header-sub {
+  font-size: 12px;
+  color: #7799AA;
+  margin-top: 2px;
+  margin-left: 20px;
+}
+
+.weather-actions button {
+  padding: 5px 10px;
+  border-radius: 10px;
+  font-size: 13px;
+  color: #557788;
+}
+
+.weather-actions button:hover {
+  background: #153344;
+  color: #1299CA;
+}
+
+.weather-current {
+  margin: 10px 0;
+  padding: 12px 0;
+  border-top: 1px solid #1A3048;
+  border-bottom: 1px solid #1A3048;
+}
+
+.weather-icon-wrap {
+  margin: 3px 0;
+  padding: 8px;
+  background: #101F33;
+  border-radius: 18px;
+  border: 1px solid #1B3148;
+}
+
+.weather-temp {
+  font-size: 44px;
+  font-weight: 700;
+  color: #C8F0F0;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.hi-lo-row {
+  margin-top: 4px;
+  padding: 0 12px;
+}
+
+.hi-lo-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #88AABB;
+}
+
+.feels-text {
+  font-size: 12px;
+  color: #669988;
+  margin-left: 18px;
+}
+
+.weather-details {
+  margin: 12px 0;
+  padding: 10px 0;
+  border-bottom: 1px solid #1A3048;
+}
+
+.detail-item {
+  padding: 8px 10px;
+  border-radius: 14px;
+  background: #0D1B30;
+  border: 1px solid #152A40;
+  min-width: 55px;
+}
+
+.detail-item:hover {
+  background: #122D44;
+  border-color: #1A4A66;
+}
+
+.detail-icon {
+  font-size: 14px;
+  color: #1299CA;
+  margin-bottom: 3px;
+}
+
+.detail-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: #C8F0F0;
+}
+
+.detail-label {
+  font-size: 9px;
+  color: #556677;
+  margin-top: 2px;
+}
+
+.weather-forecast {
+  margin: 10px 0;
+}
+
+.forecast-day {
+  padding: 10px 14px;
+  border-radius: 16px;
+  background: #0D1B30;
+  border: 1px solid #152A40;
+  min-width: 75px;
+}
+
+.forecast-day:hover {
+  background: #122D44;
+  border-color: #1A4A66;
+}
+
+.fc-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #7799AA;
+  margin-top: 4px;
+}
+
+.fc-temp {
+  font-size: 17px;
+  font-weight: 700;
+  color: #C8F0F0;
+  margin-top: 3px;
+}
+
+.fc-min {
+  font-size: 11px;
+  color: #556677;
+}
+
+.footer-row {
+  margin-top: 10px;
+  padding: 0 4px;
+}
+
+.updated-text {
+  font-size: 10px;
+  color: #334455;
+}
+
+.glass-shine {
+  min-height: 1px;
+  margin-top: 6px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.04) 30%,
+    rgba(255, 255, 255, 0.06) 50%,
+    rgba(255, 255, 255, 0.04) 70%,
+    transparent 100%
+  );
+}

--- a/examples/weather-widget/eww.yuck
+++ b/examples/weather-widget/eww.yuck
@@ -1,0 +1,103 @@
+(defwindow weather
+  :monitor 0
+  :geometry (geometry :x "2%" :y "6%" :width 430 :height 550 :anchor "top right")
+  :windowtype "notification"
+  :stacking "overlay"
+  :focusable false
+  :decorations false
+  :wm-ignore true
+  :reserve (struts :distance "0" :enabled false)
+  (weather-widget))
+
+(defpoll weather_data :interval "1800s"
+  :initial "{\"temp\":\"--\",\"condition\":\"Loading...\",\"city\":\"...\"}"
+  `./scripts/weather.sh`)
+
+(defwidget weather-widget []
+  (box :class "weather-container"
+       :orientation "v"
+       :space-evenly false
+
+       ;; Header
+       (box :class "weather-header"
+            :orientation "v"
+            :space-evenly false
+
+            ;; Actions row (top-right)
+            (box :class "weather-actions"
+                 :orientation "h"
+                 :space-evenly false
+                 :halign "end"
+                 (button :onclick "eww update weather_data=\"$(./scripts/weather.sh --force)\""
+                          (label :text "↻" :class "act-icon"))
+                 (button :onclick "eww close weather"
+                         (label :text "✕" :class "act-icon")))
+
+            ;; Location (centered)
+            (box :class "weather-location"
+                 :orientation "v"
+                 (box :orientation "h" :space-evenly false :halign "center"
+                      (label :text "⊡" :class "loc-icon")
+                      (label :text "${weather_data.city}" :class "loc-text"))
+                 (label :text "${weather_data.condition} · ${weather_data.temp}°C" :class "header-sub" :halign "center")))
+
+       ;; Current weather
+       (box :class "weather-current"
+            :orientation "v"
+            :space-evenly false
+            (box :class "weather-icon-wrap" :halign "center"
+                 (image :path "${weather_data.icon}" :image-width 72 :image-height 72))
+            (label :text "${weather_data.temp}°C" :class "weather-temp" :halign "center")
+            (box :class "hi-lo-row" :orientation "h" :space-evenly false :halign "center"
+                 (label :text "H:${weather_data.today_max}° L:${weather_data.today_min}°" :class "hi-lo-text")
+                 (label :text "Feels ${weather_data.feels}°" :class "feels-text")))
+
+       ;; Details row
+       (box :class "weather-details"
+            :orientation "h"
+            :spacing 10
+            :space-evenly true
+            (box :class "detail-item" :orientation "v"
+                 (label :text "≡" :class "detail-icon")
+                 (label :text "${weather_data.humidity}%" :class "detail-value")
+                 (label :text "Humidity" :class "detail-label"))
+            (box :class "detail-item" :orientation "v"
+                 (label :text "→" :class "detail-icon")
+                 (label :text "${weather_data.wind}km/h" :class "detail-value")
+                 (label :text "Wind" :class "detail-label"))
+            (box :class "detail-item" :orientation "v"
+                 (label :text "⊙" :class "detail-icon")
+                 (label :text "${weather_data.uv}" :class "detail-value")
+                 (label :text "UV" :class "detail-label"))
+            (box :class "detail-item" :orientation "v"
+                 (label :text "☁" :class "detail-icon")
+                 (label :text "${weather_data.cloud}%" :class "detail-value")
+                 (label :text "Cloud" :class "detail-label")))
+
+       ;; Forecast
+       (box :class "weather-forecast"
+            :orientation "h"
+            :spacing 12
+            :space-evenly true
+            (box :class "forecast-day" :orientation "v"
+                 (image :path "${weather_data.fc0_icon}" :image-width 32 :image-height 32)
+                 (label :text "${weather_data.fc0_day}" :class "fc-label")
+                 (label :text "${weather_data.fc0_temp}°" :class "fc-temp")
+                 (label :text "${weather_data.fc0_min}°" :class "fc-min"))
+            (box :class "forecast-day" :orientation "v"
+                 (image :path "${weather_data.fc1_icon}" :image-width 32 :image-height 32)
+                 (label :text "${weather_data.fc1_day}" :class "fc-label")
+                 (label :text "${weather_data.fc1_temp}°" :class "fc-temp")
+                 (label :text "${weather_data.fc1_min}°" :class "fc-min"))
+            (box :class "forecast-day" :orientation "v"
+                 (image :path "${weather_data.fc2_icon}" :image-width 32 :image-height 32)
+                 (label :text "${weather_data.fc2_day}" :class "fc-label")
+                 (label :text "${weather_data.fc2_temp}°" :class "fc-temp")
+                 (label :text "${weather_data.fc2_min}°" :class "fc-min")))
+
+       ;; Updated + glass shine
+       (box :class "footer-row"
+            :orientation "h"
+            :space-evenly false
+             (label :text "Updated ${weather_data.updated_time}" :class "updated-text" :halign "center" :hexpand true)
+             (box :class "glass-shine"))))

--- a/examples/weather-widget/scripts/weather.sh
+++ b/examples/weather-widget/scripts/weather.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Frutiger Aero Weather — fetches weather from wttr.in (auto-location)
+set -euo pipefail
+
+FORCE=false
+[ "${1:-}" = "--force" ] && FORCE=true
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/eww-weather"
+CACHE_FILE="$CACHE_DIR/weather.json"
+CACHE_TTL=1800
+ICON_DIR="./assets/icons"
+
+mkdir -p "$CACHE_DIR"
+
+if [ "$FORCE" = false ] && [ -f "$CACHE_FILE" ]; then
+  cache_age=$(($(date +%s) - $(stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)))
+  if [ "$cache_age" -lt "$CACHE_TTL" ]; then
+    cat "$CACHE_FILE"
+    exit 0
+  fi
+fi
+
+RESPONSE=$(curl -sf --max-time 10 "wttr.in?format=j1" 2>/dev/null) || {
+  if [ -f "$CACHE_FILE" ]; then
+    cat "$CACHE_FILE"
+    exit 0
+  fi
+  echo '{"error":"no data"}'
+  exit 1
+}
+
+echo "$RESPONSE" | python3 -c "
+import json, sys
+from datetime import datetime
+
+d = json.load(sys.stdin)
+cc = d['current_condition'][0]
+area = d['nearest_area'][0]
+city = area['areaName'][0]['value']
+forecast = d['weather'][:3]
+
+ICON_DIR = '$ICON_DIR'
+
+def icon_name(code):
+    c = int(code)
+    if c == 113: return 'sunny'
+    if c in (116, 119): return 'partly-cloudy'
+    if c == 122: return 'cloudy'
+    if c in (143, 248, 260): return 'foggy'
+    if c in (176, 185, 263, 266, 281, 284, 293, 296, 299, 302, 305, 308): return 'rainy'
+    if c in (311, 314, 317, 320, 323, 326, 329, 332, 335, 338): return 'snowy'
+    return 'cloudy'
+
+def day_name(date_str):
+    d = datetime.strptime(date_str, '%Y-%m-%d')
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    diff = (d - today).days
+    if diff == 0: return 'Today'
+    if diff == 1: return 'Tomorrow'
+    names = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+    return names[d.weekday()]
+
+now = datetime.now()
+updated_str = now.strftime('%H:%M')
+
+result = {
+    'city': city,
+    'temp': cc['temp_C'],
+    'feels': cc['FeelsLikeC'],
+    'condition': cc['weatherDesc'][0]['value'].strip(),
+    'icon': f'{ICON_DIR}/{icon_name(cc[\"weatherCode\"])}.svg',
+    'humidity': cc['humidity'],
+    'wind': cc['windspeedKmph'],
+    'uv': cc['uvIndex'],
+    'cloud': cc['cloudcover'],
+    'today_max': forecast[0]['maxtempC'],
+    'today_min': forecast[0]['mintempC'],
+    'updated_time': updated_str,
+    'fc0_icon': f'{ICON_DIR}/{icon_name(forecast[0][\"hourly\"][0][\"weatherCode\"])}.svg',
+    'fc0_temp': forecast[0]['maxtempC'],
+    'fc0_min': forecast[0]['mintempC'],
+    'fc0_day': day_name(forecast[0]['date']),
+    'fc1_icon': f'{ICON_DIR}/{icon_name(forecast[1][\"hourly\"][0][\"weatherCode\"])}.svg',
+    'fc1_temp': forecast[1]['maxtempC'],
+    'fc1_min': forecast[1]['mintempC'],
+    'fc1_day': day_name(forecast[1]['date']),
+    'fc2_icon': f'{ICON_DIR}/{icon_name(forecast[2][\"hourly\"][0][\"weatherCode\"])}.svg',
+    'fc2_temp': forecast[2]['maxtempC'],
+    'fc2_min': forecast[2]['mintempC'],
+    'fc2_day': day_name(forecast[2]['date']),
+}
+print(json.dumps(result))
+" > "$CACHE_FILE.tmp" && mv "$CACHE_FILE.tmp" "$CACHE_FILE"
+
+cat "$CACHE_FILE"


### PR DESCRIPTION
A standalone, styled weather widget fetching JSON data from wttr.in. It features local caching (to respect wttr.in rate limits and handle offline states gracefully), multi-day forecast, and SVG weather icons. Built as a complete drop-in example.